### PR TITLE
Properties sidebar improvements

### DIFF
--- a/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
@@ -33,17 +33,6 @@
   import type { IConfigProperty } from "$idah/v2/types";
   import type { IVideoAnnotationValue } from "$lib/types";
 
-  // Represents a group of annotations on the current frame (deduplicated by groupId)
-  type CurrentFrameGroup = {
-    groupId: string;
-    displayName: string;
-    shapeType: string;
-    color: string | null;
-    isHidden: boolean;
-    isLocked: boolean;
-    earliestStart: number;
-  };
-
   type Props = {
     selectedCategory: string;
     annotationId?: string;
@@ -106,49 +95,44 @@
 
   // -----------------------------------------------------------------------
   // Annotations on current frame (for default mode, no selection)
+  // Sorted in the same group-by-group order as the timeline
   // -----------------------------------------------------------------------
   let currentFrame = $derived(viewport.video.currentFrame.value);
-  let currentFrameGroups = $derived.by<CurrentFrameGroup[]>(() => {
+  let currentFrameAnnotations = $derived.by<IVideoAnnotationRecord[]>(() => {
     if (!data.annotations) return [];
-    const items = data.annotations.items;
+    const items = data.annotations.items as unknown as IVideoAnnotationRecord[];
     const frame = currentFrame;
 
-    // Filter and group annotations by groupId (same as groupAnnotations in group-annotation.svelte.ts)
+    // Filter to current frame
+    const onFrame = items.filter(
+      (ann) => ann.shape.start <= frame && ann.shape.end >= frame
+    );
+
+    // Group by groupId for sorting (same as timeline's groupAnnotations + compareGroups)
     const map = new Map<string, IVideoAnnotationRecord[]>();
-    for (const ann of items) {
-      const shape = ann.shape as { start?: number; end?: number };
-      if (shape.start === undefined || shape.end === undefined) continue;
-      if (shape.start > frame || shape.end < frame) continue;
+    for (const ann of onFrame) {
       const gid = ann.metadata?.group_id ?? ann.id;
       if (!map.has(gid)) map.set(gid, []);
       map.get(gid)!.push(ann);
     }
 
-    // Sort groups: compareGroups sorts by earliest start of first annotation in each group
-    const groups: CurrentFrameGroup[] = [];
-    for (const [groupId, anns] of map.entries()) {
-      // Sort annotations within group by start frame
-      anns.sort((a, b) => a.shape.start - b.shape.start || a.shape.end - b.shape.end);
-
-      const firstAnn = anns[0];
-      const annShapeType = firstAnn.shape.type as string;
-      const annConfig = getDriver().config[annShapeType];
-      const annCategory = annConfig?.values?.find((v) => v.id === firstAnn.value?.category);
-      const annColor = annCategory?.color ?? null;
-      const lastPart = groupId.split("-").pop() ?? "";
-      const displayName = annCategory ? `${annCategory.label}-${lastPart}` : (firstAnn.value?.category ?? "Uncategorized");
-
-      const isHidden = anns.some((a) => a.hidden);
-      const isLocked = anns.some((a) => a.locked);
-      const earliestStart = anns.reduce((min, a) => Math.min(min, a.shape.start), Infinity);
-
-      groups.push({ groupId, displayName, shapeType: annShapeType, color: annColor, isHidden, isLocked, earliestStart });
-    }
-
-    // Sort by earliest start (same as compareGroups)
+    // Build sorted groups by earliest start (compareGroups), then flatten with timeline naming
+    const sorted: IVideoAnnotationRecord[] = [];
+    const groups = Array.from(map.entries()).map(([groupId, anns]) => ({
+      groupId,
+      anns: anns.sort((a, b) => a.shape.start - b.shape.start || a.shape.end - b.shape.end),
+      earliestStart: Math.min(...anns.map((a) => a.shape.start)),
+    }));
     groups.sort((a, b) => a.earliestStart - b.earliestStart);
 
-    return groups;
+    // Flatten preserving group order
+    for (const group of groups) {
+      for (const ann of group.anns) {
+        sorted.push(ann);
+      }
+    }
+
+    return sorted;
   });
 
   // -----------------------------------------------------------------------
@@ -222,41 +206,51 @@
 
 <!-- ============ ANNOTATIONS ON CURRENT FRAME (default mode, no selection) ============ -->
 {#if !sel}
-  {#if viewport.mode === "default" && currentFrameGroups.length > 0}
+  {#if viewport.mode === "default" && currentFrameAnnotations.length > 0}
     <section class="flex flex-col gap-2">
       <div class="flex items-center gap-2">
         <Text weight="semibold">Annotations</Text>
-        <Badge variant="secondary">{currentFrameGroups.length}</Badge>
+        <Badge variant="secondary">{currentFrameAnnotations.length}</Badge>
       </div>
       <div class="flex flex-col gap-1">
-{#each currentFrameGroups as group (group.groupId)}
+{#each currentFrameAnnotations as ann (ann.id)}
+  {@const annShapeType = ann.shape.type as string}
+  {@const annConfig = getDriver().config[annShapeType]}
+  {@const annCategory = annConfig?.values?.find((v) => v.id === ann.value?.category)}
+  {@const annColor = annCategory?.color ?? null}
+  {@const annGroupId = ann.metadata?.group_id ?? ann.id}
+  {@const annGroupIdLastPart = annGroupId.split("-").pop()}
+  {@const annDisplayName = annCategory ? `${annCategory.label}-${annGroupIdLastPart}` : (ann.value?.category ?? "Uncategorized")}
   <div class="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-accent">
     <button
       class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left"
-      onclick={() => selection.selectGroup(group.groupId)}
+      onclick={() => selection.selectAnnotation(ann)}
     >
-      {#if group.shapeType === VIDEO_POLYGON}
-        <Icon src={polygonIconSvg} color={group.color} />
+      {#if annShapeType === VIDEO_POLYGON}
+        <Icon src={polygonIconSvg} color={annColor} />
       {:else}
-        <Icon src={vectorSquareIconSvg} color={group.color} />
+        <Icon src={vectorSquareIconSvg} color={annColor} />
       {/if}
-      <span class="truncate">{group.displayName}</span>
+      <span class="truncate">{annDisplayName}</span>
     </button>
 
     <div class="ml-auto flex shrink-0 items-center gap-0">
       <!-- BUTTON::HIDE/SHOW -->
-      <div class={cn("", group.isHidden ? "flex" : "hidden group-hover:flex")}>
-        <ToolTooltip label={group.isHidden ? "Show Group" : "Hide Group"}>
+      <div class={cn("", ann.hidden ? "flex" : "hidden group-hover:flex")}>
+        <ToolTooltip label={ann.hidden ? "Show" : "Hide"}>
           {#snippet trigger()}
             <Button
               variant="ghost"
               size="icon-sm"
               onclick={(e: MouseEvent) => {
                 e.stopPropagation();
-                getDriver().command.call("annotation.toggleGroupVisibility", { groupId: group.groupId });
+                getDriver().command.call("annotation.update", {
+                  annotation: ann,
+                  value: { hidden: !ann.hidden },
+                });
               }}
             >
-              {#if group.isHidden}
+              {#if ann.hidden}
                 <EyeOffIcon />
               {:else}
                 <EyeIcon />
@@ -267,18 +261,21 @@
       </div>
 
       <!-- BUTTON::LOCK/UNLOCK -->
-      <div class={cn("", group.isLocked ? "flex" : "hidden group-hover:flex")}>
-        <ToolTooltip label={group.isLocked ? "Unlock Group" : "Lock Group"}>
+      <div class={cn("", ann.locked ? "flex" : "hidden group-hover:flex")}>
+        <ToolTooltip label={ann.locked ? "Unlock" : "Lock"}>
           {#snippet trigger()}
             <Button
               variant="ghost"
               size="icon-sm"
               onclick={(e: MouseEvent) => {
                 e.stopPropagation();
-                getDriver().command.call("annotation.toggleGroupEditability", { groupId: group.groupId });
+                getDriver().command.call("annotation.update", {
+                  annotation: ann,
+                  value: { locked: !ann.locked },
+                });
               }}
             >
-              {#if group.isLocked}
+              {#if ann.locked}
                 <LockIcon />
               {:else}
                 <LockOpenIcon />
@@ -290,14 +287,14 @@
 
       <!-- BUTTON::DELETE -->
       <div class="hidden group-hover:flex">
-        <ToolTooltip label="Delete group">
+        <ToolTooltip label="Delete">
           {#snippet trigger()}
             <Button
               variant="ghost"
               size="icon-sm"
               onclick={(e: MouseEvent) => {
                 e.stopPropagation();
-                getDriver().command.call("annotation.deleteGroup", { groupId: group.groupId });
+                getDriver().command.call("annotation.delete", { annotationId: ann.id });
               }}
             >
               <Trash2Icon />

--- a/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
@@ -61,16 +61,45 @@
   // The active shape type: from annotation, from group (via first annotation), or from drawing mode
   let shapeType = $derived.by<string | undefined>(() => {
     if (sel?.type === "annotation") return sel.annotation.shape.type as string;
-    // For a group we have only the groupId, so fall back to current mode
-    // (the group's shape type will be known when the driver enriches selection)
-    if (sel?.type === "group") return viewport.mode !== "default" ? viewport.mode : undefined;
+    if (sel?.type === "group" && data.annotations) {
+      // Find the first annotation belonging to this group to get its shape type
+      const items = data.annotations.items as unknown as IVideoAnnotationRecord[];
+      const groupAnn = items.find((a) => (a.metadata?.group_id ?? a.id) === sel.groupId);
+      if (groupAnn) return groupAnn.shape.type as string;
+    }
     return viewport.mode;
   });
 
   let config = $derived(shapeType ? getDriver().getFilteredConfig(shapeType, annotationValue as unknown as Record<string, unknown>) : undefined);
   let configValues = $derived(config?.values ?? []);
 
-  let category = $derived(configValues.find((c) => c.id == selectedCategory));
+  // Annotation from the selected group (for group edit mode display)
+  // NOTE: Must be declared BEFORE effectiveSelectedCategory since it depends on it
+  let groupAnnotation = $derived.by<IVideoAnnotationRecord | undefined>(() => {
+    if (sel?.type !== "group" || !data.annotations) return undefined;
+    const items = data.annotations.items as unknown as IVideoAnnotationRecord[];
+    return items.find((a) => (a.metadata?.group_id ?? a.id) === sel.groupId);
+  });
+
+  let groupAnnDisplayName = $derived.by<string>(() => {
+    if (!groupAnnotation || !sel || sel.type !== "group") return "";
+    const gAnn = groupAnnotation;
+    const gShapeType = gAnn.shape.type as string;
+    const gConfig = getDriver().config[gShapeType];
+    const gCategory = gConfig?.values?.find((v) => v.id === gAnn.value?.category);
+    const lastPart = sel.groupId.split("-").pop() ?? "";
+    return gCategory ? `${gCategory.label}-${lastPart}` : (gAnn.value?.category ?? "Uncategorized");
+  });
+
+  // When a group is selected, always use the annotation's current category from the data store,
+  // so it stays in sync even when the parent doesn't update the selectedCategory prop.
+  let effectiveSelectedCategory = $derived(
+    sel?.type === "group"
+      ? (groupAnnotation?.value?.category || "")
+      : selectedCategory
+  );
+
+  let category = $derived(configValues.find((c) => c.id == effectiveSelectedCategory));
   let properties = $derived(config?.properties ?? []);
 
   // Human-readable mode title from shape type
@@ -376,7 +405,7 @@
         <Badge variant="info">EDIT</Badge>
       </div>
       <Text size="sm" class="text-muted-foreground">
-        Group-{groupIdForDisplay}
+        {groupAnnDisplayName}
       </Text>
     </div>
 
@@ -404,10 +433,10 @@
             {#each configValues as { id: value, label, color }, index (`${value}-${index}`)}
               {@const valueLabel = categoryValueToLabel(value, label)}
               <SelectItem
-                class={"text-xs " + (selectedCategory == value ? "bg-primary/20 opacity-100!" : "")}
+                class={"text-xs " + (effectiveSelectedCategory == value ? "bg-primary/20 opacity-100!" : "")}
                 label={valueLabel}
                 {value}
-                disabled={selectedCategory == value}
+                disabled={effectiveSelectedCategory == value}
               >
                 {@render shapeIcon(color)}
                 {valueLabel}

--- a/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
@@ -6,8 +6,15 @@
   import Badge from "$lib/components/ui/Badge/Badge.svelte";
   import Icon from "$lib/components/ui/Icon";
 
+  import { EyeIcon, EyeOffIcon, LockIcon, LockOpenIcon, Trash2Icon } from "@lucide/svelte";
+
   import polygonIconSvg from "$lib/assets/icons/polygon.svg?raw";
   import vectorSquareIconSvg from "$lib/assets/icons/vector-square.svg?raw";
+
+  import ToolTooltip from "$lib/components/ui/Tooltips/ToolTooltip.svelte";
+  import Button from "$lib/components/ui/Button/Button.svelte";
+
+  import { cn } from "$lib/utils";
 
   import BooleanProperty from "$lib/components/App/SelectionPanel/Properties/_BooleanProperty.svelte";
   import IntegerProperty from "$lib/components/App/SelectionPanel/Properties/_IntegerProperty.svelte";
@@ -19,10 +26,23 @@
   import { selection } from "$lib/state/selection.svelte";
   import { viewport } from "$lib/state/viewport.svelte";
   import { getDriver } from "$lib/state/driver.svelte";
+  import { data } from "$lib/state/data.svelte";
   import { categoryValueToLabel } from "$lib/utils/annotation";
+  import type { IVideoAnnotationRecord } from "$lib/types";
 
   import type { IConfigProperty } from "$idah/v2/types";
   import type { IVideoAnnotationValue } from "$lib/types";
+
+  // Represents a group of annotations on the current frame (deduplicated by groupId)
+  type CurrentFrameGroup = {
+    groupId: string;
+    displayName: string;
+    shapeType: string;
+    color: string | null;
+    isHidden: boolean;
+    isLocked: boolean;
+    earliestStart: number;
+  };
 
   type Props = {
     selectedCategory: string;
@@ -85,7 +105,52 @@
   });
 
   // -----------------------------------------------------------------------
-  // Handlers
+  // Annotations on current frame (for default mode, no selection)
+  // -----------------------------------------------------------------------
+  let currentFrame = $derived(viewport.video.currentFrame.value);
+  let currentFrameGroups = $derived.by<CurrentFrameGroup[]>(() => {
+    if (!data.annotations) return [];
+    const items = data.annotations.items;
+    const frame = currentFrame;
+
+    // Filter and group annotations by groupId (same as groupAnnotations in group-annotation.svelte.ts)
+    const map = new Map<string, IVideoAnnotationRecord[]>();
+    for (const ann of items) {
+      const shape = ann.shape as { start?: number; end?: number };
+      if (shape.start === undefined || shape.end === undefined) continue;
+      if (shape.start > frame || shape.end < frame) continue;
+      const gid = ann.metadata?.group_id ?? ann.id;
+      if (!map.has(gid)) map.set(gid, []);
+      map.get(gid)!.push(ann);
+    }
+
+    // Sort groups: compareGroups sorts by earliest start of first annotation in each group
+    const groups: CurrentFrameGroup[] = [];
+    for (const [groupId, anns] of map.entries()) {
+      // Sort annotations within group by start frame
+      anns.sort((a, b) => a.shape.start - b.shape.start || a.shape.end - b.shape.end);
+
+      const firstAnn = anns[0];
+      const annShapeType = firstAnn.shape.type as string;
+      const annConfig = getDriver().config[annShapeType];
+      const annCategory = annConfig?.values?.find((v) => v.id === firstAnn.value?.category);
+      const annColor = annCategory?.color ?? null;
+      const lastPart = groupId.split("-").pop() ?? "";
+      const displayName = annCategory ? `${annCategory.label}-${lastPart}` : (firstAnn.value?.category ?? "Uncategorized");
+
+      const isHidden = anns.some((a) => a.hidden);
+      const isLocked = anns.some((a) => a.locked);
+      const earliestStart = anns.reduce((min, a) => Math.min(min, a.shape.start), Infinity);
+
+      groups.push({ groupId, displayName, shapeType: annShapeType, color: annColor, isHidden, isLocked, earliestStart });
+    }
+
+    // Sort by earliest start (same as compareGroups)
+    groups.sort((a, b) => a.earliestStart - b.earliestStart);
+
+    return groups;
+  });
+
   // -----------------------------------------------------------------------
   // Handlers
   // -----------------------------------------------------------------------
@@ -155,8 +220,99 @@
   </div>
 {/snippet}
 
-<!-- ============ CREATE MODE ============ -->
+<!-- ============ ANNOTATIONS ON CURRENT FRAME (default mode, no selection) ============ -->
 {#if !sel}
+  {#if viewport.mode === "default" && currentFrameGroups.length > 0}
+    <section class="flex flex-col gap-2">
+      <div class="flex items-center gap-2">
+        <Text weight="semibold">Annotations</Text>
+        <Badge variant="secondary">{currentFrameGroups.length}</Badge>
+      </div>
+      <div class="flex flex-col gap-1">
+{#each currentFrameGroups as group (group.groupId)}
+  <div class="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-accent">
+    <button
+      class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left"
+      onclick={() => selection.selectGroup(group.groupId)}
+    >
+      {#if group.shapeType === VIDEO_POLYGON}
+        <Icon src={polygonIconSvg} color={group.color} />
+      {:else}
+        <Icon src={vectorSquareIconSvg} color={group.color} />
+      {/if}
+      <span class="truncate">{group.displayName}</span>
+    </button>
+
+    <div class="ml-auto flex shrink-0 items-center gap-0">
+      <!-- BUTTON::HIDE/SHOW -->
+      <div class={cn("", group.isHidden ? "flex" : "hidden group-hover:flex")}>
+        <ToolTooltip label={group.isHidden ? "Show Group" : "Hide Group"}>
+          {#snippet trigger()}
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onclick={(e: MouseEvent) => {
+                e.stopPropagation();
+                getDriver().command.call("annotation.toggleGroupVisibility", { groupId: group.groupId });
+              }}
+            >
+              {#if group.isHidden}
+                <EyeOffIcon />
+              {:else}
+                <EyeIcon />
+              {/if}
+            </Button>
+          {/snippet}
+        </ToolTooltip>
+      </div>
+
+      <!-- BUTTON::LOCK/UNLOCK -->
+      <div class={cn("", group.isLocked ? "flex" : "hidden group-hover:flex")}>
+        <ToolTooltip label={group.isLocked ? "Unlock Group" : "Lock Group"}>
+          {#snippet trigger()}
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onclick={(e: MouseEvent) => {
+                e.stopPropagation();
+                getDriver().command.call("annotation.toggleGroupEditability", { groupId: group.groupId });
+              }}
+            >
+              {#if group.isLocked}
+                <LockIcon />
+              {:else}
+                <LockOpenIcon />
+              {/if}
+            </Button>
+          {/snippet}
+        </ToolTooltip>
+      </div>
+
+      <!-- BUTTON::DELETE -->
+      <div class="hidden group-hover:flex">
+        <ToolTooltip label="Delete group">
+          {#snippet trigger()}
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onclick={(e: MouseEvent) => {
+                e.stopPropagation();
+                getDriver().command.call("annotation.deleteGroup", { groupId: group.groupId });
+              }}
+            >
+              <Trash2Icon />
+            </Button>
+          {/snippet}
+        </ToolTooltip>
+      </div>
+    </div>
+  </div>
+{/each}
+      </div>
+    </section>
+    <Separator class="my-2" />
+  {/if}
+
   {#if config}
     <section class="flex flex-col gap-3">
       <div class="flex items-center gap-2">
@@ -268,15 +424,18 @@
 
 <!-- ============ ANNOTATION SELECTION ============ -->
 {:else if sel.type === "annotation"}
+  {@const selAnnGroupId = sel.annotation.metadata?.group_id ?? sel.annotation.id}
+  {@const selAnnGroupIdLastPart = selAnnGroupId.split("-").pop()}
+  {@const selAnnDisplayName = category ? `${category.label}-${selAnnGroupIdLastPart}` : undefined}
   <section class="flex flex-col gap-3">
     <div class="flex flex-col gap-1">
       <div class="flex items-center gap-2">
         <Text weight="semibold">{modeTitle}</Text>
         <Badge variant="info">EDIT</Badge>
       </div>
-      {#if category}
+      {#if selAnnDisplayName}
         <Text size="sm" class="text-muted-foreground">
-          {category.label}
+          {selAnnDisplayName}
         </Text>
       {/if}
     </div>

--- a/plugins/idah-video/frontend/src/lib/components/ui/Icon/Icon.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/ui/Icon/Icon.svelte
@@ -9,6 +9,6 @@
   let { src, color, class: className }: Props = $props();
 </script>
 
-<div class={cn("shrink-0", className)} style={color ? `color: ${color}` : ""}>
+<div class={cn("shrink-0", color && "[&>svg]:!text-current", className)} style={color ? `color: ${color}` : ""}>
   {@html src}
 </div>


### PR DESCRIPTION
Improvements
- [x] When nothing is selected, display all visible annotations of the current frame
  - [ ] add minor details like current frame, root category name, etc.
- [x] Delete/hide/lock on annotation list
  - [ ] recheck functionality once annotation state is handled
- [x] When annotation is selected, switch to annotation's category/properties view
- [x] When group is selected, switch to group's category/properties view

Bugs/Issues
- [x] Category icon in category dropdown should have the color as per configuration in label editor
- [x] No shape name showing on right sidebar when selecting the group
- [x] Group name showing on sidebar is different to those on the timeline
- [ ] When selecting annotation group in timeline, Category dropdown is empty and Cannot edit category for entire group.
  - WIP: fixing group category editing 