### PR TITLE
Submit entry redirects to blank entries list page

### DIFF
--- a/app/frontend/src/lib/plugin/ActivityContext.ts
+++ b/app/frontend/src/lib/plugin/ActivityContext.ts
@@ -97,7 +97,15 @@ export function activityContextForEntry(entry: EntryRecord): IActivityContext {
           .submit(entry.id, opts)
           .then(async () => {
             try {
-              const datasetsRes = await datasetsBackendDataSource.list();
+              /**
+               * After submission successfully,
+               * We need to check if there are more entries to do or not
+               * by fetching the datasets without cache
+               *
+               * If there are more entries, redirect to the entries list page
+               * If there are no more entries, redirect to the datasets list page
+               */
+              const datasetsRes = await datasetsBackendDataSource.list({ noCache: true });
               if (datasetsRes.data.length) {
                 goto(resolve(`/projects/${entry.dataset.project.id}/datasets/${entry.dataset.id}/entries`));
               } else {


### PR DESCRIPTION
### Issue

Users are redirected to the Entries page when there are no more assigned entries, resulting in a blank page. Occasionally, they may see an empty Entries page when they no longer have permission to access it.