### PR TITLE
IAM, Dataset & Frontent: improve project members and accounts relation

### DIFF
--- a/app/dataset/app/expo/entries_expo.rb
+++ b/app/dataset/app/expo/entries_expo.rb
@@ -6,7 +6,7 @@ class EntriesExpo < BaseExpo
   use_service Entry::Service
 
   json_api Entry::Record do
-    allowed_included "dataset", "dataset.project"
+    allowed_included "dataset", "dataset.project", "assigned_to", "submitted_by", "reviewed_by"
     show
     index do
       allowed_filters :status__in,

--- a/app/dataset/app/expo/project_members_expo.rb
+++ b/app/dataset/app/expo/project_members_expo.rb
@@ -25,7 +25,8 @@ class ProjectMembersExpo < BaseExpo
                       :role__in,
                       :created_at__gte,
                       :created_at__lte,
-                      :organization_id__in
+                      :organization_id__in,
+                      :enabled
     end
 
     show

--- a/app/dataset/app/expo/project_members_expo.rb
+++ b/app/dataset/app/expo/project_members_expo.rb
@@ -41,6 +41,16 @@ class ProjectMembersExpo < BaseExpo
   def on_account_deleted
     account_id = message.content[:resource_id]
 
-    service.remove_nonparticipant_member(account_id)
+    service.delete_account_members(account_id)
+  end
+
+  expose on_resource_event(Resource::Iam::Accounts, "updated")
+  def on_account_updated
+    account_id = message.content[:resource_id]
+
+    # Only disable project members if the account is being disabled
+    return if message.content.dig(:args, 0, :enabled)
+
+    service.disable_account_members(account_id)
   end
 end

--- a/app/dataset/app/expo/project_members_expo_spec.rb
+++ b/app/dataset/app/expo/project_members_expo_spec.rb
@@ -99,4 +99,50 @@ RSpec.describe ProjectMembersExpo, type: :exposition, as: :system do
 
     expect(last_response.status).to eq 204
   end
+
+  describe "#on_account_deleted" do
+    it "deletes all project members for the deleted account" do
+      resource_id = 42
+      expect(service).to(receive(:delete_account_members).with(resource_id))
+
+      Verse.publish_resource_event(
+        resource_type: Resource::Iam::Accounts,
+        resource_id:,
+        event: "deleted",
+        payload: { resource_id: }
+      )
+    end
+  end
+
+  describe "#on_account_updated" do
+    it "disables all project members for the disabled account" do
+      resource_id = 42
+      expect(service).to(receive(:disable_account_members).with(resource_id))
+
+      Verse.publish_resource_event(
+        resource_type: Resource::Iam::Accounts,
+        resource_id:,
+        event: "updated",
+        payload: {
+          resource_id:,
+          args: [{ enabled: false }]
+        }
+      )
+    end
+
+    it "does not disable project members if the account is still enabled" do
+      resource_id = 42
+      expect(service).not_to(receive(:disable_account_members))
+
+      Verse.publish_resource_event(
+        resource_type: Resource::Iam::Accounts,
+        resource_id:,
+        event: "updated",
+        payload: {
+          resource_id:,
+          args: [{ enabled: true }]
+        }
+      )
+    end
+  end
 end

--- a/app/dataset/app/model/annotation.rb
+++ b/app/dataset/app/model/annotation.rb
@@ -66,6 +66,7 @@ module Annotation
           FROM project_members pm
           WHERE pm.account_id = :account_id
             AND pm.project_id = annotations.project_id
+            AND pm.disabled_at IS NULL
             AND (
               -- All with roles
               pm.role IN :with_roles OR

--- a/app/dataset/app/model/dataset.rb
+++ b/app/dataset/app/model/dataset.rb
@@ -79,6 +79,7 @@ module Dataset
             FROM project_members pm
             WHERE pm.account_id = :account_id
               AND pm.project_id = datasets.project_id
+              AND pm.disabled_at IS NULL
               AND (
                 -- All with roles
                 pm.role IN :with_roles OR
@@ -125,6 +126,7 @@ module Dataset
             FROM project_members pm
             WHERE pm.account_id = :account_id
               AND pm.project_id = datasets.project_id
+              AND pm.disabled_at IS NULL
               AND pm.role IN :roles
           )
         SQL

--- a/app/dataset/app/model/entry.rb
+++ b/app/dataset/app/model/entry.rb
@@ -27,6 +27,19 @@ module Entry
     belongs_to :dataset, repository: "Dataset::Repository", foreign_key: :dataset_id
     belongs_to :project, repository: "Project::Repository", foreign_key: :project_id
 
+    belongs_to :assigned_to,
+               repository: "ProjectMember::Repository",
+               primary_key: :account_id,
+               foreign_key: :assigned_to_id
+    belongs_to :submitted_by,
+               repository: "ProjectMember::Repository",
+               primary_key: :account_id,
+               foreign_key: :submitted_by_id
+    belongs_to :reviewed_by,
+               repository: "ProjectMember::Repository",
+               primary_key: :account_id,
+               foreign_key: :reviewed_by_id
+
     has_many :annotations, repository: "Annotation::Repository", foreign_key: :entry_id
   end
 

--- a/app/dataset/app/model/entry.rb
+++ b/app/dataset/app/model/entry.rb
@@ -97,6 +97,7 @@ module Entry
             FROM project_members pm
             WHERE pm.account_id = :account_id
               AND pm.project_id = entries.project_id
+              AND pm.disabled_at IS NULL
               AND (
                 -- All with roles
                 pm.role IN :with_roles OR
@@ -137,6 +138,7 @@ module Entry
             FROM project_members pm
             WHERE pm.account_id = :account_id
               AND pm.project_id = entries.project_id
+              AND pm.disabled_at IS NULL
               AND pm.role IN :roles
           )
         SQL

--- a/app/dataset/app/model/note_comment.rb
+++ b/app/dataset/app/model/note_comment.rb
@@ -84,6 +84,7 @@ module NoteComment
                 FROM project_members pm
                 WHERE pm.account_id = :account_id
                   AND pm.project_id = nf.project_id
+                  AND pm.disabled_at IS NULL
                   AND (
                     -- All with roles
                     pm.role IN :with_roles OR
@@ -122,6 +123,7 @@ module NoteComment
                 FROM project_members pm
                 WHERE pm.account_id = :account_id
                   AND pm.project_id = nf.project_id
+                  AND pm.disabled_at IS NULL
                   AND (
                     pm.role IN :with_roles OR
                     (

--- a/app/dataset/app/model/note_feed.rb
+++ b/app/dataset/app/model/note_feed.rb
@@ -91,6 +91,7 @@ module NoteFeed
             FROM project_members pm
             WHERE pm.account_id = :account_id
               AND pm.project_id = note_feeds.project_id
+              AND pm.disabled_at IS NULL
               AND (
                 pm.role IN :with_roles OR
                 (
@@ -122,6 +123,7 @@ module NoteFeed
             FROM project_members pm
             WHERE pm.account_id = :account_id
               AND pm.project_id = note_feeds.project_id
+              AND pm.disabled_at IS NULL
               AND (
                 pm.role IN :with_roles OR
                 (

--- a/app/dataset/app/model/project.rb
+++ b/app/dataset/app/model/project.rb
@@ -61,6 +61,7 @@ module Project
           FROM project_members pm
           WHERE pm.account_id = :account_id
             AND pm.project_id = projects.id
+            AND pm.disabled_at IS NULL
             AND pm.role IN :roles
         )
       SQL

--- a/app/dataset/app/model/project_member.rb
+++ b/app/dataset/app/model/project_member.rb
@@ -11,9 +11,10 @@ module ProjectMember
     field :name, type: [String, NilClass]
     field :email, type: String
 
-    field :role, type: String, readonly: true
+    field :role, type: String
 
     field :invited_by_id, type: Integer, readonly: true
+    field :disabled_at, type: [Time, NilClass]
 
     field :created_at, type: Time, readonly: true
     field :updated_at, type: Time, readonly: true
@@ -36,6 +37,16 @@ module ProjectMember
       SQL
 
       collection.where(Sequel.lit(where_fragment, value.map(&:to_i)))
+    end
+
+    custom_filter :enabled do |collection, value|
+      enabled = value.to_s.downcase == "true"
+
+      if enabled
+        collection.where(disabled_at: nil)
+      else
+        collection.where(Sequel.~(disabled_at: nil))
+      end
     end
 
     def scoped(action)

--- a/app/dataset/app/model/project_member.rb
+++ b/app/dataset/app/model/project_member.rb
@@ -87,6 +87,7 @@ module ProjectMember
           FROM project_members pm
           WHERE pm.account_id = :account_id
             AND pm.project_id = project_members.project_id
+            AND pm.disabled_at IS NULL
             AND pm.role IN :roles
         )
       SQL

--- a/app/dataset/app/service/annotation/permission_spec.rb
+++ b/app/dataset/app/service/annotation/permission_spec.rb
@@ -366,6 +366,21 @@ RSpec.describe Annotation::Service, database: true do
       end
     end
 
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(project_owner_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        # Setup: create note feed to test visibility
+        first_annotation_id # assigned
+
+        result = subject.index({})
+
+        expect(result.count).to eq 0
+      end
+    end
+
     describe "with not assigned project" do
       it "cannot index" do
         # Setup: Create annotations as "Project Owner" can see all annotations in assigned project
@@ -459,6 +474,21 @@ RSpec.describe Annotation::Service, database: true do
         expect {
           subject.show(first_annotation_id)
         }.to raise_error(Verse::Error::RecordNotFound)
+      end
+    end
+
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(annotator_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        # Setup: create note feed to test visibility
+        first_annotation_id # assigned
+
+        result = subject.index({})
+
+        expect(result.count).to eq 0
       end
     end
 
@@ -613,6 +643,21 @@ RSpec.describe Annotation::Service, database: true do
         expect {
           subject.show(second_annotation_id)
         }.to raise_error(Verse::Error::RecordNotFound)
+      end
+    end
+
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(reviewer_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        # Setup: create note feed to test visibility
+        second_annotation_id # assigned
+
+        result = subject.index({})
+
+        expect(result.count).to eq 0
       end
     end
 

--- a/app/dataset/app/service/dataset/permission_spec.rb
+++ b/app/dataset/app/service/dataset/permission_spec.rb
@@ -321,6 +321,21 @@ RSpec.describe Dataset::Service, database: true do
       end
     end
 
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(project_owner_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        # Setup: create note feed to test visibility
+        first_dataset_id # assigned
+
+        result = subject.index({})
+
+        expect(result.count).to eq 0
+      end
+    end
+
     describe "with not assigned project" do
       it "cannot index" do
         # Setup: Create datasets as "Project Owner" can see all datasets in assigned project
@@ -406,6 +421,21 @@ RSpec.describe Dataset::Service, database: true do
         expect {
           subject.delete(first_dataset_id)
         }.to raise_error(Verse::Error::RecordNotFound)
+      end
+    end
+
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(annotator_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        # Setup: create note feed to test visibility
+        first_entry_id # assigned
+
+        result = subject.index({})
+
+        expect(result.count).to eq 0
       end
     end
 
@@ -521,6 +551,21 @@ RSpec.describe Dataset::Service, database: true do
         expect {
           subject.delete(first_dataset_id)
         }.to raise_error(Verse::Error::RecordNotFound)
+      end
+    end
+
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(reviewer_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        # Setup: create note feed to test visibility
+        second_entry_id # assigned
+
+        result = subject.index({})
+
+        expect(result.count).to eq 0
       end
     end
 

--- a/app/dataset/app/service/entry/permission_spec.rb
+++ b/app/dataset/app/service/entry/permission_spec.rb
@@ -326,6 +326,21 @@ RSpec.describe Entry::Service, database: true do
       end
     end
 
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(project_owner_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        # Setup: create note feed to test visibility
+        first_entry_id # assigned
+
+        result = subject.index({})
+
+        expect(result.count).to eq 0
+      end
+    end
+
     describe "with not assigned project" do
       it "cannot index" do
         # Setup: Create entries as "Project Owner" can see all entries in assigned project
@@ -441,6 +456,21 @@ RSpec.describe Entry::Service, database: true do
         expect {
           subject.delete(first_entry_id)
         }.to raise_error(Verse::Error::RecordNotFound)
+      end
+    end
+
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(annotator_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        # Setup: create note feed to test visibility
+        first_entry_id # assigned
+
+        result = subject.index({})
+
+        expect(result.count).to eq 0
       end
     end
 
@@ -564,6 +594,21 @@ RSpec.describe Entry::Service, database: true do
         expect {
           subject.delete(first_entry_id)
         }.to raise_error(Verse::Error::RecordNotFound)
+      end
+    end
+
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(reviewer_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        # Setup: create note feed to test visibility
+        second_entry_id # assigned
+
+        result = subject.index({})
+
+        expect(result.count).to eq 0
       end
     end
 

--- a/app/dataset/app/service/note_comment/permission_spec.rb
+++ b/app/dataset/app/service/note_comment/permission_spec.rb
@@ -506,6 +506,21 @@ RSpec.describe NoteComment::Service, database: true do
       end
     end
 
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(project_owner_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        # Setup: create note feed to test visibility
+        project_owner_note_comment_id # assigned
+
+        result = subject.index({})
+
+        expect(result.count).to eq 0
+      end
+    end
+
     describe "with not assigned project" do
       it "cannot index" do
         # Setup: create note feeds to test visibility
@@ -623,6 +638,21 @@ RSpec.describe NoteComment::Service, database: true do
         expect {
           subject.delete(reviewer_first_note_comment_id)
         }.to raise_error(Verse::Error::RecordNotFound)
+      end
+    end
+
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(annotator_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        # Setup: create note feed to test visibility
+        project_owner_note_comment_id # assigned
+
+        result = subject.index({})
+
+        expect(result.count).to eq 0
       end
     end
 
@@ -783,6 +813,21 @@ RSpec.describe NoteComment::Service, database: true do
         expect {
           subject.show(reviewer_third_note_comment_id)
         }.to raise_error(Verse::Error::RecordNotFound)
+      end
+    end
+
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(reviewer_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        # Setup: create note feed to test visibility
+        reviewer_third_note_comment_id # assigned
+
+        result = subject.index({})
+
+        expect(result.count).to eq 0
       end
     end
 

--- a/app/dataset/app/service/note_feed/permission_spec.rb
+++ b/app/dataset/app/service/note_feed/permission_spec.rb
@@ -475,6 +475,21 @@ RSpec.describe NoteFeed::Service, database: true do
       end
     end
 
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(project_owner_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        # Setup: create note feed to test visibility
+        project_owner_note_feed_id # assigned
+
+        result = subject.index({})
+
+        expect(result.count).to eq 0
+      end
+    end
+
     describe "with not assigned project" do
       it "cannot index" do
         # Setup: create note feeds to test visibility
@@ -610,6 +625,21 @@ RSpec.describe NoteFeed::Service, database: true do
         expect {
           subject.resolve(reviewer_first_note_feed_id)
         }.to raise_error(Verse::Error::RecordNotFound)
+      end
+    end
+
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(annotator_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        # Setup: create note feed to test visibility
+        project_owner_note_feed_id # assigned
+
+        result = subject.index({})
+
+        expect(result.count).to eq 0
       end
     end
 
@@ -816,6 +846,21 @@ RSpec.describe NoteFeed::Service, database: true do
         expect {
           subject.resolve(project_owner_note_feed_id)
         }.to raise_error(Verse::Error::RecordNotFound)
+      end
+    end
+
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(reviewer_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        # Setup: create note feed to test visibility
+        reviewer_third_note_feed_id # assigned
+
+        result = subject.index({})
+
+        expect(result.count).to eq 0
       end
     end
 

--- a/app/dataset/app/service/project/permission_spec.rb
+++ b/app/dataset/app/service/project/permission_spec.rb
@@ -204,6 +204,18 @@ RSpec.describe Project::Service, database: true do
       end
     end
 
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(project_owner_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        result = subject.index({})
+
+        expect(result.count).to eq 0
+      end
+    end
+
     describe "with not assigned project" do
       it "cannot index" do
         result = subject.index({})
@@ -276,6 +288,18 @@ RSpec.describe Project::Service, database: true do
       end
     end
 
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(annotator_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        result = subject.index({})
+
+        expect(result.count).to eq 0
+      end
+    end
+
     describe "with not assigned project" do
       it "cannot index" do
         result = subject.index({})
@@ -345,6 +369,18 @@ RSpec.describe Project::Service, database: true do
         expect {
           subject.delete(first_project_id)
         }.to raise_error(Verse::Error::RecordNotFound)
+      end
+    end
+
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(reviewer_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        result = subject.index({})
+
+        expect(result.count).to eq 0
       end
     end
 

--- a/app/dataset/app/service/project_member/permission_spec.rb
+++ b/app/dataset/app/service/project_member/permission_spec.rb
@@ -235,6 +235,18 @@ RSpec.describe ProjectMember::Service, database: true do
       end
     end
 
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(project_owner_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        result = subject.index({})
+
+        expect(result.count).to eq 0
+      end
+    end
+
     describe "with not assigned project" do
       it "cannot index" do
         # Setup: create other project members to test visibility
@@ -319,6 +331,18 @@ RSpec.describe ProjectMember::Service, database: true do
       end
     end
 
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(annotator_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        result = subject.index({})
+
+        expect(result.count).to eq 0
+      end
+    end
+
     describe "with not assigned project" do
       it "cannot index" do
         # Setup: create other project members to test visibility
@@ -398,6 +422,18 @@ RSpec.describe ProjectMember::Service, database: true do
         expect {
           subject.delete(annotator_member_id)
         }.to raise_error(Verse::Error::RecordNotFound)
+      end
+    end
+
+    describe "with assigned project and disabled project member" do
+      before do
+        project_member_repo.delete(reviewer_member_id) # soft delete
+      end
+
+      it "cannot index" do
+        result = subject.index({})
+
+        expect(result.count).to eq 0
       end
     end
 

--- a/app/dataset/app/service/project_member/permission_spec.rb
+++ b/app/dataset/app/service/project_member/permission_spec.rb
@@ -138,19 +138,11 @@ RSpec.describe ProjectMember::Service, database: true do
         expect(record.role).to eq update_data[:data][:attributes][:role]
       end
 
-      it "can delete" do
-        allow(Api[:idah].iam.accounts).to receive(:show).and_return(
-          double(name: "Remover User", email: "remover@example.com", joined_at: Time.now)
-        )
-
+      it "can soft delete" do
         subject.delete(annotator_member_id)
 
-        expect {
-          subject.show(annotator_member_id)
-        }.to raise_error(Verse::Error::RecordNotFound)
-
-        # the record we tried to delete should not be there anymore
-        expect { project_member_repo.find!(annotator_member_id) }.to raise_error(Verse::Error::RecordNotFound)
+        member = project_member_repo.find(annotator_member_id)
+        expect(member.disabled_at).not_to be_nil
       end
     end
 
@@ -235,16 +227,11 @@ RSpec.describe ProjectMember::Service, database: true do
         expect(record.role).to eq "reviewer"
       end
 
-      it "can delete" do
-        allow(Api[:idah].iam.accounts).to receive(:show).and_return(
-          double(name: "Remover User", email: "remover@example.com", joined_at: Time.now)
-        )
-
+      it "can soft delete" do
         subject.delete(annotator_member_id)
 
-        expect {
-          subject.show(annotator_member_id)
-        }.to raise_error(Verse::Error::RecordNotFound)
+        member = project_member_repo.find(annotator_member_id)
+        expect(member.disabled_at).not_to be_nil
       end
     end
 

--- a/app/dataset/app/service/project_member/service.rb
+++ b/app/dataset/app/service/project_member/service.rb
@@ -120,7 +120,7 @@ module ProjectMember
         member = project_members.find!(id, included: [:project])
 
         # Soft delete project member
-        project_members.update!(id, { disabled_at: Time.now })
+        project_members.update!(member.id, { disabled_at: Time.now })
         project_members.after_commit do
           ::Service::Notification.email(
             to: member.email,
@@ -136,12 +136,16 @@ module ProjectMember
       end
     end
 
-    def remove_nonparticipant_member(account_id)
-      project_member_ids = system_project_members.index({ account_id: account_id }).map(&:id).uniq
+    def delete_account_members(account_id)
+      system_project_members.chunked_index({ account_id: account_id }).each do |member|
+        project_members.delete!(member.id)
+      end
+    end
 
-      project_member_ids.each do |project_member_id|
-        # directly delete, no need use service delete to send a notification as the account is already deleted
-        project_members.delete!(project_member_id)
+    def disable_account_members(account_id)
+      now = Time.now
+      system_project_members.chunked_index({ account_id: account_id }).each do |member|
+        project_members.update!(member.id, { disabled_at: now })
       end
     end
   end

--- a/app/dataset/app/service/project_member/service.rb
+++ b/app/dataset/app/service/project_member/service.rb
@@ -96,13 +96,16 @@ module ProjectMember
       access = auth_context.can?(:update, project_members.class.resource)
       # "project_owner" can only be added by an org_owner of the project
       if record.attributes[:role] == "project_owner"
-        unless access == :as_org_owner
+        unless [:as_org_owner, :all].include?(access)
           raise Verse::Error::Unauthorized,
                 "You do not have permission to update a member for this project"
         end
 
-        project = projects.find!(record.project.id) # this can raise Verse::Error::RecordNotFound if not in org scope
-        unless auth_context.custom_scopes[:org]&.include?(project.organization_id.to_s)
+        member = project_members.find!(record.id)
+        project = projects.find!(member.project_id) # this can raise Verse::Error::RecordNotFound if not in org scope
+
+        # Check if org_owner has access to the project's organization
+        if access != :all && !auth_context.custom_scopes[:org]&.include?(project.organization_id.to_s)
           raise Verse::Error::Unauthorized,
                 "You do not have permission to update a member to a project owner for this project"
         end
@@ -115,8 +118,9 @@ module ProjectMember
     def delete(id)
       project_members.transaction do
         member = project_members.find!(id, included: [:project])
-        project_members.delete!(id)
 
+        # Soft delete project member
+        project_members.update!(id, { disabled_at: Time.now })
         project_members.after_commit do
           ::Service::Notification.email(
             to: member.email,

--- a/app/dataset/app/service/project_member/service_spec.rb
+++ b/app/dataset/app/service/project_member/service_spec.rb
@@ -221,7 +221,144 @@ RSpec.describe ProjectMember::Service, database: true do
       end
     end
 
-    describe "#remove_nonparticipant_member" do
+    describe "#delete_account_members" do
+      let(:account_id) { 123 }
+      let(:another_account_id) { 456 }
+
+      before do
+        # Create another project
+        @another_project_id = project_repo.create(
+          name: "Another Project",
+          description: "Another test project",
+          created_by_email: "user@example.com",
+          organization_id: 1
+        )
+
+        # Create project members for account 123
+        @member1_id = project_member_repo.create(
+          attributes.merge(account_id: account_id, email: "member1@email.com")
+        )
+        @member2_id = project_member_repo.create(
+          attributes.merge(
+            account_id: account_id,
+            email: "member2@email.com",
+            project_id: @another_project_id
+          )
+        )
+
+        # Create project member for different account
+        @other_account_member_id = project_member_repo.create(
+          attributes.merge(account_id: another_account_id, email: "other@email.com")
+        )
+      end
+
+      it "hard deletes all project members for the given account_id" do
+        subject.delete_account_members(account_id)
+
+        # Members for the specified account should be deleted
+        expect { project_member_repo.find!(@member1_id) }.to raise_error(Verse::Error::NotFound)
+        expect { project_member_repo.find!(@member2_id) }.to raise_error(Verse::Error::NotFound)
+
+        # Members for other accounts should still exist
+        expect(project_member_repo.find!(@other_account_member_id)).not_to be_nil
+      end
+
+      it "handles accounts with no project members" do
+        expect { subject.delete_account_members(99_999) }.not_to raise_error
+      end
+
+      it "deletes members from multiple projects" do
+        subject.delete_account_members(account_id)
+
+        # Verify both members from different projects are deleted
+        all_members = project_member_repo.index({})
+        remaining_member_ids = all_members.map{ |m| m.id.to_s }
+
+        expect(remaining_member_ids).not_to include(@member1_id)
+        expect(remaining_member_ids).not_to include(@member2_id)
+        expect(remaining_member_ids).to include(@other_account_member_id)
+      end
+    end
+
+    describe "#disable_account_members" do
+      let(:account_id) { 123 }
+      let(:another_account_id) { 456 }
+
+      before do
+        @expected_time = Time.utc(2026, 1, 1, 0, 0, 0)
+
+        # freeze the time
+        allow(Time).to receive(:now).and_return(@expected_time)
+
+        # Create another project
+        @another_project_id = project_repo.create(
+          name: "Another Project",
+          description: "Another test project",
+          created_by_email: "user@example.com",
+          organization_id: 1
+        )
+
+        # Create project members for account 123
+        @member1_id = project_member_repo.create(
+          attributes.merge(account_id: account_id, email: "member1@email.com")
+        )
+        @member2_id = project_member_repo.create(
+          attributes.merge(
+            account_id: account_id,
+            email: "member2@email.com",
+            project_id: @another_project_id
+          )
+        )
+
+        # Create project member for different account
+        @other_account_member_id = project_member_repo.create(
+          attributes.merge(account_id: another_account_id, email: "other@email.com")
+        )
+      end
+
+      it "soft deletes all project members for the given account_id" do
+        subject.disable_account_members(account_id)
+
+        # Members for the specified account should be disabled
+        member1 = project_member_repo.find!(@member1_id)
+        member2 = project_member_repo.find!(@member2_id)
+
+        expect(member1.disabled_at).to eq(@expected_time)
+        expect(member2.disabled_at).to eq(@expected_time)
+
+        # Members for other accounts should not be disabled
+        other_member = project_member_repo.find!(@other_account_member_id)
+        expect(other_member.disabled_at).to be_nil
+      end
+
+      it "handles accounts with no project members" do
+        expect { subject.disable_account_members(99_999) }.not_to raise_error
+      end
+
+      it "disables members from multiple projects" do
+        subject.disable_account_members(account_id)
+
+        # Verify both members from different projects are disabled
+        all_members = project_member_repo.index({})
+        account_members = all_members.select { |m| m.account_id == account_id }
+        other_members = all_members.reject { |m| m.account_id == account_id }
+
+        expect(account_members.all? { |m| m.disabled_at == @expected_time }).to be true
+        expect(other_members.all? { |m| m.disabled_at.nil? }).to be true
+      end
+
+      it "sets the same timestamp for all disabled members" do
+        subject.disable_account_members(account_id)
+
+        member1 = project_member_repo.find!(@member1_id)
+        member2 = project_member_repo.find!(@member2_id)
+
+        expect(member1.disabled_at).to eq(@expected_time)
+        expect(member2.disabled_at).to eq(@expected_time)
+      end
+    end
+
+    describe "#delete_account_members" do
       before do
         another_project_id = project_repo.create(
           name: "Another Project",
@@ -269,7 +406,7 @@ RSpec.describe ProjectMember::Service, database: true do
       end
 
       it "deletes a nonparticipant project member if after the account is deleted" do
-        subject.remove_nonparticipant_member(1)
+        subject.delete_account_members(1)
 
         expect { project_member_repo.find!(@project_member.id) }.to raise_error(Verse::Error::NotFound)
         expect { project_member_repo.find!(@another_project_member.id) }.to raise_error(Verse::Error::NotFound)

--- a/app/dataset/app/service/project_member/service_spec.rb
+++ b/app/dataset/app/service/project_member/service_spec.rb
@@ -191,7 +191,9 @@ RSpec.describe ProjectMember::Service, database: true do
         project_member_id = project_member_repo.create(attributes)
 
         subject.delete(project_member_id)
-        expect { project_member_repo.find!(project_member_id) }.to raise_error(Verse::Error::NotFound)
+
+        member = project_member_repo.find(project_member_id)
+        expect(member.disabled_at).not_to be_nil
       end
 
       context "notifications" do

--- a/app/dataset/db/migrations/20260105000000_add_disabled_at_to_project_members.rb
+++ b/app/dataset/db/migrations/20260105000000_add_disabled_at_to_project_members.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:project_members) do
+      add_column :disabled_at, DateTime, null: true, index: true
+    end
+  end
+end

--- a/app/frontend/src/lib/components/app/datasets/entries/cards/entry-card.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/cards/entry-card.svelte
@@ -341,7 +341,7 @@
         {#if wf_step !== "done"}
           <DataDisplay label="Assigned to">
             {#snippet slotValue()}
-              <ProjectMemberAvatar memberAccountId={assigned_to_id} />
+              <ProjectMemberAvatar member={entry.assigned_to} />
             {/snippet}
           </DataDisplay>
         {/if}
@@ -349,7 +349,7 @@
         {#if submitted_by_id}
           <DataDisplay label="Submitted by">
             {#snippet slotValue()}
-              <ProjectMemberAvatar memberAccountId={submitted_by_id} />
+              <ProjectMemberAvatar member={entry.submitted_by} />
             {/snippet}
           </DataDisplay>
         {/if}
@@ -357,7 +357,7 @@
         {#if reviewed_by_id}
           <DataDisplay label="Reviewed by">
             {#snippet slotValue()}
-              <ProjectMemberAvatar memberAccountId={reviewed_by_id} />
+              <ProjectMemberAvatar member={entry.reviewed_by} />
             {/snippet}
           </DataDisplay>
         {/if}

--- a/app/frontend/src/lib/components/app/datasets/entries/forms/assign-entry-form.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/forms/assign-entry-form.svelte
@@ -43,6 +43,7 @@
       listOptions={{
         filters: {
           project_id: projectId,
+          enabled: true,
           role__in: wfStep === "review" ? ["reviewer", "project_owner"] : ["annotator", "project_owner"],
         },
       }}

--- a/app/frontend/src/lib/components/app/iam/accounts/data-tables/account-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/iam/accounts/data-tables/account-row-action-cell.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SquarePenIcon, Trash2Icon } from "@lucide/svelte";
+  import { SquarePenIcon, UserXIcon } from "@lucide/svelte";
   import { onMount } from "svelte";
   import { toast } from "svelte-sonner";
 
@@ -35,9 +35,9 @@
           },
         },
         {
-          label: "Delete",
-          icon: Trash2Icon,
-          hidden: !canDeleteAccount,
+          label: "Cancel Invitation",
+          icon: UserXIcon,
+          hidden: !canDeleteAccount || account.joined_at,
           action: () => {
             openConfirmDeleteAccountModal = true;
           },

--- a/app/frontend/src/lib/components/app/projects/members/avatars/project-member-avatar.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/avatars/project-member-avatar.svelte
@@ -2,42 +2,23 @@
   import type { Snippet } from "svelte";
 
   import AccountAvatar from "@/components/app/iam/accounts/avatars/account-avatar.svelte";
-  import Spinner from "@/components/ui/spinner/spinner.svelte";
   import Text from "@/components/ui/text/Text.svelte";
-
-  import { AccountRecord, accountsBackendDataSource } from "@/data/model/iam/accounts/record";
+  import type { ProjectMemberRecord } from "@/data/model/dataset/projects/members/record";
 
   // Props
   interface Props {
-    memberAccountId: number | null;
+    member: ProjectMemberRecord | null;
     slotUnassigned?: Snippet;
   }
-  let { memberAccountId, slotUnassigned }: Props = $props();
-
-  // Functions
-  async function fetchProjectMember() {
-    if (!memberAccountId) {
-      return undefined;
-    }
-
-    return await accountsBackendDataSource.get(String(memberAccountId), {
-      fields: {
-        [AccountRecord.type]: ["name", "email", "picture_url"],
-      },
-    });
-  }
+  let { member, slotUnassigned }: Props = $props();
 </script>
 
-{#await fetchProjectMember()}
-  <Spinner size="sm"></Spinner>
-{:then projectMemberRes}
-  {#if projectMemberRes}
-    {@const { name, email, picture_url: pictureUrl } = projectMemberRes.data}
+{#if member}
+  {@const { name, email, picture_url: pictureUrl } = member}
 
-    <AccountAvatar size="sm" {name} {email} {pictureUrl} showEmail />
-  {:else if slotUnassigned}
-    {@render slotUnassigned()}
-  {:else}
-    <Text size="sm">Unassigned</Text>
-  {/if}
-{/await}
+  <AccountAvatar size="sm" {name} {email} {pictureUrl} showEmail />
+{:else if slotUnassigned}
+  {@render slotUnassigned()}
+{:else}
+  <Text size="sm">Unassigned</Text>
+{/if}

--- a/app/frontend/src/lib/components/app/projects/members/forms/project-member-form.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/forms/project-member-form.svelte
@@ -46,6 +46,7 @@
       },
       filters: {
         project_id: projectId,
+        enabled: true,
       },
     });
     projectMemberEmails = projectMembersRes.data.map((member) => member.email);

--- a/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
@@ -58,14 +58,16 @@
         account = createdAccount.data;
 
         /** Check if member is already in the project */
-        const existingProjectMember = (await projectMembersBackendDataSource.list({
-          filters: {
-            project_id: projectId,
-            account_id: account.id,
-          },
-        })).data[0];
+        const existingProjectMember = (
+          await projectMembersBackendDataSource.list({
+            filters: {
+              project_id: projectId,
+              account_id: account.id,
+            },
+          })
+        ).data[0];
 
-        if(existingProjectMember) {
+        if (existingProjectMember) {
           await accountsBackendDataSource.join({ id: account.id });
 
           // Re-enable the existing project member
@@ -75,11 +77,11 @@
               attributes: {
                 disabled_at: null,
                 role,
-              }
+              },
             },
             {
               showErrorToast: false,
-            }
+            },
           );
         } else {
           // Create new project member
@@ -104,7 +106,7 @@
             },
             {
               showErrorToast: false,
-            }
+            },
           );
         }
 

--- a/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
@@ -68,8 +68,6 @@
         ).data[0];
 
         if (existingProjectMember) {
-          await accountsBackendDataSource.join({ id: account.id });
-
           // Re-enable the existing project member
           await projectMembersBackendDataSource.update(
             existingProjectMember.id,

--- a/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
@@ -68,7 +68,7 @@
         //   await accountsBackendDataSource.join({ id: account.id });
         // }
 
-        if(existingProjectMember.disabled_at) {
+        if(existingProjectMember) {
           // Re-enable the existing project member
           await projectMembersBackendDataSource.update(existingProjectMember.id, {
             attributes: {

--- a/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
@@ -57,35 +57,46 @@
         account = createdAccount.data;
 
         /** Check if member is already in the project */
-        const existingProjectMember = await projectMembersBackendDataSource.list({
+        const existingProjectMember = (await projectMembersBackendDataSource.list({
           filters: {
             project_id: projectId,
             account_id: account.id,
           },
-        });
+        })).data[0];
 
-        if (existingProjectMember.data.length) {
-          await accountsBackendDataSource.join({ id: account.id });
-        }
+        // if (existingProjectMember) {
+        //   await accountsBackendDataSource.join({ id: account.id });
+        // }
 
-        await projectMembersBackendDataSource.create({
-          attributes: {
-            project_id: projectId!,
-            account_id: Number(account.id),
-            name: account.name,
-            email,
-            role,
-            invited_by_id: Number(currentAccount?.id),
-          },
-          relationships: {
-            project: {
-              data: {
-                type: "dataset:projects",
-                id: projectId,
+        if(existingProjectMember.disabled_at) {
+          // Re-enable the existing project member
+          await projectMembersBackendDataSource.update(existingProjectMember.id, {
+            attributes: {
+              disabled_at: null,
+              role,
+            },
+          });
+        } else {
+          // Create new project member
+          await projectMembersBackendDataSource.create({
+            attributes: {
+              project_id: projectId!,
+              account_id: Number(account.id),
+              name: account.name,
+              email,
+              role,
+              invited_by_id: Number(currentAccount?.id),
+            },
+            relationships: {
+              project: {
+                data: {
+                  type: "dataset:projects",
+                  id: projectId,
+                },
               },
             },
-          },
-        });
+          });
+        }
       }
 
       $refetches.projectMembers.list = new Date();

--- a/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
@@ -108,6 +108,15 @@
           );
         }
 
+        // If account is disabled we enable after adding to project
+        if(!account.enabled) {
+          await accountsBackendDataSource.update(account.id, {
+            attributes: {
+              enabled: true,
+            },
+          });
+        }
+
         toast.success("Project member added", {
           description: `An invitation will be sent to "${email}" if the account is not yet existed.`,
         });

--- a/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
@@ -109,7 +109,7 @@
         }
 
         // If account is disabled we enable after adding to project
-        if(!account.enabled) {
+        if (!account.enabled) {
           await accountsBackendDataSource.update(account.id, {
             attributes: {
               enabled: true,

--- a/app/frontend/src/lib/data/model/dataset/entries/record.ts
+++ b/app/frontend/src/lib/data/model/dataset/entries/record.ts
@@ -14,6 +14,7 @@ import { parseSingleElementError, parseSingleElementReturn } from "@/data/model/
 
 import type { JsonApiErrorResponse, RecordResponse } from "@/data/model/types";
 import type { Hash } from "@/utils/types";
+import type { ProjectMemberRecord } from "@/data/model/dataset/projects/members/record";
 
 @type("dataset:entries")
 export class EntryRecord extends Record {
@@ -37,6 +38,9 @@ export class EntryRecord extends Record {
   @field() public updated_at!: Date;
 
   @relationship() public dataset!: DatasetRecord;
+  @relationship() public assigned_to!: ProjectMemberRecord;
+  @relationship() public reviewed_by!: ProjectMemberRecord;
+  @relationship() public submitted_by!: ProjectMemberRecord;
 
   public get priorityBadge(): EntryPriorityBadgeProps {
     const defaultBadgeProps: EntryPriorityBadgeProps = {

--- a/app/frontend/src/lib/data/model/dataset/projects/members/record.ts
+++ b/app/frontend/src/lib/data/model/dataset/projects/members/record.ts
@@ -15,6 +15,7 @@ export class ProjectMemberRecord extends Record {
   @field() public role!: ProjectMemberRole;
 
   @field() public invited_by_id!: number;
+  @field() public disabled_at!: Date | null;
 
   @field({ transformer: Transformers.Time }) public created_at!: Date;
   @field({ transformer: Transformers.Time }) public updated_at!: Date;

--- a/app/frontend/src/routes/(app)/projects/[projectId]/datasets/[datasetId]/entries/+page.svelte
+++ b/app/frontend/src/routes/(app)/projects/[projectId]/datasets/[datasetId]/entries/+page.svelte
@@ -108,6 +108,8 @@
     filters: {
       dataset_id: datasetId,
     },
+    included: ["assigned_to", "submitted_by", "reviewed_by"],
+    fields: { "dataset:project_members": ["name", "email", "picture_url"] },
     sort: ["priority"],
     count: true,
     pagination: {

--- a/app/frontend/src/routes/(app)/projects/[projectId]/members/+page.svelte
+++ b/app/frontend/src/routes/(app)/projects/[projectId]/members/+page.svelte
@@ -55,6 +55,7 @@
     listOptions={{
       filters: {
         project_id: projectId,
+        enabled: true,
       },
     }}
   >

--- a/app/iam/app/model/account.rb
+++ b/app/iam/app/model/account.rb
@@ -84,7 +84,7 @@ module Account
       membership_account_ids =
         if org_ids.any?
           Api[:idah].dataset.project_members.index(
-            filter: { organization_id__in: org_ids }
+            filter: { organization_id__in: org_ids, enabled: true }
           ).data.map(&:account_id).uniq
         else
           []

--- a/app/iam/app/service/account/service.rb
+++ b/app/iam/app/service/account/service.rb
@@ -90,10 +90,11 @@ module Account
     end
 
     def delete(id)
-      participated_projects = Api[:idah].dataset.entries.index(filter: { participated: id }).data
-      unless participated_projects.empty?
-        raise Verse::Error::ValidationFailed,
-              "Unable to delete account participated in project(s), consider disable it instead"
+      account = accounts.find!(id)
+
+      if account.joined_at
+        raise Verse::Error::Unauthorized,
+              "Cannot delete an account that has already joined"
       end
 
       accounts.delete(id)

--- a/app/iam/app/service/account/service_spec.rb
+++ b/app/iam/app/service/account/service_spec.rb
@@ -155,23 +155,18 @@ RSpec.describe Account::Service, database: true do
         @account_id = account_repo.create(attributes)
       end
 
-      it "deletes an account" do
-        allow(Api[:idah].dataset.entries).to receive(:index).and_return(
-          Verse::JsonApi::Struct.new([])
-        )
-
+      it "deletes an account that has not joined" do
         subject.delete(@account_id)
+
         expect { account_repo.find!(@account_id) }.to raise_error(Verse::Error::NotFound)
       end
 
-      it "doesn't allow account deletion if it's participated in any work" do
-        allow(Api[:idah].dataset.entries).to receive(:index).and_return(
-          Verse::JsonApi::Struct.new(Verse::JsonApi::Struct.new({ id: "mocked_entry_id" }))
-        )
+      it "cannot delete an account that has already joined" do
+        account_repo.update!(@account_id, { joined_at: Time.now })
 
         expect { subject.delete(@account_id) }.to raise_error(
-          Verse::Error::ValidationFailed,
-          "Unable to delete account participated in project(s), consider disable it instead"
+          Verse::Error::Unauthorized,
+          "Cannot delete an account that has already joined"
         )
       end
     end


### PR DESCRIPTION
Updates:
- Project member is only disabled when deleted from project.
- Disabling account will automatically disable all project membership.
- Adding project member which account is disabled will automatically enable the account.
- Cancel of pending account invitation will delete the account and project memberships permanently.
- Org owner, Project owner, Reviewer and Annotator can only see accounts with enabled project membership.
- Entries now used project member to view account details.