### PR TITLE
Add Hover Card on Account Role

### DIFF
--- a/app/frontend/src/lib/components/app/datasets/dropdowns/project-dataset-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/dropdowns/project-dataset-dropdown-menu.svelte
@@ -83,7 +83,7 @@
   async function fetchDataset() {
     return await datasetsBackendDataSource.get(datasetId, {
       fields: {
-        "datasets:datasets": ["name", "modality"],
+        [DatasetRecord.type]: ["name", "modality"],
       },
       noCache: true,
     });

--- a/app/frontend/src/lib/components/app/datasets/entries/cards/entry-card.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/cards/entry-card.svelte
@@ -236,9 +236,9 @@
 </script>
 
 <Card class="hover:bg-primary/5 hover:shadow-primary/10 group transition-shadow hover:shadow-md">
-  <CardContent class="grid grid-cols-2">
+  <CardContent class="flex">
     <!-- SECTION::LEFT -->
-    <section class="flex flex-row gap-4">
+    <section class="flex flex-1 flex-row gap-4">
       <!-- CHECKBOX -->
       {#if canUpdateEntry || canDeleteEntry}
         <div class="my-auto">
@@ -260,7 +260,7 @@
               <img
                 src={thumbnailUrl}
                 alt="Entry thumbnail"
-                class="absolute top-0 left-0 cursor-pointer object-cover"
+                class="absolute left-0 top-0 cursor-pointer object-cover"
                 style:height="{imgContainer?.clientHeight}px"
                 style:width="{containerWidth * TOTAL_POSITIONS}px"
                 style:max-width="none"
@@ -298,71 +298,76 @@
           </Text>
         {/if}
 
-        <div class="flex flex-col items-start">
-          <DataDisplay label="Created at">
-            {#snippet slotValue()}
-              <DateText
-                datetime={entry.created_at}
-                datetimeFormat="MMM dd, yyyy"
-                size="sm"
-                weight="light"
-                showTooltip
-              />
-            {/snippet}
-          </DataDisplay>
+        <!-- INFO -->
+        <div class="grid grid-cols-2 gap-4">
+          <div class="flex flex-col gap-2">
+            <!-- CREATED AT -->
+            <DataDisplay label="Created at">
+              {#snippet slotValue()}
+                <DateText
+                  datetime={entry.created_at}
+                  datetimeFormat="MMM dd, yyyy"
+                  size="sm"
+                  weight="light"
+                  showTooltip
+                />
+              {/snippet}
+            </DataDisplay>
 
-          <DataDisplay label="Updated at">
-            {#snippet slotValue()}
-              <DateText
-                datetime={entry.updated_at}
-                datetimeFormat="MMM dd, yyyy"
-                size="sm"
-                weight="light"
-                showTooltip
-              />
-            {/snippet}
-          </DataDisplay>
-        </div>
+            <!-- UPDATED AT -->
+            <DataDisplay label="Updated at">
+              {#snippet slotValue()}
+                <DateText
+                  datetime={entry.updated_at}
+                  datetimeFormat="MMM dd, yyyy"
+                  size="sm"
+                  weight="light"
+                  showTooltip
+                />
+              {/snippet}
+            </DataDisplay>
 
-        <!-- PRIORITY AT -->
-        <div>
-          <EntryPriority {entry} updatable />
+            <!-- PRIORITY AT -->
+            <div>
+              <EntryPriority {entry} updatable />
+            </div>
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <!-- STAGE & ASSIGNED TO -->
+            <DataDisplay label="Stage" value={humanize(wf_step)} />
+
+            <!-- NOTE: Only show assigned to if wf_step is not "done" -->
+            {#if wf_step !== "done"}
+              <DataDisplay label="Assigned to">
+                {#snippet slotValue()}
+                  <ProjectMemberAvatar member={entry.assigned_to} />
+                {/snippet}
+              </DataDisplay>
+            {/if}
+
+            {#if submitted_by_id}
+              <DataDisplay label="Submitted by">
+                {#snippet slotValue()}
+                  <ProjectMemberAvatar member={entry.submitted_by} />
+                {/snippet}
+              </DataDisplay>
+            {/if}
+
+            {#if reviewed_by_id}
+              <DataDisplay label="Reviewed by">
+                {#snippet slotValue()}
+                  <ProjectMemberAvatar member={entry.reviewed_by} />
+                {/snippet}
+              </DataDisplay>
+            {/if}
+          </div>
         </div>
       </div>
     </section>
 
     <!-- SECTION::RIGHT -->
     <section class="flex flex-row gap-4">
-      <!-- STAGE & ASSIGNED TO -->
-      <div class="my-auto flex flex-1 flex-col gap-2">
-        <DataDisplay label="Stage" value={humanize(wf_step)} />
-
-        <!-- NOTE: Only show assigned to if wf_step is not "done" -->
-        {#if wf_step !== "done"}
-          <DataDisplay label="Assigned to">
-            {#snippet slotValue()}
-              <ProjectMemberAvatar member={entry.assigned_to} />
-            {/snippet}
-          </DataDisplay>
-        {/if}
-
-        {#if submitted_by_id}
-          <DataDisplay label="Submitted by">
-            {#snippet slotValue()}
-              <ProjectMemberAvatar member={entry.submitted_by} />
-            {/snippet}
-          </DataDisplay>
-        {/if}
-
-        {#if reviewed_by_id}
-          <DataDisplay label="Reviewed by">
-            {#snippet slotValue()}
-              <ProjectMemberAvatar member={entry.reviewed_by} />
-            {/snippet}
-          </DataDisplay>
-        {/if}
-      </div>
-
       <!-- STATUS & ACTIONS -->
       <div>
         <div class="flex items-center gap-2">

--- a/app/frontend/src/lib/components/app/datasets/entries/cards/entry-card.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/cards/entry-card.svelte
@@ -260,7 +260,7 @@
               <img
                 src={thumbnailUrl}
                 alt="Entry thumbnail"
-                class="absolute left-0 top-0 cursor-pointer object-cover"
+                class="absolute top-0 left-0 cursor-pointer object-cover"
                 style:height="{imgContainer?.clientHeight}px"
                 style:width="{containerWidth * TOTAL_POSITIONS}px"
                 style:max-width="none"

--- a/app/frontend/src/lib/components/app/datasource-table/datasource-table-head-options.svelte
+++ b/app/frontend/src/lib/components/app/datasource-table/datasource-table-head-options.svelte
@@ -1,4 +1,6 @@
 <script lang="ts" generics="T extends Record">
+  import { getContext } from "svelte";
+
   import FilterSortDropdownMenu from "@/components/app/dropdown-menus/filter-sort-dropdown-menu.svelte";
 
   import type {
@@ -31,6 +33,9 @@
     onSort,
     onHide,
   }: Props = $props();
+
+  // Contexts
+  const disabledActiveFilterSortKeys = getContext<Array<string>>("disabledActiveFilterSortKeys");
 </script>
 
 <FilterSortDropdownMenu
@@ -42,4 +47,5 @@
   {onFilter}
   {onSort}
   {onHide}
+  {disabledActiveFilterSortKeys}
 ></FilterSortDropdownMenu>

--- a/app/frontend/src/lib/components/app/datasource-table/datasource-table-head-options.svelte
+++ b/app/frontend/src/lib/components/app/datasource-table/datasource-table-head-options.svelte
@@ -35,7 +35,7 @@
   }: Props = $props();
 
   // Contexts
-  const disabledActiveFilterSortKeys = getContext<Array<string>>("disabledActiveFilterSortKeys");
+  const disabledActiveStateFilterSortKeys = getContext<Array<string>>("disabledActiveStateFilterSortKeys");
 </script>
 
 <FilterSortDropdownMenu
@@ -47,5 +47,5 @@
   {onFilter}
   {onSort}
   {onHide}
-  {disabledActiveFilterSortKeys}
+  {disabledActiveStateFilterSortKeys}
 ></FilterSortDropdownMenu>

--- a/app/frontend/src/lib/components/app/datasource-table/datasource-table.svelte
+++ b/app/frontend/src/lib/components/app/datasource-table/datasource-table.svelte
@@ -45,6 +45,7 @@
     listOptions,
     columns: _columns,
     hidePagination,
+    disabledActiveFilterSortKeys,
     onLoadSetContexts = async () => ({}),
     actions,
     addNewRecordButton,
@@ -60,6 +61,7 @@
   setContext("addNewRecordButton", addNewRecordButton);
   setContext("emptyState", emptyState);
   setContext("filteredState", filteredState);
+  setContext("disabledActiveFilterSortKeys", disabledActiveFilterSortKeys);
 
   // Variables
   let tableState: TableState<T> = getTableState(id);

--- a/app/frontend/src/lib/components/app/datasource-table/datasource-table.svelte
+++ b/app/frontend/src/lib/components/app/datasource-table/datasource-table.svelte
@@ -45,7 +45,7 @@
     listOptions,
     columns: _columns,
     hidePagination,
-    disabledActiveFilterSortKeys,
+    disabledActiveStateFilterSortKeys,
     onLoadSetContexts = async () => ({}),
     actions,
     addNewRecordButton,
@@ -61,7 +61,7 @@
   setContext("addNewRecordButton", addNewRecordButton);
   setContext("emptyState", emptyState);
   setContext("filteredState", filteredState);
-  setContext("disabledActiveFilterSortKeys", disabledActiveFilterSortKeys);
+  setContext("disabledActiveStateFilterSortKeys", disabledActiveStateFilterSortKeys);
 
   // Variables
   let tableState: TableState<T> = getTableState(id);

--- a/app/frontend/src/lib/components/app/datasource-table/types.ts
+++ b/app/frontend/src/lib/components/app/datasource-table/types.ts
@@ -92,11 +92,11 @@ export interface DataTableBaseProps<T extends Record> {
    *     role_name__nin: ["system"]
    *   }
    * }
-   * then the disabledActiveFilterSortKeys should be ["role_name__nin"]
+   * then the disabledActiveStateFilterSortKeys should be ["role_name__nin"]
    *
    * So the FilterSortDropdownMenu component will not showing the active state for the "role_name__nin" filter.
    */
-  disabledActiveFilterSortKeys?: Array<string>;
+  disabledActiveStateFilterSortKeys?: Array<string>;
 
   // Functions
   onLoadSetContexts?: (response: CollectionResponse<T>) => Promise<Hash>;

--- a/app/frontend/src/lib/components/app/datasource-table/types.ts
+++ b/app/frontend/src/lib/components/app/datasource-table/types.ts
@@ -84,6 +84,20 @@ export interface DataTableBaseProps<T extends Record> {
   columns: ColumnsSettings<T>;
   hidePagination?: boolean;
 
+  /**
+   * Keys of filters and sorts that should be disabled from the active state of the filter-sort dropdown menu.
+   * For example: if the listOptions.filters is set like
+   * {
+   *   filters: {
+   *     role_name__nin: ["system"]
+   *   }
+   * }
+   * then the disabledActiveFilterSortKeys should be ["role_name__nin"]
+   *
+   * So the FilterSortDropdownMenu component will not showing the active state for the "role_name__nin" filter.
+   */
+  disabledActiveFilterSortKeys?: Array<string>;
+
   // Functions
   onLoadSetContexts?: (response: CollectionResponse<T>) => Promise<Hash>;
 

--- a/app/frontend/src/lib/components/app/dropdown-menus/filter-sort-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/dropdown-menus/filter-sort-dropdown-menu.svelte
@@ -45,7 +45,7 @@
     // DataSource
     filters: Filters;
     sort: Sort;
-    disabledActiveFilterSortKeys?: Array<string>;
+    disabledActiveStateFilterSortKeys?: Array<string>;
 
     // Functions
     onFilter: (params: FilterDataSourceParams) => Promise<void>;
@@ -75,7 +75,7 @@
     // DataSource
     filters,
     sort,
-    disabledActiveFilterSortKeys,
+    disabledActiveStateFilterSortKeys,
 
     // Functions
     onFilter,
@@ -106,7 +106,7 @@
 
   // let isFiltering = $derived(Object.keys(filters).some((key) => key.startsWith(filterKey)));
   // let isSorting = $derived(sort.some((s) => s.endsWith(columnKey)));
-  let hideFilterSortKeys = $derived(Array.from(new Set(disabledActiveFilterSortKeys ?? [])));
+  let hideFilterSortKeys = $derived(Array.from(new Set(disabledActiveStateFilterSortKeys ?? [])));
   let isFiltering = $derived.by(() => {
     const filterKeys = Array.from(new Set(Object.keys(filters)));
     const symmetricDifferenceFilterKeys = [
@@ -392,7 +392,9 @@
         <CommandGroup heading="Filter">
           {#if filterComponent}
             {@const FilterComponent = filterComponent}
-            <FilterComponent {columnSetting} {filters} {contexts} {onFilter}></FilterComponent>
+            <div class="pb-2">
+              <FilterComponent {columnSetting} {filters} {contexts} {onFilter}></FilterComponent>
+            </div>
           {:else if filterOptions?.filterBy === "string"}
             {@const filterKey = `${columnKey}__${filterOptions.filterOperation || "match"}`}
             <div class="pb-2">

--- a/app/frontend/src/lib/components/app/dropdown-menus/filter-sort-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/dropdown-menus/filter-sort-dropdown-menu.svelte
@@ -364,7 +364,7 @@
         {#if filterable}
           {#if isFiltering}
             <FunnelIcon />
-            <div class="absolute left-[1.4rem] top-2 size-2 animate-pulse rounded-full bg-amber-500"></div>
+            <div class="absolute top-2 left-[1.4rem] size-2 animate-pulse rounded-full bg-amber-500"></div>
           {:else}
             <FunnelIcon />
           {/if}

--- a/app/frontend/src/lib/components/app/dropdown-menus/filter-sort-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/dropdown-menus/filter-sort-dropdown-menu.svelte
@@ -45,6 +45,7 @@
     // DataSource
     filters: Filters;
     sort: Sort;
+    disabledActiveFilterSortKeys?: Array<string>;
 
     // Functions
     onFilter: (params: FilterDataSourceParams) => Promise<void>;
@@ -74,6 +75,7 @@
     // DataSource
     filters,
     sort,
+    disabledActiveFilterSortKeys,
 
     // Functions
     onFilter,
@@ -102,8 +104,26 @@
     return "start";
   });
 
-  let isFiltering = $derived(Object.keys(filters).some((key) => key.startsWith(filterKey)));
-  let isSorting = $derived(sort.some((s) => s.endsWith(columnKey)));
+  // let isFiltering = $derived(Object.keys(filters).some((key) => key.startsWith(filterKey)));
+  // let isSorting = $derived(sort.some((s) => s.endsWith(columnKey)));
+  let hideFilterSortKeys = $derived(Array.from(new Set(disabledActiveFilterSortKeys ?? [])));
+  let isFiltering = $derived.by(() => {
+    const filterKeys = Array.from(new Set(Object.keys(filters)));
+    const symmetricDifferenceFilterKeys = [
+      ...filterKeys.filter((item) => !hideFilterSortKeys.includes(item)),
+      ...hideFilterSortKeys.filter((item) => !filterKeys.includes(item)),
+    ];
+    return symmetricDifferenceFilterKeys.some((key) => key.startsWith(filterKey));
+  });
+
+  let isSorting = $derived.by(() => {
+    const sortKeys = Array.from(new Set(sort));
+    const symmetricDifferenceSortKeys = [
+      ...sortKeys.filter((item) => !hideFilterSortKeys.includes(item)),
+      ...hideFilterSortKeys.filter((item) => !sortKeys.includes(item)),
+    ];
+    return symmetricDifferenceSortKeys.some((key) => key.endsWith(columnKey));
+  });
   let isSortingAsc = $derived(sort.includes(columnKey));
   let isSortingDesc = $derived(sort.includes(`-${columnKey}`));
   let isFilteringOrSorting = $derived(isFiltering || isSorting);
@@ -344,7 +364,7 @@
         {#if filterable}
           {#if isFiltering}
             <FunnelIcon />
-            <div class="absolute top-2 left-[1.4rem] size-2 animate-pulse rounded-full bg-amber-500"></div>
+            <div class="absolute left-[1.4rem] top-2 size-2 animate-pulse rounded-full bg-amber-500"></div>
           {:else}
             <FunnelIcon />
           {/if}

--- a/app/frontend/src/lib/components/app/iam/accounts/avatars/account-avatar.svelte
+++ b/app/frontend/src/lib/components/app/iam/accounts/avatars/account-avatar.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
+  import { CheckIcon } from "@lucide/svelte";
+
   import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-  import { Badge } from "@/components/ui/badge";
+  import Badge from "@/components/ui/badge/badge.svelte";
   import Link from "@/components/ui/text/Link.svelte";
 
+  import { roles } from "@/data/model/iam/accounts/constants";
   import { cn } from "@/utils";
-
   import { getAvatarFallback, humanize, truncateEmail } from "@/utils/string";
-  import { CheckIcon } from "@lucide/svelte";
+
+  import { type Role } from "@/data/model/iam/accounts/auth/constants";
 
   // Props
   interface Props {
@@ -16,7 +19,7 @@
     name?: string | null;
     email?: string | null;
     pictureUrl?: string | null;
-    roleName?: string | null;
+    roleName?: Role | null;
     showName?: boolean;
     showEmail?: boolean;
     showRole?: boolean;
@@ -73,7 +76,10 @@
     {/if}
 
     {#if showRole}
-      <Badge variant="outline" class="mt-1">{humanize(roleName || "")}</Badge>
+      <Badge variant="outline" rounded="full" class="mt-1">
+        {@const foundRole = roles.find((role) => role.value === roleName)}
+        {foundRole ? foundRole.label : humanize(roleName || "")}
+      </Badge>
     {/if}
   </div>
 </div>

--- a/app/frontend/src/lib/components/app/iam/accounts/badges/account-role-badge.svelte
+++ b/app/frontend/src/lib/components/app/iam/accounts/badges/account-role-badge.svelte
@@ -119,7 +119,7 @@
         {#if role_name === "org_owner"}
           {@render HoverCardTitle("Organizations")}
 
-          {#each belongsToOrganization as organizationRecord}
+          {#each belongsToOrganization as organizationRecord (organizationRecord.id)}
             {@render Content(organizationRecord.name)}
           {:else}
             {@render NoContent("Not an owner of any organization yet")}
@@ -127,7 +127,7 @@
         {:else if role_name === "user"}
           {@render HoverCardTitle("Projects")}
 
-          {#each belongsToProjectMembers as projectMemberRecord}
+          {#each belongsToProjectMembers as projectMemberRecord (projectMemberRecord.id)}
             <div class="flex w-full items-center justify-between gap-4">
               {@render Content(projectMemberRecord.project.name)}
               <ProjectMemberRoleBadge {projectMemberRecord} />

--- a/app/frontend/src/lib/components/app/iam/accounts/badges/account-role-badge.svelte
+++ b/app/frontend/src/lib/components/app/iam/accounts/badges/account-role-badge.svelte
@@ -1,27 +1,144 @@
 <script lang="ts">
-  import Badge from "@/components/ui/badge/badge.svelte";
+  import { onMount } from "svelte";
 
+  import ProjectMemberRoleBadge from "@/components/app/projects/members/badges/project-member-role-badge.svelte";
+  import Badge from "@/components/ui/badge/badge.svelte";
+  import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
+  import Text from "@/components/ui/text/Text.svelte";
+
+  import { ProjectMemberRecord, projectMembersBackendDataSource } from "@/data/model/dataset/projects/members/record";
+  import { ProjectRecord } from "@/data/model/dataset/projects/project-record";
   import { roles } from "@/data/model/iam/accounts/constants";
   import { AccountRecord } from "@/data/model/iam/accounts/record";
+  import { OrganizationRecord, organizationsBackendDataSource } from "@/data/model/iam/organizations/record";
+  import { cn } from "@/utils";
   import { humanize } from "@/utils/string";
+
+  import type { Role } from "@/data/model/iam/accounts/auth/constants";
 
   // Props
   interface Props {
     accountRecord: AccountRecord;
+    class?: string | null;
   }
-  let { accountRecord }: Props = $props();
+  let { accountRecord, class: className }: Props = $props();
+
+  // Lifecycle
+  onMount(async () => {
+    await Promise.all([
+      fetchOrganizations(accountRecord.role_scope.org as Array<string> | undefined),
+      fetchProjectMembers(accountRecord.id),
+    ]);
+  });
 
   // Variables
+  let belongsToOrganization: OrganizationRecord[] = [];
+  let belongsToProjectMembers: ProjectMemberRecord[] = [];
+
   let { role_name } = $derived(accountRecord);
   let roleName = $derived.by(() => {
     if (!role_name) return "Unassigned";
-
     const foundRole = roles.find((role) => role.value === role_name);
-
     return foundRole ? foundRole.label : humanize(role_name);
   });
+
+  let rolesRequireMoreInfo: Array<Role> = ["org_owner", "user"];
+  let hoverable = $derived.by(() => {
+    if (!role_name) return false;
+    return rolesRequireMoreInfo.includes(role_name);
+  });
+
+  // Functions
+  async function fetchOrganizations(ids: Array<string> | undefined) {
+    if (!ids || !ids.length) {
+      belongsToOrganization = [];
+      return;
+    }
+
+    const organizationsRes = await organizationsBackendDataSource.list({
+      fields: {
+        [OrganizationRecord.type]: ["id", "name"],
+      },
+      filters: {
+        id: ids,
+      },
+    });
+    belongsToOrganization = organizationsRes.data;
+  }
+
+  async function fetchProjectMembers(accountId: string) {
+    const projectMembersRes = await projectMembersBackendDataSource.list({
+      fields: {
+        [ProjectMemberRecord.type]: ["id", "role"],
+        [ProjectRecord.type]: ["id", "name"],
+      },
+      filters: {
+        account_id: accountId,
+      },
+      included: ["project"],
+    });
+    belongsToProjectMembers = projectMembersRes.data;
+  }
 </script>
 
-<Badge variant="outline" rounded="full">
-  {roleName}
-</Badge>
+{#snippet RoleBadge()}
+  <Badge
+    variant="outline"
+    rounded="full"
+    class={cn(
+      {
+        "hover:bg-accent hover:text-accent-foreground cursor-pointer": hoverable,
+      },
+      className,
+    )}
+  >
+    {roleName}
+  </Badge>
+{/snippet}
+
+{#snippet HoverCardTitle(title: string)}
+  <Text size="sm" weight="semibold">{title}</Text>
+{/snippet}
+
+{#snippet Content(content: string)}
+  <Text size="xs">{content}</Text>
+{/snippet}
+
+{#snippet NoContent(content: string)}
+  <Text size="xs" class="text-muted-foreground">{content}</Text>
+{/snippet}
+
+{#if hoverable}
+  <HoverCard openDelay={200}>
+    <HoverCardTrigger>
+      {@render RoleBadge()}
+    </HoverCardTrigger>
+
+    <HoverCardContent class="w-auto min-w-40 max-w-64 p-2" align="center" sideOffset={8}>
+      <div class="flex flex-col gap-1">
+        {#if role_name === "org_owner"}
+          {@render HoverCardTitle("Organizations")}
+
+          {#each belongsToOrganization as organizationRecord}
+            {@render Content(organizationRecord.name)}
+          {:else}
+            {@render NoContent("Not an owner of any organization yet")}
+          {/each}
+        {:else if role_name === "user"}
+          {@render HoverCardTitle("Projects")}
+
+          {#each belongsToProjectMembers as projectMemberRecord}
+            <div class="flex w-full items-center justify-between gap-4">
+              {@render Content(projectMemberRecord.project.name)}
+              <ProjectMemberRoleBadge {projectMemberRecord} />
+            </div>
+          {:else}
+            {@render NoContent("Not a member of any project yet")}
+          {/each}
+        {/if}
+      </div>
+    </HoverCardContent>
+  </HoverCard>
+{:else}
+  {@render RoleBadge()}
+{/if}

--- a/app/frontend/src/lib/components/app/iam/accounts/badges/account-role-badge.svelte
+++ b/app/frontend/src/lib/components/app/iam/accounts/badges/account-role-badge.svelte
@@ -114,7 +114,7 @@
       {@render RoleBadge()}
     </HoverCardTrigger>
 
-    <HoverCardContent class="w-auto min-w-40 max-w-64 p-2" align="center" sideOffset={8}>
+    <HoverCardContent class="w-auto max-w-64 min-w-40 p-2" align="center" sideOffset={8}>
       <div class="flex flex-col gap-1">
         {#if role_name === "org_owner"}
           {@render HoverCardTitle("Organizations")}

--- a/app/frontend/src/lib/components/app/iam/accounts/data-tables/account-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/iam/accounts/data-tables/account-row-action-cell.svelte
@@ -74,7 +74,7 @@
   async function fetchAccount() {
     return await accountsBackendDataSource.get(account.id, {
       fields: {
-        "iam:accounts": ["name", "email", "enabled", "role_name", "sso_channel"],
+        [AccountRecord.type]: ["name", "email", "enabled", "role_name", "sso_channel"],
       },
       noCache: true,
     });

--- a/app/frontend/src/lib/components/app/iam/accounts/dropdowns/account-dropdown.svelte
+++ b/app/frontend/src/lib/components/app/iam/accounts/dropdowns/account-dropdown.svelte
@@ -13,6 +13,7 @@
   import { AuthContext, authStatus } from "@/security/AuthContext";
 
   import type { IDropdownMenus } from "@/components/app/dropdown-menus/types";
+  import type { Role } from "@/data/model/iam/accounts/auth/constants";
 
   // Variables
   AuthContext.backend ||= accountAuthService();
@@ -23,7 +24,7 @@
       name: "",
       email: "",
       pictureUrl: "",
-      roleName: "user",
+      roleName: "user" as Role,
     },
   );
 

--- a/app/frontend/src/lib/components/app/organizations/data-tables/organization-owner-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/organizations/data-tables/organization-owner-row-action-cell.svelte
@@ -24,6 +24,9 @@
   async function removeOrgOwner() {
     try {
       const { data: account } = await accountsBackendDataSource.get(accountId, {
+        fields: {
+          [AccountRecord.type]: ["id", "role_name", "role_scope"],
+        },
         noCache: true,
       });
 

--- a/app/frontend/src/lib/components/app/organizations/data-tables/organization-owner-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/organizations/data-tables/organization-owner-row-action-cell.svelte
@@ -4,6 +4,7 @@
   import { toast } from "svelte-sonner";
 
   import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
+  import Tooltips from "@/components/app/tooltips/tooltips.svelte";
   import Button from "@/components/ui/button/button.svelte";
 
   import { AccountRecord, accountsBackendDataSource } from "@/data/model/iam/accounts/record";
@@ -65,9 +66,18 @@
 </script>
 
 <Can action="delete" resource="iam:organizations" scopes={["as_org_owner"]}>
-  <Button variant="ghost" size="icon-sm" onclick={() => (openConfirmRemoveOrgOwnerModal = true)}>
-    <UserRoundXIcon />
-  </Button>
+  <Tooltips align="center">
+    {#snippet trigger()}
+      <Button variant="ghost" size="icon-sm" onclick={() => (openConfirmRemoveOrgOwnerModal = true)}>
+        <UserRoundXIcon />
+      </Button>
+    {/snippet}
+
+    {#snippet content()}
+      Remove "{accountRecord.email}" <br />
+      from organization owner
+    {/snippet}
+  </Tooltips>
 
   <ConfirmModal
     title="Remove Organization Owner"

--- a/app/frontend/src/lib/components/app/organizations/dropdowns/organization-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/organizations/dropdowns/organization-dropdown-menu.svelte
@@ -83,6 +83,9 @@
 
   async function loadRelatedProjects() {
     const projectsRes = await projectsBackendDataSource.list({
+      fields: {
+        [ProjectRecord.type]: ["id"],
+      },
       filters: {
         organization_id: organizationId,
       },

--- a/app/frontend/src/lib/components/app/organizations/overlays/organization-owners-form-modal.svelte
+++ b/app/frontend/src/lib/components/app/organizations/overlays/organization-owners-form-modal.svelte
@@ -7,7 +7,7 @@
   import Button from "@/components/ui/button/button.svelte";
   import { DialogTitle } from "@/components/ui/dialog";
 
-  import { accountsBackendDataSource } from "@/data/model/iam/accounts/record";
+  import { AccountRecord, accountsBackendDataSource } from "@/data/model/iam/accounts/record";
   import { showActionFailedToast } from "@/utils/error/error.toasts";
   import { refetches } from "@/utils/refetch";
 
@@ -39,6 +39,9 @@
     for (const accountId of owners) {
       /** Get latest account data */
       const { data: account } = await accountsBackendDataSource.get(accountId, {
+        fields: {
+          [AccountRecord.type]: ["id", "role_name", "role_scope"],
+        },
         noCache: true,
       });
 

--- a/app/frontend/src/lib/components/app/projects/dropdowns/project-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/projects/dropdowns/project-dropdown-menu.svelte
@@ -81,7 +81,7 @@
   async function fetchProject() {
     return await projectsBackendDataSource.get(projectId, {
       fields: {
-        "datasets:projects": ["name", "description", "organization_id"],
+        [ProjectRecord.type]: ["name", "description", "organization_id"],
       },
       noCache: true,
     });

--- a/app/frontend/src/lib/components/app/projects/entries/account-entries.svelte
+++ b/app/frontend/src/lib/components/app/projects/entries/account-entries.svelte
@@ -28,11 +28,11 @@
 
     entries = (
       await entriesBackendDataSource.list({
-        filters: filters,
         fields: {
           [DatasetRecord.type]: ["name"],
           [EntryRecord.type]: ["resource", "project_id", "dataset_id", "assigned_to_id"],
         },
+        filters: filters,
         included: ["dataset"],
       })
     ).data;

--- a/app/frontend/src/lib/components/app/projects/entries/account-entries.svelte
+++ b/app/frontend/src/lib/components/app/projects/entries/account-entries.svelte
@@ -65,7 +65,7 @@
 {#if entries.length > 0}
   <div class="text-muted-foreground text-sm">
     <div>Entries on these datasets will be unassigned from this account.</div>
-    <ul class="ml-5 mt-2 max-h-40 overflow-y-auto">
+    <ul class="mt-2 ml-5 max-h-40 overflow-y-auto">
       {#each Object.entries(countEntriesByDataset) as [datasetId, count] (datasetId)}
         <li>
           <Link

--- a/app/frontend/src/lib/components/app/projects/entries/account-entries.svelte
+++ b/app/frontend/src/lib/components/app/projects/entries/account-entries.svelte
@@ -1,18 +1,24 @@
 <script lang="ts">
-  import Link from "@/components/ui/text/Link.svelte";
-  import { entriesBackendDataSource, EntryRecord } from "@/data/model/dataset/entries/record";
   import { onMount } from "svelte";
 
+  import Link from "@/components/ui/text/Link.svelte";
+
+  import { DatasetRecord } from "@/data/model/dataset/dataset-record";
+  import { entriesBackendDataSource, EntryRecord } from "@/data/model/dataset/entries/record";
+
+  // Props
   interface Props {
     accountId: number | string;
     projectId?: number | string;
   }
 
+  // Variables
   let entries: EntryRecord[] = $state([]);
   let countEntriesByDataset: Record<string, number> = $state({});
   let nameDatasetMap: Record<string, string> = $state({});
   let { accountId, projectId }: Props = $props();
 
+  // Functions
   async function fetchEntries(): Promise<void> {
     const filters = { assigned_to_id: accountId };
 
@@ -24,8 +30,8 @@
       await entriesBackendDataSource.list({
         filters: filters,
         fields: {
-          "dataset:datasets": ["name"],
-          "dataset:entries": ["resource", "project_id", "dataset_id", "assigned_to_id"],
+          [DatasetRecord.type]: ["name"],
+          [EntryRecord.type]: ["resource", "project_id", "dataset_id", "assigned_to_id"],
         },
         included: ["dataset"],
       })
@@ -50,6 +56,7 @@
     );
   }
 
+  // Lifecycle
   onMount(async () => {
     await fetchEntries();
   });
@@ -58,7 +65,7 @@
 {#if entries.length > 0}
   <div class="text-muted-foreground text-sm">
     <div>Entries on these datasets will be unassigned from this account.</div>
-    <ul class="mt-2 ml-5 max-h-40 overflow-y-auto">
+    <ul class="ml-5 mt-2 max-h-40 overflow-y-auto">
       {#each Object.entries(countEntriesByDataset) as [datasetId, count] (datasetId)}
         <li>
           <Link

--- a/app/frontend/src/lib/components/app/projects/members/badges/project-member-role-badge.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/badges/project-member-role-badge.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import Badge from "@/components/ui/badge/badge.svelte";
+
+  import { ProjectMemberRecord, projectMemberRoles } from "@/data/model/dataset/projects/members/record";
+  import { humanize } from "@/utils/string";
+
+  // Props
+  interface Props {
+    projectMemberRecord: ProjectMemberRecord;
+  }
+  let { projectMemberRecord } = $props();
+
+  // Variables
+  let foundRole = $derived(projectMemberRoles.find((role) => role.value === projectMemberRecord.role));
+</script>
+
+<Badge variant="outline" rounded="full">
+  {foundRole ? foundRole.label : humanize(projectMemberRecord.role)}
+</Badge>

--- a/app/frontend/src/lib/components/app/projects/members/badges/project-member-role-badge.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/badges/project-member-role-badge.svelte
@@ -8,7 +8,7 @@
   interface Props {
     projectMemberRecord: ProjectMemberRecord;
   }
-  let { projectMemberRecord } = $props();
+  let { projectMemberRecord }: Props = $props();
 
   // Variables
   let foundRole = $derived(projectMemberRoles.find((role) => role.value === projectMemberRecord.role));

--- a/app/frontend/src/lib/components/app/projects/members/datasource-tables/project-member-role-cell.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/datasource-tables/project-member-role-cell.svelte
@@ -1,15 +1,12 @@
 <script lang="ts">
-  import { Badge } from "@/components/ui/badge";
+  import ProjectMemberRoleBadge from "@/components/app/projects/members/badges/project-member-role-badge.svelte";
 
-  import { ProjectMemberRecord, projectMemberRoles } from "@/data/model/dataset/projects/members/record";
-  import { humanize } from "@/utils/string";
+  import { ProjectMemberRecord } from "@/data/model/dataset/projects/members/record";
 
   import type { DataTableCellBaseProps } from "@/components/app/datasource-table/types";
 
   // Props
-  let { record: projectMember }: DataTableCellBaseProps<ProjectMemberRecord> = $props();
+  let { record: projectMemberRecord }: DataTableCellBaseProps<ProjectMemberRecord> = $props();
 </script>
 
-<Badge variant="outline">
-  {projectMemberRoles.find((role) => role.value === projectMember.role)?.label || humanize(projectMember.role)}
-</Badge>
+<ProjectMemberRoleBadge {projectMemberRecord} />

--- a/app/frontend/src/lib/components/app/projects/members/datasource-tables/project-member-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/datasource-tables/project-member-row-action-cell.svelte
@@ -4,6 +4,8 @@
   import { toast } from "svelte-sonner";
 
   import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
+  import AccountEntries from "@/components/app/projects/entries/account-entries.svelte";
+  import Tooltips from "@/components/app/tooltips/tooltips.svelte";
   import Button from "@/components/ui/button/button.svelte";
   import Can from "@/security/can.svelte";
 
@@ -11,11 +13,11 @@
   import { showActionFailedToast } from "@/utils/error/error.toasts";
   import { refetches } from "@/utils/refetch";
 
-  import type { DataTableCellBaseProps } from "@/components/app/datasource-table/types";
-  import AccountEntries from "../../entries/account-entries.svelte";
-  import { clearCache } from "@/data/Cache";
   import { resourcePath } from "@/data/BackendDataSource";
+  import { clearCache } from "@/data/Cache";
   import { entriesBasePath } from "@/data/model/dataset/entries/record";
+
+  import type { DataTableCellBaseProps } from "@/components/app/datasource-table/types";
 
   // Props
   interface Props extends DataTableCellBaseProps<ProjectMemberRecord> {
@@ -60,9 +62,17 @@
     },
   ]}
 >
-  <Button variant="ghost" size="icon-sm" onclick={() => (openConfirmRemoveMemberModal = true)}>
-    <UserRoundXIcon />
-  </Button>
+  <Tooltips align="center">
+    {#snippet trigger()}
+      <Button variant="ghost" size="icon-sm" onclick={() => (openConfirmRemoveMemberModal = true)}>
+        <UserRoundXIcon />
+      </Button>
+    {/snippet}
+
+    {#snippet content()}
+      Remove "{projectMember.email}" <br /> from project membership
+    {/snippet}
+  </Tooltips>
 
   <ConfirmModal
     title="Remove member"

--- a/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
@@ -8,6 +8,7 @@
   import DialogTitle from "@/components/ui/dialog/dialog-title.svelte";
 
   import {
+    ProjectMemberRecord,
     projectMembersBackendDataSource,
     type ProjectMemberRole,
   } from "@/data/model/dataset/projects/members/record";
@@ -60,10 +61,14 @@
         /** Check if member is already in the project */
         const existingProjectMember = (
           await projectMembersBackendDataSource.list({
+            fields: {
+              [ProjectMemberRecord.type]: ["id"],
+            },
             filters: {
               project_id: projectId,
               account_id: account.id,
             },
+            noCache: true,
           })
         ).data[0];
 
@@ -74,7 +79,7 @@
             {
               attributes: {
                 disabled_at: null,
-                role,
+                role: role || undefined,
               },
             },
             {

--- a/app/frontend/src/lib/components/app/texts/copyable.svelte
+++ b/app/frontend/src/lib/components/app/texts/copyable.svelte
@@ -5,7 +5,7 @@
   import Text from "@/components/ui/text/Text.svelte";
   import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
-  import { truncate } from "@/utils/string";
+  import { truncateEmail } from "@/utils/string";
 
   // Props
   interface Props {
@@ -36,7 +36,7 @@
   {#if slotValue}
     {@render slotValue()}
   {:else}
-    <Text size="sm">{truncate(value)}</Text>
+    <Text size="sm">{truncateEmail(value)}</Text>
   {/if}
 
   <TooltipProvider disableCloseOnTriggerClick>

--- a/app/frontend/src/lib/components/app/texts/data-display.svelte
+++ b/app/frontend/src/lib/components/app/texts/data-display.svelte
@@ -18,7 +18,7 @@
 
 <div
   id="data-display-container"
-  class={cn("flex", {
+  class={cn("flex min-h-6", {
     "flex-row items-center gap-1": direction === "horizontal",
     "flex-col gap-1": direction === "vertical",
   })}

--- a/app/frontend/src/lib/components/ui/field/field-label.svelte
+++ b/app/frontend/src/lib/components/ui/field/field-label.svelte
@@ -21,6 +21,10 @@
     "group/field-label peer/field-label flex w-fit gap-1 leading-snug group-data-[disabled=true]/field:opacity-50",
     "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4",
     "has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10",
+    {
+      "text-accent-foreground": required,
+      "text-accent-foreground/70": !required,
+    },
     className,
   )}
   {...restProps}

--- a/app/frontend/src/lib/data/model/iam/accounts/record.ts
+++ b/app/frontend/src/lib/data/model/iam/accounts/record.ts
@@ -33,7 +33,7 @@ RecordFactory.registerTypes(AccountRecord);
 const accountBasePath: string = `${import.meta.env.VITE_IDAH_HOST}/api/v1/iam/accounts`;
 
 export const accountsBackendDataSource = createBackendDataSource(AccountRecord, accountBasePath, {
-  join: async (params: { token: string }): Promise<RecordResponse<AccountRecord> | { data: null }> => {
+  join: async (params: { token: string }): Promise<RecordResponse<AccountRecord> | { data: null; meta?: Hash }> => {
     const res = await fetch(`${accountBasePath}/${params.token}/join`, {
       method: "PATCH",
       body: encodeModel(AccountRecord, { attributes: { joined_at: new Date() } }),

--- a/app/frontend/src/lib/plugin/ActivityContext.ts
+++ b/app/frontend/src/lib/plugin/ActivityContext.ts
@@ -1,7 +1,7 @@
 import { goto } from "$app/navigation";
 import { resolve } from "$app/paths";
 
-import { datasetsBackendDataSource } from "@/data/model/dataset/dataset-record";
+import { DatasetRecord, datasetsBackendDataSource } from "@/data/model/dataset/dataset-record";
 import { entriesBackendDataSource, EntryRecord } from "@/data/model/dataset/entries/record";
 
 import type { Command } from "@/command/Command";
@@ -105,7 +105,12 @@ export function activityContextForEntry(entry: EntryRecord): IActivityContext {
                * If there are more entries, redirect to the entries list page
                * If there are no more entries, redirect to the datasets list page
                */
-              const datasetsRes = await datasetsBackendDataSource.list({ noCache: true });
+              const datasetsRes = await datasetsBackendDataSource.list({
+                fields: {
+                  [DatasetRecord.type]: ["id"],
+                },
+                noCache: true,
+              });
               if (datasetsRes.data.length) {
                 goto(resolve(`/projects/${entry.dataset.project.id}/datasets/${entry.dataset.id}/entries`));
               } else {

--- a/app/frontend/src/lib/security/AuthContext.ts
+++ b/app/frontend/src/lib/security/AuthContext.ts
@@ -3,7 +3,7 @@ import { resolve } from "$app/paths";
 import { writable, type Writable } from "svelte/store";
 
 import { clearAllCache } from "@/data/Cache";
-import { projectMembersBackendDataSource } from "@/data/model/dataset/projects/members/record";
+import { ProjectMemberRecord, projectMembersBackendDataSource } from "@/data/model/dataset/projects/members/record";
 import { AccountAuthRecord, type AuthService } from "@/data/model/iam/accounts/auth/records";
 import { ActionMap } from "@/security/ActionMap";
 
@@ -153,6 +153,9 @@ export class AuthContext {
           const { projectId, projectMemberRoles } = scope["as_user"];
 
           const projectMemberRes = await projectMembersBackendDataSource.list({
+            fields: {
+              [ProjectMemberRecord.type]: ["id", "role"],
+            },
             filters: {
               project_id: projectId,
               account_id: this.id,

--- a/app/frontend/src/routes/(app)/accounts/+page.svelte
+++ b/app/frontend/src/routes/(app)/accounts/+page.svelte
@@ -71,6 +71,7 @@
           role_name__nin: ["system"],
         },
       }}
+      disabledActiveFilterSortKeys={["role_name__nin"]}
     >
       {#snippet addNewRecordButton()}
         {@render AddNewAccountButton()}

--- a/app/frontend/src/routes/(app)/accounts/+page.svelte
+++ b/app/frontend/src/routes/(app)/accounts/+page.svelte
@@ -74,6 +74,7 @@
             "email",
             "enabled",
             "role_name",
+            "role_scope",
             "picture_url",
             "joined_at",
             "invitation_expired_at",

--- a/app/frontend/src/routes/(app)/accounts/+page.svelte
+++ b/app/frontend/src/routes/(app)/accounts/+page.svelte
@@ -12,7 +12,7 @@
   import { accountColumns } from "@/components/app/iam/accounts/data-tables/account-columns";
   import { accountBreadcrumb } from "@/components/app/page/breadcrumbs/constants";
   import { pageBreadcrumbsStore } from "@/components/app/page/breadcrumbs/stores";
-  import { accountsBackendDataSource } from "@/data/model/iam/accounts/record";
+  import { AccountRecord, accountsBackendDataSource } from "@/data/model/iam/accounts/record";
   import { authStatus } from "@/security/AuthContext";
   import { refetches } from "@/utils/refetch";
 
@@ -67,11 +67,24 @@
       {columns}
       dataSource={accountsBackendDataSource}
       listOptions={{
+        fields: {
+          [AccountRecord.type]: [
+            "id",
+            "name",
+            "email",
+            "enabled",
+            "role_name",
+            "picture_url",
+            "joined_at",
+            "invitation_expired_at",
+            "created_at",
+          ],
+        },
         filters: {
           role_name__nin: ["system"],
         },
       }}
-      disabledActiveFilterSortKeys={["role_name__nin"]}
+      disabledActiveStateFilterSortKeys={["role_name__nin"]}
     >
       {#snippet addNewRecordButton()}
         {@render AddNewAccountButton()}

--- a/app/frontend/src/routes/(app)/audit-logs/+page.svelte
+++ b/app/frontend/src/routes/(app)/audit-logs/+page.svelte
@@ -228,6 +228,21 @@
       columns={logColumns}
       dataSource={logsBackendDataSource}
       listOptions={{
+        fields: {
+          [LogRecord.type]: [
+            "id",
+            "actor_account_id",
+            "actor_account_email",
+            "action",
+            "resource_type",
+            "resource_id",
+            "organization_id",
+            "project_id",
+            "dataset_id",
+            "entry_id",
+            "event_timestamp",
+          ],
+        },
         filters: {
           actor_account_role_name__nin: ["system"],
         },

--- a/app/frontend/src/routes/(app)/organizations/+page.svelte
+++ b/app/frontend/src/routes/(app)/organizations/+page.svelte
@@ -65,7 +65,7 @@
       dataSource={organizationsBackendDataSource}
       listOptions={{
         fields: {
-          [OrganizationRecord.type]: ["name", "created_at"],
+          [OrganizationRecord.type]: ["id", "name", "created_at"],
         },
       }}
     >

--- a/app/frontend/src/routes/(app)/organizations/[organizationId]/+layout.svelte
+++ b/app/frontend/src/routes/(app)/organizations/[organizationId]/+layout.svelte
@@ -44,7 +44,7 @@
   async function fetchOrganization() {
     const organizationRes = await organizationsBackendDataSource.get(organizationId, {
       fields: {
-        "iam/organizations": ["name"],
+        [OrganizationRecord.type]: ["name"],
       },
     });
     organization = organizationRes.data;

--- a/app/frontend/src/routes/(app)/organizations/[organizationId]/owners/+page.svelte
+++ b/app/frontend/src/routes/(app)/organizations/[organizationId]/owners/+page.svelte
@@ -9,7 +9,7 @@
   import { organizationOwnerColumns } from "@/components/app/organizations/data-tables/organization-owner-column";
   import { organizationBreadcrumb } from "@/components/app/page/breadcrumbs/constants";
   import { pageBreadcrumbsStore } from "@/components/app/page/breadcrumbs/stores";
-  import { accountsBackendDataSource } from "@/data/model/iam/accounts/record";
+  import { AccountRecord, accountsBackendDataSource } from "@/data/model/iam/accounts/record";
   import { OrganizationRecord } from "@/data/model/iam/organizations/record";
   import { authStatus } from "@/security/AuthContext";
   import { refetches } from "@/utils/refetch";
@@ -45,6 +45,9 @@
     {columns}
     dataSource={accountsBackendDataSource}
     listOptions={{
+      fields: {
+        [AccountRecord.type]: ["id", "name", "email", "created_at"],
+      },
       filters: {
         with_role_scope: {
           org: [organizationId],

--- a/app/frontend/src/routes/(app)/organizations/[organizationId]/projects/+page.svelte
+++ b/app/frontend/src/routes/(app)/organizations/[organizationId]/projects/+page.svelte
@@ -10,7 +10,7 @@
   import { organizationProjectColumns } from "@/components/app/organizations/data-tables/organization-project-columns";
   import { organizationBreadcrumb } from "@/components/app/page/breadcrumbs/constants";
   import { pageBreadcrumbsStore } from "@/components/app/page/breadcrumbs/stores";
-  import { projectsBackendDataSource } from "@/data/model/dataset/projects/project-record";
+  import { ProjectRecord, projectsBackendDataSource } from "@/data/model/dataset/projects/project-record";
   import { OrganizationRecord } from "@/data/model/iam/organizations/record";
   import { refetches } from "@/utils/refetch";
 
@@ -35,6 +35,9 @@
     columns={organizationProjectColumns}
     dataSource={projectsBackendDataSource}
     listOptions={{
+      fields: {
+        [ProjectRecord.type]: ["id", "name", "organization_id", "created_at"],
+      },
       filters: {
         organization_id: organizationId,
       },

--- a/app/frontend/src/routes/(app)/projects/+page.svelte
+++ b/app/frontend/src/routes/(app)/projects/+page.svelte
@@ -9,7 +9,7 @@
   import { projectBreadcrumb } from "@/components/app/page/breadcrumbs/constants";
   import { pageBreadcrumbsStore } from "@/components/app/page/breadcrumbs/stores";
   import { projectColumns } from "@/components/app/projects/datasource-tables/project-columns";
-  import { datasetsBackendDataSource } from "@/data/model/dataset/dataset-record";
+  import { DatasetRecord, datasetsBackendDataSource } from "@/data/model/dataset/dataset-record";
   import { ProjectRecord, projectsBackendDataSource } from "@/data/model/dataset/projects/project-record";
   import { OrganizationRecord, organizationsBackendDataSource } from "@/data/model/iam/organizations/record";
   import { authStatus } from "@/security/AuthContext";
@@ -44,8 +44,8 @@
     const projectIds = Array.from(new Set(response.data.map((project) => project.id)));
     const datasetsRes = await datasetsBackendDataSource.list({
       fields: {
-        "dataset:datasets": ["labels"],
-        "dataset:projects": [],
+        [DatasetRecord.type]: ["labels"],
+        [ProjectRecord.type]: ["id"],
       },
       filters: {
         project_id__in: projectIds,

--- a/app/frontend/src/routes/(app)/projects/[projectId]/+layout.svelte
+++ b/app/frontend/src/routes/(app)/projects/[projectId]/+layout.svelte
@@ -40,7 +40,7 @@
   async function fetchProject() {
     const projectRes = await projectsBackendDataSource.get(projectId, {
       fields: {
-        "datasets/projects": ["name"],
+        [ProjectRecord.type]: ["name"],
       },
     });
     project = projectRes.data;

--- a/app/frontend/src/routes/(app)/projects/[projectId]/datasets/+page.svelte
+++ b/app/frontend/src/routes/(app)/projects/[projectId]/datasets/+page.svelte
@@ -60,7 +60,7 @@
     dataSource={datasetsBackendDataSource}
     listOptions={{
       fields: {
-        [DatasetRecord.type]: ["name", "status", "modality", "progress", "created_at", "updated_at"],
+        [DatasetRecord.type]: ["id", "name", "status", "modality", "progress", "created_at", "updated_at"],
         [ProjectRecord.type]: ["name"],
         [EntryRecord.type]: ["status"],
       },

--- a/app/frontend/src/routes/(app)/projects/[projectId]/datasets/[datasetId]/+layout.svelte
+++ b/app/frontend/src/routes/(app)/projects/[projectId]/datasets/[datasetId]/+layout.svelte
@@ -56,7 +56,7 @@
   async function fetchData() {
     const datasetRes = await datasetsBackendDataSource.get(datasetId, {
       fields: {
-        "dataset:datasets": ["name"],
+        [DatasetRecord.type]: ["name"],
       },
     });
     dataset = datasetRes.data;

--- a/app/frontend/src/routes/(app)/projects/[projectId]/datasets/[datasetId]/entries/+page.svelte
+++ b/app/frontend/src/routes/(app)/projects/[projectId]/datasets/[datasetId]/entries/+page.svelte
@@ -43,6 +43,7 @@
   import { pageBreadcrumbsStore } from "@/components/app/page/breadcrumbs/stores";
   import { DatasetRecord } from "@/data/model/dataset/dataset-record";
   import { entriesBackendDataSource, EntryRecord } from "@/data/model/dataset/entries/record";
+  import { ProjectMemberRecord } from "@/data/model/dataset/projects/members/record";
   import { ProjectRecord } from "@/data/model/dataset/projects/project-record";
   import { authStatus } from "@/security/AuthContext";
   import { cn } from "@/utils";
@@ -142,7 +143,7 @@
   let listOptions: ListOptions = $state({
     filters: filters,
     included: ["assigned_to", "submitted_by", "reviewed_by"],
-    fields: { "dataset:project_members": ["name", "email", "picture_url"] },
+    fields: { [ProjectMemberRecord.type]: ["name", "email", "picture_url"] },
     sort: ["priority"],
     count: true,
     pagination: {

--- a/app/frontend/src/routes/(app)/projects/[projectId]/datasets/[datasetId]/entries/+page.svelte
+++ b/app/frontend/src/routes/(app)/projects/[projectId]/datasets/[datasetId]/entries/+page.svelte
@@ -322,7 +322,7 @@
   {#snippet slotTitle()}
     <div class="flex w-full gap-4">
       <div class="flex w-full flex-col items-center justify-between gap-4 md:flex-row">
-        <div class="flex w-4/5 items-center gap-4">
+        <div class="flex flex-1 items-center gap-4">
           <!-- SELECT ALL -->
           {#if canUpdateEntry || canDeleteEntry}
             <div class="pl-6">
@@ -330,7 +330,7 @@
             </div>
           {/if}
 
-          <div>
+          <div class="flex gap-2">
             {#each Object.entries(entryColumns) as [columnKey, columnSetting] (columnKey)}
               <FilterSortDropdownMenu
                 contexts={{
@@ -348,12 +348,12 @@
                   <Button
                     variant={isFiltering || isSorting ? "default" : "outline"}
                     class={cn(
-                      "data-[state=open]:bg-primary data-[state=open]:text-primary-foreground hover:bg-primary hover:text-primary-foreground my-2 w-full min-w-52 gap-2 font-normal",
+                      "data-[state=open]:bg-primary data-[state=open]:text-primary-foreground hover:bg-primary hover:text-primary-foreground my-2 w-full min-w-40 gap-2 font-normal",
                       isFiltering || isSorting ? "text-primary-foreground" : "text-muted-foreground",
                     )}
                   >
                     {#if isFiltering}
-                      <FunnelIcon class="size-4"></FunnelIcon>
+                      <FunnelIcon class="size-4" />
                     {/if}
 
                     <span class="mr-auto">{label}</span>
@@ -374,7 +374,7 @@
           </div>
         </div>
 
-        <div class="flex w-1/5 items-center justify-end gap-2">
+        <div class="flex items-center justify-end gap-2">
           <!-- BULK ACTIONS -->
           {#if isRowSelected}
             <DropdownMenu>

--- a/app/frontend/src/routes/(app)/projects/[projectId]/members/+page.svelte
+++ b/app/frontend/src/routes/(app)/projects/[projectId]/members/+page.svelte
@@ -9,7 +9,7 @@
   import { projectBreadcrumb } from "@/components/app/page/breadcrumbs/constants";
   import { pageBreadcrumbsStore } from "@/components/app/page/breadcrumbs/stores";
   import { projectMemberColumns } from "@/components/app/projects/members/datasource-tables/project-member-columns";
-  import { projectMembersBackendDataSource } from "@/data/model/dataset/projects/members/record";
+  import { ProjectMemberRecord, projectMembersBackendDataSource } from "@/data/model/dataset/projects/members/record";
   import { ProjectRecord } from "@/data/model/dataset/projects/project-record";
   import { authStatus } from "@/security/AuthContext";
   import { refetches } from "@/utils/refetch";
@@ -53,6 +53,9 @@
     {columns}
     dataSource={projectMembersBackendDataSource}
     listOptions={{
+      fields: {
+        [ProjectMemberRecord.type]: ["id", "account_id", "email", "role", "invited_by_id", "created_at"],
+      },
       filters: {
         project_id: projectId,
         enabled: true,

--- a/app/frontend/src/routes/(public)/accept-invitation/+page.svelte
+++ b/app/frontend/src/routes/(public)/accept-invitation/+page.svelte
@@ -11,9 +11,9 @@
       const accountResponse = await accountsBackendDataSource.join({
         token: page.url.searchParams.get("token") as string,
       });
-      const passwordResetToken = accountResponse.meta.password_reset_token || "";
+      const passwordResetToken = accountResponse.meta?.password_reset_token || "";
 
-      goto(resolve(`/reset-password?token=${passwordResetToken}`));
+      goto(`/reset-password?token=${passwordResetToken}`);
     } catch (error) {
       console.error("Error accepting invitation", error);
       goto(resolve("/error"));

--- a/app/frontend/src/routes/(public)/accept-invitation/+page.svelte
+++ b/app/frontend/src/routes/(public)/accept-invitation/+page.svelte
@@ -13,6 +13,7 @@
       });
       const passwordResetToken = accountResponse.meta?.password_reset_token || "";
 
+      /* eslint-disable svelte/no-navigation-without-resolve */
       goto(`/reset-password?token=${passwordResetToken}`);
     } catch (error) {
       console.error("Error accepting invitation", error);

--- a/app/frontend/src/routes/+layout.svelte
+++ b/app/frontend/src/routes/+layout.svelte
@@ -18,6 +18,6 @@
 
 <main class="bg-background relative flex min-h-screen flex-col">
   <ModeWatcher />
-  <Toaster position="bottom-right" richColors />
+  <Toaster position="bottom-center" richColors closeButton />
   {@render children?.()}
 </main>

--- a/app/frontend/src/routes/+layout.svelte
+++ b/app/frontend/src/routes/+layout.svelte
@@ -18,6 +18,6 @@
 
 <main class="bg-background relative flex min-h-screen flex-col">
   <ModeWatcher />
-  <Toaster position="top-right" richColors />
+  <Toaster position="bottom-right" richColors />
   {@render children?.()}
 </main>


### PR DESCRIPTION
## Summary

- Add HoverCard on AccountRoleBadge to display organizations for each account is an org onwer.
- Add HoverCard on AccountRoleBadge to display projects & project member role for each account is a user.
- Add `disabledActiveFilterSortKeys` props to hide the active filter or sort state for the specific key.
- Update key in `fields` when fetch data with `list()` and `get()` method to use Record.type instead of hard coded string.
- Add `fields` in datasource-table listOptions on each implemented pages.
- Move toast position from top-right to bottom-center