### PR TITLE
Adjusting job ID

### DIFF
--- a/app/dataset/app/service/dataset/service.rb
+++ b/app/dataset/app/service/dataset/service.rb
@@ -27,16 +27,7 @@ module Dataset
               "project relationship is required to create a dataset"
       end
 
-      # With "as_user" ensure account can "create" dataset to the project
-      if auth_context.can?(:create, datasets.class.resource) == :as_user &&
-         ScopedQuery::Service.without_project_access?(
-           auth_context.metadata[:id],
-           record.project.id,
-           ["project_owner"]
-         )
-        raise Verse::Error::Unauthorized,
-              "You do not have permission to create dataset on this project"
-      end
+      access = auth_context.can?(:create, datasets.class.resource)
 
       if access == :as_org_owner
         project = projects.find!(record.project.id) # this can raise Verse::Error::RecordNotFound if not in org scope
@@ -44,6 +35,17 @@ module Dataset
           raise Verse::Error::Unauthorized,
                 "You do not have permission to create dataset on this project"
         end
+      end
+
+      # With "as_user" ensure account can "create" dataset to the project
+      if access == :as_user &&
+         ScopedQuery::Service.without_project_access?(
+           auth_context.metadata[:id],
+           record.project.id,
+           ["project_owner"]
+         )
+        raise Verse::Error::Unauthorized,
+              "You do not have permission to create dataset on this project"
       end
 
       # Assign attributes

--- a/app/dataset/app/service/project/permission_spec.rb
+++ b/app/dataset/app/service/project/permission_spec.rb
@@ -91,6 +91,8 @@ RSpec.describe Project::Service, database: true do
 
     describe "with projects in owned organization scope" do
       it "can index" do
+        [first_project_id, second_project_id]
+
         result = subject.index({})
 
         expect(result.count).to eq 1
@@ -125,9 +127,10 @@ RSpec.describe Project::Service, database: true do
 
     describe "with projects not in owned organization scope" do
       it "cannot index projects outside scope org scope" do
+        [first_project_id, second_project_id]
+
         result = subject.index({})
 
-        expect(result.first.id).to_not eq second_project_id
         expect(result.map(&:organization_id)).to all(satisfy { |id| @org_scope.include?(id.to_s) })
       end
 

--- a/app/dataset/app/service/project/service.rb
+++ b/app/dataset/app/service/project/service.rb
@@ -21,14 +21,12 @@ module Project
 
     def create(record)
       access = auth_context.can?(:create, projects.class.resource)
-      unless access == :as_org_owner
+
+      unless access == :all ||
+             (access == :as_org_owner &&
+             auth_context.custom_scopes[:org]&.include?(record.attributes[:organization_id].to_s))
         raise Verse::Error::Unauthorized,
               "You do not have permission to create a project"
-      end
-
-      unless auth_context.custom_scopes[:org]&.include?(record.attributes[:organization_id].to_s)
-        raise Verse::Error::Unauthorized,
-              "You do not have permission to create a project for this organization"
       end
 
       attributes = record.attributes

--- a/app/dataset/app/service/project_member/service.rb
+++ b/app/dataset/app/service/project_member/service.rb
@@ -27,16 +27,7 @@ module ProjectMember
               "project relationship is required to create a project member"
       end
 
-      # With "as_user" access ensure account can "create" project member to the project
-      if auth_context.can?(:create, project_members.class.resource) == :as_user &&
-         ScopedQuery::Service.without_project_access?(
-           auth_context.metadata[:id],
-           record.project.id,
-           ["project_owner"]
-         )
-        raise Verse::Error::Unauthorized,
-              "You do not have permission to create project member on this project"
-      end
+      access = auth_context.can?(:create, project_members.class.resource)
 
       # "project_owner" can only be added by an org_owner of the project
       if access == :as_org_owner || record.attributes[:role] == "project_owner"
@@ -46,6 +37,17 @@ module ProjectMember
           raise Verse::Error::Unauthorized,
                 "You do not have permission to create a project owner member for this project"
         end
+      end
+
+      # With "as_user" access ensure account can "create" project member to the project
+      if access == :as_user &&
+         ScopedQuery::Service.without_project_access?(
+           auth_context.metadata[:id],
+           record.project.id,
+           ["project_owner"]
+         )
+        raise Verse::Error::Unauthorized,
+              "You do not have permission to create project member on this project"
       end
 
       # Assign attributes

--- a/app/media/app/expo/medias_expo_spec.rb
+++ b/app/media/app/expo/medias_expo_spec.rb
@@ -117,33 +117,35 @@ RSpec.describe MediasExpo, type: :exposition, as: :system do
       )
     end
     it "without key" do
-      expect_any_instance_of(Medias::Service).to receive(:upload) do |_service, file, resource:, key:|
+      expect_any_instance_of(Medias::Service).to receive(:upload) do |_service, file, resource:, key:, project_id:|
         expect(file.filename).to eq("sample.mp4")
         expect(file.type).to eq("video/mp4")
         expect(file.name).to eq("file")
         expect(resource).to eq("some-resource")
         expect(key).to eq("")
+        expect(project_id).to eq("mocked_project_id")
 
         media
       end
 
-      post "/medias/files/some-resource", file: file
+      post "/medias/files/some-resource", { file: file, project_id: "mocked_project_id" }
 
       expect(last_response.status).to eq 200
     end
 
     it "with key" do
-      expect_any_instance_of(Medias::Service).to receive(:upload) do |_service, file, resource:, key:|
+      expect_any_instance_of(Medias::Service).to receive(:upload) do |_service, file, resource:, key:, project_id:|
         expect(file.filename).to eq("sample.mp4")
         expect(file.type).to eq("video/mp4")
         expect(file.name).to eq("file")
         expect(resource).to eq("some-resource")
         expect(key).to eq("some-key")
+        expect(project_id).to eq("mocked_project_id")
 
         media
       end.and_return(media)
 
-      post "/medias/files/some-resource/some-key", file: file
+      post "/medias/files/some-resource/some-key", { file: file, project_id: "mocked_project_id" }
 
       expect(last_response.status).to eq 200
     end

--- a/app/media/app/service/medias/service_spec.rb
+++ b/app/media/app/service/medias/service_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe Medias::Service, as: :system, database: true do
           }
         ),
         resource: "test_resource",
-        key: "test_key"
+        key: "test_key",
+        project_id: "mocked_project_id"
       )
 
       expect(result).to be_truthy
@@ -57,7 +58,8 @@ RSpec.describe Medias::Service, as: :system, database: true do
           }
         ),
         resource: "test_resource",
-        key: "test_key"
+        key: "test_key",
+        project_id: "mocked_project_id"
       )
 
       # Try to upload duplicate
@@ -71,7 +73,8 @@ RSpec.describe Medias::Service, as: :system, database: true do
             }
           ),
           resource: "test_resource",
-          key: "test_key"
+          key: "test_key",
+          project_id: "mocked_project_id"
         )
       end.to raise_error(Verse::Error::ValidationFailed, /Resource test_resource with key test_key already exists/)
     ensure
@@ -89,7 +92,8 @@ RSpec.describe Medias::Service, as: :system, database: true do
           }
         ),
         resource: "test_resource_no_key",
-        key: ""
+        key: "",
+        project_id: "mocked_project_id"
       )
 
       expect(result).to be_truthy
@@ -138,7 +142,8 @@ RSpec.describe Medias::Service, as: :system, database: true do
           }
         ),
         resource: "resource1",
-        key: "key1"
+        key: "key1",
+        project_id: "mocked_project_id"
       )
 
       subject.upload(
@@ -150,7 +155,8 @@ RSpec.describe Medias::Service, as: :system, database: true do
           }
         ),
         resource: "resource2",
-        key: "key2"
+        key: "key2",
+        project_id: "mocked_project_id"
       )
       file&.close
     end
@@ -175,7 +181,8 @@ RSpec.describe Medias::Service, as: :system, database: true do
           }
         ),
         resource: "show_resource",
-        key: "show_key"
+        key: "show_key",
+        project_id: "mocked_project_id"
       )
       file&.close
       result
@@ -209,7 +216,8 @@ RSpec.describe Medias::Service, as: :system, database: true do
           }
         ),
         resource: "delete_resource",
-        key: "delete_key"
+        key: "delete_key",
+        project_id: "mocked_project_id"
       )
       file&.close
       result

--- a/app/media/app/service/processor/service.rb
+++ b/app/media/app/service/processor/service.rb
@@ -47,7 +47,6 @@ module Processor
         )
         # TODO: what to do with multiple job ids?
         # Update the entry with the job_id
-        binding.pry
         Api[:idah].dataset.entries.update(
           id: entry.id,
           status: "processing",

--- a/app/media/app/service/processor/service.rb
+++ b/app/media/app/service/processor/service.rb
@@ -47,6 +47,7 @@ module Processor
         )
         # TODO: what to do with multiple job ids?
         # Update the entry with the job_id
+        binding.pry
         Api[:idah].dataset.entries.update(
           id: entry.id,
           status: "processing",

--- a/app/media/db/migrations/20250628000000_create_initial_schema.rb
+++ b/app/media/db/migrations/20250628000000_create_initial_schema.rb
@@ -3,6 +3,65 @@
 Sequel.migration do
   change do
     execute(%(CREATE EXTENSION IF NOT EXISTS "pg_trgm"))
+    execute(%(CREATE EXTENSION IF NOT EXISTS "uuid-ossp"))
+
+    execute <<-SQL
+      -- Based off IETF draft, https://datatracker.ietf.org/doc/draft-peabody-dispatch-new-uuid-format/
+      create or replace function uuid_generate_v7()
+      returns uuid
+      as $$
+      begin
+        -- use random v4 uuid as starting point (which has the same variant we need)
+        -- then overlay timestamp
+        -- then set version 7 by flipping the 2 and 1 bit in the version 4 string
+        return encode(
+          set_bit(
+            set_bit(
+              overlay(uuid_send(gen_random_uuid())
+                      placing substring(int8send(floor(extract(epoch from clock_timestamp()) * 1000)::bigint) from 3)
+                      from 1 for 6
+              ),
+              52, 1
+            ),
+            53, 1
+          ),
+          'hex')::uuid;
+      end
+      $$
+      language plpgsql
+      volatile;
+
+      -- Generate a custom UUID v8 with microsecond precision
+      create or replace function uuid_generate_v8()
+      returns uuid
+      as $$
+      declare
+        timestamp    timestamptz;
+        microseconds int;
+      begin
+        timestamp    = clock_timestamp();
+        microseconds = (cast(extract(microseconds from timestamp)::int - (floor(extract(milliseconds from timestamp))::int * 1000) as double precision) * 4.096)::int;
+
+        -- use random v4 uuid as starting point (which has the same variant we need)
+        -- then overlay timestamp
+        -- then set version 8 and add microseconds
+        return encode(
+          set_byte(
+            set_byte(
+              overlay(uuid_send(gen_random_uuid())
+                      placing substring(int8send(floor(extract(epoch from timestamp) * 1000)::bigint) from 3)
+                      from 1 for 6
+              ),
+              6, (b'1000' || (microseconds >> 8)::bit(4))::bit(8)::int
+            ),
+            7, microseconds::bit(8)::int
+          ),
+          'hex')::uuid;
+      end
+      $$
+      language plpgsql
+      volatile;
+    SQL
 
     Migration::Timestamps.install_updated_at_function
 
@@ -36,6 +95,7 @@ Sequel.migration do
 
     create_table(:jobs) do
       column :id, :bigserial, primary_key: true
+      # column :id, :uuid, primary_key: true, default: Sequel.lit("uuid_generate_v7()")
 
       column :job_class, String, null: false, index: true
       column :arguments, :jsonb, text: true, null: false


### PR DESCRIPTION
- Change Job's ID type from integer to UUID
  - allowing to query a specific job without checking additional permissions, while keeping it safe  so we can't easily access unauthorized job
- other spec fixes