### PR TITLE
IDAH - Viewport fix lock and hide state

### DIFF
--- a/plugins/idah-video/frontend/src/lib/commands/annotation/extend_next.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/extend_next.ts
@@ -14,15 +14,26 @@ import { selection } from "$lib/state/selection.svelte";
 import { viewport } from "$lib/state/viewport.svelte";
 import type { IIdahDriverV2 } from "$idah/v2/types";
 import { nearestKeyframe } from "$lib/utils/interpolation";
+import { noopAction } from "..";
+import { annotation } from "$lib/state/annotation.svelte";
+
+export const command = {
+  name: "annotation.extend_next",
+  group: "Annotation",
+  modes: ["default"],
+  shortcut: "BracketLeft",
+  shortDescription: "Extend next annotation",
+  longDescription: "Extend the next annotation to the current frame",
+};
 
 export function register(driver: IIdahDriverV2): void {
   driver.command.register({
-    name: "annotation.extend_next",
-    group: "Annotation",
-    modes: ["default"],
-    shortcut: "BracketLeft",
-    shortDescription: "Extend next annotation",
-    longDescription: "Extend the next annotation to the current frame",
+    name: command.name,
+    group: command.group,
+    modes: command.modes,
+    shortcut: command.shortcut,
+    shortDescription: command.shortDescription,
+    longDescription: command.longDescription,
     callback: (opts?: Record<string, unknown>) => {
       return {
         command: {
@@ -35,30 +46,43 @@ export function register(driver: IIdahDriverV2): void {
         },
         do() {
           // ── Resolve target annotation and frame ────────────────────────
-          const frame = opts?.frame as number | undefined ?? viewport.video.currentFrame.value;
+          const frame = (opts?.frame as number | undefined) ?? viewport.video.currentFrame.value;
 
           // Resolve group annotations
-          let groupAnnotations: { id: string; shape: { frames: { frame: number; angle: number; points: [number, number][] }[] } }[];
+          let groupAnnotations: {
+            id: string;
+            shape: { frames: { frame: number; angle: number; points: [number, number][] }[] };
+          }[];
           if (opts?.annotationId) {
-            const targetId = opts.annotationId as string;
+            const annotationId = opts.annotationId as string;
             const all = data.annotations?.items ?? [];
-            const target = all.find((a) => a.id === targetId);
-            if (!target) return;
-            const gid = (target.metadata as any)?.group_id ?? targetId;
+            const target = all.find((a) => a.id === annotationId);
+
+            // If no target annotation or target is locked, abort.
+            if (!target || annotation.isLocked(target)) return noopAction(command);
+
+            const gid = (target.metadata as any)?.group_id ?? annotationId;
             groupAnnotations = all
               .filter((a) => ((a.metadata as any)?.group_id ?? a.id) === gid)
               .map((a) => ({ id: a.id, shape: a.shape as any }));
           } else {
             const sel = selection.value;
-            if (!sel) return;
+
+            // If no selection, abort.
+            if (!sel) return noopAction(command);
+
             let gid: string;
             if (sel.type === "group") {
               gid = sel.groupId;
             } else if (sel.type === "annotation") {
               gid = (sel.annotation.metadata as any)?.group_id ?? sel.annotation.id;
             } else {
-              return;
+              return noopAction(command);
             }
+
+            // If the current group is locked, abort.
+            if (annotation.isLocked(gid)) return noopAction(command);
+
             groupAnnotations = (data.annotations?.items ?? [])
               .filter((a) => ((a.metadata as any)?.group_id ?? a.id) === gid)
               .map((a) => ({ id: a.id, shape: a.shape as any }));
@@ -70,11 +94,9 @@ export function register(driver: IIdahDriverV2): void {
               const firstFrame = a.shape.frames?.[0]?.frame ?? Infinity;
               return firstFrame > frame;
             })
-            .sort(
-              (a, b) => (a.shape.frames?.[0]?.frame ?? Infinity) - (b.shape.frames?.[0]?.frame ?? Infinity),
-            )[0];
+            .sort((a, b) => (a.shape.frames?.[0]?.frame ?? Infinity) - (b.shape.frames?.[0]?.frame ?? Infinity))[0];
 
-          if (!nextAnn) return;
+          if (!nextAnn) return noopAction(command);
 
           // Overlap protection: don't go below the previous annotation's end
           const prevAnn = groupAnnotations
@@ -82,13 +104,11 @@ export function register(driver: IIdahDriverV2): void {
               const lastFrame = a.shape.frames?.[a.shape.frames.length - 1]?.frame ?? -1;
               return lastFrame < frame && a.id !== nextAnn.id;
             })
-            .sort(
-              (a, b) => {
-                const aEnd = a.shape.frames?.[a.shape.frames.length - 1]?.frame ?? -1;
-                const bEnd = b.shape.frames?.[b.shape.frames.length - 1]?.frame ?? -1;
-                return bEnd - aEnd;
-              },
-            )[0];
+            .sort((a, b) => {
+              const aEnd = a.shape.frames?.[a.shape.frames.length - 1]?.frame ?? -1;
+              const bEnd = b.shape.frames?.[b.shape.frames.length - 1]?.frame ?? -1;
+              return bEnd - aEnd;
+            })[0];
 
           let cappedFrame = frame;
           if (prevAnn) {
@@ -97,7 +117,7 @@ export function register(driver: IIdahDriverV2): void {
           }
 
           const nearest = nearestKeyframe(nextAnn.shape, cappedFrame);
-          if (!nearest) return;
+          if (!nearest) return noopAction(command);
 
           driver.command.call("annotation.keyframe_add", {
             annotationId: nextAnn.id,
@@ -110,8 +130,12 @@ export function register(driver: IIdahDriverV2): void {
         undo() {
           // No undo — the nested keyframe_add handles its own undo.
         },
-        isCombinable() { return false; },
-        combine(p: never) { return p; },
+        isCombinable() {
+          return false;
+        },
+        combine(p: never) {
+          return p;
+        },
       };
     },
   });

--- a/plugins/idah-video/frontend/src/lib/commands/annotation/extend_next.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/extend_next.ts
@@ -127,9 +127,7 @@ export function register(driver: IIdahDriverV2): void {
             },
           });
         },
-        undo() {
-          // No undo — the nested keyframe_add handles its own undo.
-        },
+        // No undo — the nested keyframe_add handles its own undo.
         isCombinable() {
           return false;
         },

--- a/plugins/idah-video/frontend/src/lib/commands/annotation/extend_prev.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/extend_prev.ts
@@ -136,9 +136,7 @@ export function register(driver: IIdahDriverV2): void {
             },
           });
         },
-        undo() {
-          // No undo — the nested keyframe_add handles its own undo.
-        },
+        // No undo — the nested keyframe_add handles its own undo.
         isCombinable() {
           return false;
         },

--- a/plugins/idah-video/frontend/src/lib/commands/annotation/extend_prev.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/extend_prev.ts
@@ -14,15 +14,26 @@ import { selection } from "$lib/state/selection.svelte";
 import { viewport } from "$lib/state/viewport.svelte";
 import type { IIdahDriverV2 } from "$idah/v2/types";
 import { nearestKeyframe } from "$lib/utils/interpolation";
+import { noopAction } from "..";
+import { annotation } from "$lib/state/annotation.svelte";
+
+export const command = {
+  name: "annotation.extend_prev",
+  group: "Annotation",
+  modes: ["default"],
+  shortcut: "BracketRight",
+  shortDescription: "Extend previous annotation",
+  longDescription: "Extend the previous annotation to the current frame",
+};
 
 export function register(driver: IIdahDriverV2): void {
   driver.command.register({
-    name: "annotation.extend_prev",
-    group: "Annotation",
-    modes: ["default"],
-    shortcut: "BracketRight",
-    shortDescription: "Extend previous annotation",
-    longDescription: "Extend the previous annotation to the current frame",
+    name: command.name,
+    group: command.group,
+    modes: command.modes,
+    shortcut: command.shortcut,
+    shortDescription: command.shortDescription,
+    longDescription: command.longDescription,
     callback: (opts?: Record<string, unknown>) => {
       return {
         command: {
@@ -37,39 +48,53 @@ export function register(driver: IIdahDriverV2): void {
           // ── Resolve target annotation and frame ────────────────────────
           // If called with explicit props (context menu), use them.
           // Otherwise resolve from the current selection state (shortcut path).
-          const frame = opts?.frame as number | undefined ?? viewport.video.currentFrame.value;
+          const frame = (opts?.frame as number | undefined) ?? viewport.video.currentFrame.value;
 
           // Find the annotations in the currently selected group
-          let groupAnnotations: { id: string; shape: { type: string; start: number; end: number; frames: { frame: number; angle: number; points: [number, number][] }[] } }[];
+          let groupAnnotations: {
+            id: string;
+            shape: {
+              type: string;
+              start: number;
+              end: number;
+              frames: { frame: number; angle: number; points: [number, number][] }[];
+            };
+          }[];
+
           if (opts?.annotationId) {
             // Context menu knows exactly which annotation
-            const targetId = opts.annotationId as string;
+            const annotationId = opts.annotationId as string;
             const all = data.annotations?.items ?? [];
-            const target = all.find((a) => a.id === targetId);
-            if (!target) return;
+            const target = all.find((a) => a.id === annotationId);
+
+            // If no target annotation or target is locked, abort.
+            if (!target || annotation.isLocked(target)) return noopAction(command);
+
             // Build a list for the overlap check: same group as the target
-            const gid = (target.metadata as any)?.group_id ?? targetId;
+            const gid = (target.metadata as any)?.group_id ?? annotationId;
             groupAnnotations = all
               .filter((a) => ((a.metadata as any)?.group_id ?? a.id) === gid)
               .map((a) => ({ id: a.id, shape: a.shape as any }));
           } else {
             // Shortcut: resolve from selection
             const sel = selection.value;
-            if (!sel) return;
+            if (!sel) return noopAction(command);
+
+            let gid: string;
             if (sel.type === "group") {
-              // Build group members from the whole annotation list
-              const gid = sel.groupId;
-              groupAnnotations = (data.annotations?.items ?? [])
-                .filter((a) => ((a.metadata as any)?.group_id ?? a.id) === gid)
-                .map((a) => ({ id: a.id, shape: a.shape as any }));
+              gid = sel.groupId;
             } else if (sel.type === "annotation") {
-              const gid = (sel.annotation.metadata as any)?.group_id ?? sel.annotation.id;
-              groupAnnotations = (data.annotations?.items ?? [])
-                .filter((a) => ((a.metadata as any)?.group_id ?? a.id) === gid)
-                .map((a) => ({ id: a.id, shape: a.shape as any }));
+              gid = (sel.annotation.metadata as any)?.group_id ?? sel.annotation.id;
             } else {
-              return;
+              return noopAction(command);
             }
+
+            // If the current group is locked, abort.
+            if (annotation.isLocked(gid)) return noopAction(command);
+
+            groupAnnotations = (data.annotations?.items ?? [])
+              .filter((a) => ((a.metadata as any)?.group_id ?? a.id) === gid)
+              .map((a) => ({ id: a.id, shape: a.shape as any }));
           }
 
           // Find the annotation whose end is closest to but before `frame`
@@ -78,15 +103,13 @@ export function register(driver: IIdahDriverV2): void {
               const lastFrame = a.shape.frames?.[a.shape.frames.length - 1]?.frame ?? -1;
               return lastFrame < frame;
             })
-            .sort(
-              (a, b) => {
-                const aEnd = a.shape.frames?.[a.shape.frames.length - 1]?.frame ?? -1;
-                const bEnd = b.shape.frames?.[b.shape.frames.length - 1]?.frame ?? -1;
-                return bEnd - aEnd;
-              },
-            )[0];
+            .sort((a, b) => {
+              const aEnd = a.shape.frames?.[a.shape.frames.length - 1]?.frame ?? -1;
+              const bEnd = b.shape.frames?.[b.shape.frames.length - 1]?.frame ?? -1;
+              return bEnd - aEnd;
+            })[0];
 
-          if (!prevAnn) return;
+          if (!prevAnn) return noopAction(command);
 
           // Overlap protection: don't exceed the next annotation's start
           const nextAnn = groupAnnotations
@@ -94,9 +117,7 @@ export function register(driver: IIdahDriverV2): void {
               const firstFrame = a.shape.frames?.[0]?.frame ?? Infinity;
               return firstFrame > frame && a.id !== prevAnn.id;
             })
-            .sort(
-              (a, b) => (a.shape.frames?.[0]?.frame ?? Infinity) - (b.shape.frames?.[0]?.frame ?? Infinity),
-            )[0];
+            .sort((a, b) => (a.shape.frames?.[0]?.frame ?? Infinity) - (b.shape.frames?.[0]?.frame ?? Infinity))[0];
 
           let cappedFrame = frame;
           if (nextAnn) {
@@ -105,7 +126,7 @@ export function register(driver: IIdahDriverV2): void {
           }
 
           const nearest = nearestKeyframe(prevAnn.shape, cappedFrame);
-          if (!nearest) return;
+          if (!nearest) return noopAction(command);
 
           driver.command.call("annotation.keyframe_add", {
             annotationId: prevAnn.id,
@@ -118,8 +139,12 @@ export function register(driver: IIdahDriverV2): void {
         undo() {
           // No undo — the nested keyframe_add handles its own undo.
         },
-        isCombinable() { return false; },
-        combine(p: never) { return p; },
+        isCombinable() {
+          return false;
+        },
+        combine(p: never) {
+          return p;
+        },
       };
     },
   });

--- a/plugins/idah-video/frontend/src/lib/commands/annotation/split.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/split.ts
@@ -14,7 +14,7 @@
 // Shortcut: S
 // Active only when there's a selected annotation.
 // ---------------------------------------------------------------------------
-import type { IAnnotationRecord, IIdahDriverV2 } from "$idah/v2/types";
+import type { IIdahDriverV2 } from "$idah/v2/types";
 import type { AnnotationItem } from "$lib/state/data.svelte";
 import { data } from "$lib/state/data.svelte";
 import { selection, type IAnnotationSelection } from "$lib/state/selection.svelte";
@@ -159,10 +159,7 @@ export function register(driver: IIdahDriverV2): void {
     },
     group: command.group,
     activeWhen: () => {
-      if (!selection.isAnnotation()) return false;
-      const sel = selection.value;
-      if (sel?.type !== "annotation") return false;
-      return !annotation.isLocked(sel.annotation);
+      return selection.isAnnotation() && !annotation.isLocked((selection.value as IAnnotationSelection).annotation);
     },
   });
 }

--- a/plugins/idah-video/frontend/src/lib/commands/annotation/split.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/split.ts
@@ -18,6 +18,7 @@ import type { IAnnotationRecord, IIdahDriverV2 } from "$idah/v2/types";
 import type { AnnotationItem } from "$lib/state/data.svelte";
 import { data } from "$lib/state/data.svelte";
 import { selection, type IAnnotationSelection } from "$lib/state/selection.svelte";
+import { annotation } from "$lib/state/annotation.svelte";
 import { viewport } from "$lib/state/viewport.svelte";
 import type { IVideoAnnotationShape, IVideoFrameSelection } from "$lib/types";
 import { getInterpolatedFrame } from "$lib/utils/interpolation";
@@ -157,6 +158,11 @@ export function register(driver: IIdahDriverV2): void {
       };
     },
     group: command.group,
-    activeWhen: selection.isAnnotation,
+    activeWhen: () => {
+      if (!selection.isAnnotation()) return false;
+      const sel = selection.value;
+      if (sel?.type !== "annotation") return false;
+      return !annotation.isLocked(sel.annotation);
+    },
   });
 }

--- a/plugins/idah-video/frontend/src/lib/commands/annotation/toggle_editability_all.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/toggle_editability_all.ts
@@ -30,9 +30,9 @@ export function register(driver: IIdahDriverV2): void {
     callback: () => {
       if (!data.annotations) return noopAction(command);
 
-      const snapshot: { id: string; locked: boolean }[] = data.annotations.items.map((a) => ({
-        id: a.id,
-        locked: annotation.isLocked(a.id),
+      const snapshot: { id: string; locked: boolean }[] = data.annotations.items.map((ann) => ({
+        id: ann.id,
+        locked: annotation.isLocked(ann),
       }));
       if (snapshot.length === 0) return noopAction(command);
 

--- a/plugins/idah-video/frontend/src/lib/commands/annotation/toggle_editability_all.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/toggle_editability_all.ts
@@ -7,6 +7,7 @@
 // ---------------------------------------------------------------------------
 import type { IIdahDriverV2 } from "$idah/v2/types";
 import type { AnnotationItem } from "$lib/state/data.svelte";
+import { annotation } from "$lib/state/annotation.svelte";
 import { data } from "$lib/state/data.svelte";
 import { noopAction } from "..";
 
@@ -29,24 +30,24 @@ export function register(driver: IIdahDriverV2): void {
     callback: () => {
       if (!data.annotations) return noopAction(command);
 
-      const snapshot: AnnotationItem[] = [...data.annotations.items];
+      const snapshot: { id: string; locked: boolean }[] = data.annotations.items.map((a) => ({
+        id: a.id,
+        locked: annotation.isLocked(a.id),
+      }));
       if (snapshot.length === 0) return noopAction(command);
 
       return {
         command: { ...command },
         async do() {
-          if (!data.annotations) return;
-          // If any annotation is locked, unlock all; otherwise lock all
-          const anyLocked = snapshot.some((a) => a.locked);
+          const anyLocked = snapshot.some((s) => s.locked);
           const newLocked = !anyLocked;
-          for (const ann of snapshot) {
-            await data.annotations!.update({ ...ann, locked: newLocked });
+          for (const { id } of snapshot) {
+            annotation.toggleLocked(id, newLocked);
           }
         },
         async undo() {
-          if (!data.annotations) return;
-          for (const ann of snapshot) {
-            await data.annotations!.update({ ...ann, locked: ann.locked });
+          for (const { id, locked } of snapshot) {
+            annotation.toggleLocked(id, locked);
           }
         },
         isCombinable() {

--- a/plugins/idah-video/frontend/src/lib/commands/annotation/toggle_visibility_all.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/toggle_visibility_all.ts
@@ -30,9 +30,9 @@ export function register(driver: IIdahDriverV2): void {
     callback: () => {
       if (!data.annotations) return noopAction(command);
 
-      const snapshot: { id: string; hidden: boolean }[] = data.annotations.items.map((a) => ({
-        id: a.id,
-        hidden: annotation.isHidden(a.id),
+      const snapshot: { id: string; hidden: boolean }[] = data.annotations.items.map((ann) => ({
+        id: ann.id,
+        hidden: annotation.isHidden(ann),
       }));
       if (snapshot.length === 0) return noopAction(command);
 

--- a/plugins/idah-video/frontend/src/lib/commands/annotation/toggle_visibility_all.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/toggle_visibility_all.ts
@@ -7,6 +7,7 @@
 // ---------------------------------------------------------------------------
 import type { IIdahDriverV2 } from "$idah/v2/types";
 import type { AnnotationItem } from "$lib/state/data.svelte";
+import { annotation } from "$lib/state/annotation.svelte";
 import { data } from "$lib/state/data.svelte";
 import { noopAction } from "..";
 
@@ -29,24 +30,24 @@ export function register(driver: IIdahDriverV2): void {
     callback: () => {
       if (!data.annotations) return noopAction(command);
 
-      const snapshot: AnnotationItem[] = [...data.annotations.items];
+      const snapshot: { id: string; hidden: boolean }[] = data.annotations.items.map((a) => ({
+        id: a.id,
+        hidden: annotation.isHidden(a.id),
+      }));
       if (snapshot.length === 0) return noopAction(command);
 
       return {
         command: { ...command },
         async do() {
-          if (!data.annotations) return;
-          // If any annotation is hidden, show all; otherwise hide all
-          const anyHidden = snapshot.some((a) => a.hidden);
+          const anyHidden = snapshot.some((s) => s.hidden);
           const newHidden = !anyHidden;
-          for (const ann of snapshot) {
-            await data.annotations!.update({ ...ann, hidden: newHidden });
+          for (const { id } of snapshot) {
+            annotation.toggleHidden(id, newHidden);
           }
         },
         async undo() {
-          if (!data.annotations) return;
-          for (const ann of snapshot) {
-            await data.annotations!.update({ ...ann, hidden: ann.hidden });
+          for (const { id, hidden } of snapshot) {
+            annotation.toggleHidden(id, hidden);
           }
         },
         isCombinable() {

--- a/plugins/idah-video/frontend/src/lib/commands/category/toggle_editability.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/category/toggle_editability.ts
@@ -21,6 +21,7 @@
 
 import type { IIdahDriverV2 } from "$idah/v2/types";
 import type { AnnotationItem } from "$lib/state/data.svelte";
+import { annotation } from "$lib/state/annotation.svelte";
 import { data } from "$lib/state/data.svelte";
 import { noopAction } from "..";
 
@@ -79,7 +80,11 @@ export function register(driver: IIdahDriverV2): void {
         return noopAction(command);
       }
 
-      const snapshot = [...categoryAnnotations];
+      // Snapshot IDs and their current locked state from annotation module
+      const snapshot = categoryAnnotations.map((ann) => ({
+        id: ann.id,
+        locked: annotation.isLocked(ann.id),
+      }));
 
       return {
         command: { ...command },
@@ -87,17 +92,11 @@ export function register(driver: IIdahDriverV2): void {
         async do() {
           if (!data.annotations) return;
 
-          // If any annotation is locked,
-          // unlock all. Otherwise lock all.
-          const anyLocked = snapshot.some((ann) => ann.locked);
-
+          const anyLocked = snapshot.some((s) => s.locked);
           const newLocked = !anyLocked;
 
-          for (const ann of snapshot) {
-            await data.annotations!.update({
-              ...ann,
-              locked: newLocked,
-            });
+          for (const { id } of snapshot) {
+            annotation.toggleLocked(id, newLocked);
           }
         },
 
@@ -105,11 +104,8 @@ export function register(driver: IIdahDriverV2): void {
           if (!data.annotations) return;
 
           // Restore original states
-          for (const ann of snapshot) {
-            await data.annotations!.update({
-              ...ann,
-              locked: ann.locked,
-            });
+          for (const { id, locked } of snapshot) {
+            annotation.toggleLocked(id, locked);
           }
         },
 

--- a/plugins/idah-video/frontend/src/lib/commands/category/toggle_editability.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/category/toggle_editability.ts
@@ -83,7 +83,7 @@ export function register(driver: IIdahDriverV2): void {
       // Snapshot IDs and their current locked state from annotation module
       const snapshot = categoryAnnotations.map((ann) => ({
         id: ann.id,
-        locked: annotation.isLocked(ann.id),
+        locked: annotation.isLocked(ann),
       }));
 
       return {

--- a/plugins/idah-video/frontend/src/lib/commands/category/toggle_visibility.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/category/toggle_visibility.ts
@@ -21,6 +21,7 @@
 
 import type { IIdahDriverV2 } from "$idah/v2/types";
 import type { AnnotationItem } from "$lib/state/data.svelte";
+import { annotation } from "$lib/state/annotation.svelte";
 import { data } from "$lib/state/data.svelte";
 import { noopAction } from "..";
 
@@ -79,7 +80,11 @@ export function register(driver: IIdahDriverV2): void {
         return noopAction(command);
       }
 
-      const snapshot = [...categoryAnnotations];
+      // Snapshot IDs and their current hidden state from annotation module
+      const snapshot = categoryAnnotations.map((ann) => ({
+        id: ann.id,
+        hidden: annotation.isHidden(ann.id),
+      }));
 
       return {
         command: { ...command },
@@ -87,17 +92,11 @@ export function register(driver: IIdahDriverV2): void {
         async do() {
           if (!data.annotations) return;
 
-          // If any annotation is hidden,
-          // show all. Otherwise hide all.
-          const anyHidden = snapshot.some((ann) => ann.hidden);
-
+          const anyHidden = snapshot.some((s) => s.hidden);
           const newHidden = !anyHidden;
 
-          for (const ann of snapshot) {
-            await data.annotations!.update({
-              ...ann,
-              hidden: newHidden,
-            });
+          for (const { id } of snapshot) {
+            annotation.toggleHidden(id, newHidden);
           }
         },
 
@@ -105,11 +104,8 @@ export function register(driver: IIdahDriverV2): void {
           if (!data.annotations) return;
 
           // Restore original hidden states
-          for (const ann of snapshot) {
-            await data.annotations!.update({
-              ...ann,
-              hidden: ann.hidden,
-            });
+          for (const { id, hidden } of snapshot) {
+            annotation.toggleHidden(id, hidden);
           }
         },
 

--- a/plugins/idah-video/frontend/src/lib/commands/category/toggle_visibility.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/category/toggle_visibility.ts
@@ -83,7 +83,7 @@ export function register(driver: IIdahDriverV2): void {
       // Snapshot IDs and their current hidden state from annotation module
       const snapshot = categoryAnnotations.map((ann) => ({
         id: ann.id,
-        hidden: annotation.isHidden(ann.id),
+        hidden: annotation.isHidden(ann),
       }));
 
       return {

--- a/plugins/idah-video/frontend/src/lib/commands/group/toggle_editability.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/group/toggle_editability.ts
@@ -9,6 +9,7 @@
 // ---------------------------------------------------------------------------
 import type { IIdahDriverV2 } from "$idah/v2/types";
 import type { AnnotationItem } from "$lib/state/data.svelte";
+import { annotation } from "$lib/state/annotation.svelte";
 import { data } from "$lib/state/data.svelte";
 import { noopAction } from "..";
 
@@ -59,23 +60,24 @@ export function register(driver: IIdahDriverV2): void {
 
       if (groupAnnotations.length === 0) return noopAction(command);
 
-      const snapshot = [...groupAnnotations];
+      // Snapshot IDs and their current locked state from the annotation module
+      const snapshot = groupAnnotations.map((a) => ({
+        id: a.id,
+        locked: annotation.isLocked(a.id),
+      }));
 
       return {
         command: { ...command },
         async do() {
-          if (!data.annotations) return;
-          // If any annotation is locked, unlock all; otherwise lock all
-          const anyLocked = snapshot.some((a) => a.locked);
+          const anyLocked = snapshot.some((s) => s.locked);
           const newLocked = !anyLocked;
-          for (const ann of snapshot) {
-            await data.annotations!.update({ ...ann, locked: newLocked });
+          for (const { id } of snapshot) {
+            annotation.toggleLocked(id, newLocked);
           }
         },
         async undo() {
-          if (!data.annotations) return;
-          for (const ann of snapshot) {
-            await data.annotations!.update({ ...ann, locked: ann.locked });
+          for (const { id, locked } of snapshot) {
+            annotation.toggleLocked(id, locked);
           }
         },
         isCombinable() {

--- a/plugins/idah-video/frontend/src/lib/commands/group/toggle_editability.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/group/toggle_editability.ts
@@ -57,9 +57,9 @@ export function register(driver: IIdahDriverV2): void {
       if (groupAnnotations.length === 0) return noopAction(command);
 
       // Snapshot IDs and their current locked state from the annotation module
-      const snapshot = groupAnnotations.map((a) => ({
-        id: a.id,
-        locked: annotation.isLocked(a.id),
+      const snapshot = groupAnnotations.map((ann) => ({
+        id: ann.id,
+        locked: annotation.isLocked(ann),
       }));
 
       return {

--- a/plugins/idah-video/frontend/src/lib/commands/group/toggle_editability.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/group/toggle_editability.ts
@@ -45,15 +45,11 @@ export function register(driver: IIdahDriverV2): void {
       if (props.annotations && props.annotations.length > 0) {
         groupAnnotations = props.annotations;
       } else if (props.groupId) {
-        groupAnnotations = data.annotations.items.filter((ann) => (ann as any).metadata?.group_id === props.groupId);
-
-        // If filter is empty, also search for annotation with id === props.groupId
-        if (groupAnnotations.length === 0) {
-          const matchById = data.annotations.items.find((ann) => ann.id === props.groupId);
-          if (matchById) {
-            groupAnnotations = [matchById];
-          }
-        }
+        groupAnnotations = data.annotations.items.filter(
+          (ann) =>
+            (ann as AnnotationItem).id === props.groupId ||
+            (ann as AnnotationItem).metadata?.group_id === props.groupId,
+        );
       } else {
         return noopAction(command);
       }

--- a/plugins/idah-video/frontend/src/lib/commands/group/toggle_visibility.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/group/toggle_visibility.ts
@@ -45,15 +45,11 @@ export function register(driver: IIdahDriverV2): void {
       if (props.annotations && props.annotations.length > 0) {
         groupAnnotations = props.annotations;
       } else if (props.groupId) {
-        groupAnnotations = data.annotations.items.filter((ann) => (ann as any).metadata?.group_id === props.groupId);
-
-        // If filter is empty, also search for annotation with id === props.groupId
-        if (groupAnnotations.length === 0) {
-          const matchById = data.annotations.items.find((ann) => ann.id === props.groupId);
-          if (matchById) {
-            groupAnnotations = [matchById];
-          }
-        }
+        groupAnnotations = data.annotations.items.filter(
+          (ann) =>
+            (ann as AnnotationItem).id === props.groupId ||
+            (ann as AnnotationItem).metadata?.group_id === props.groupId,
+        );
       } else {
         return noopAction(command);
       }

--- a/plugins/idah-video/frontend/src/lib/commands/group/toggle_visibility.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/group/toggle_visibility.ts
@@ -3,12 +3,13 @@
 // Undoable: restores the previous hidden state.
 //
 // Usage:
-//   driver.command.call("annotation.toggleGroupVisibility", {
+//   driver.command.call("annotation.toggle_group_visibility", {
 //     groupId: "...", annotations?: [ ... ]
 //   });
 // ---------------------------------------------------------------------------
 import type { IIdahDriverV2 } from "$idah/v2/types";
 import type { AnnotationItem } from "$lib/state/data.svelte";
+import { annotation } from "$lib/state/annotation.svelte";
 import { data } from "$lib/state/data.svelte";
 import { noopAction } from "..";
 
@@ -59,23 +60,24 @@ export function register(driver: IIdahDriverV2): void {
 
       if (groupAnnotations.length === 0) return noopAction(command);
 
-      const snapshot = [...groupAnnotations];
+      // Snapshot IDs and their current hidden state from the annotation module
+      const snapshot = groupAnnotations.map((a) => ({
+        id: a.id,
+        hidden: annotation.isHidden(a.id),
+      }));
 
       return {
         command: { ...command },
         async do() {
-          if (!data.annotations) return;
-          // If any annotation is hidden, show all; otherwise hide all
-          const anyHidden = snapshot.some((a) => a.hidden);
+          const anyHidden = snapshot.some((s) => s.hidden);
           const newHidden = !anyHidden;
-          for (const ann of snapshot) {
-            await data.annotations!.update({ ...ann, hidden: newHidden });
+          for (const { id } of snapshot) {
+            annotation.toggleHidden(id, newHidden);
           }
         },
         async undo() {
-          if (!data.annotations) return;
-          for (const ann of snapshot) {
-            await data.annotations!.update({ ...ann, hidden: ann.hidden });
+          for (const { id, hidden } of snapshot) {
+            annotation.toggleHidden(id, hidden);
           }
         },
         isCombinable() {

--- a/plugins/idah-video/frontend/src/lib/commands/group/toggle_visibility.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/group/toggle_visibility.ts
@@ -57,9 +57,9 @@ export function register(driver: IIdahDriverV2): void {
       if (groupAnnotations.length === 0) return noopAction(command);
 
       // Snapshot IDs and their current hidden state from the annotation module
-      const snapshot = groupAnnotations.map((a) => ({
-        id: a.id,
-        hidden: annotation.isHidden(a.id),
+      const snapshot = groupAnnotations.map((ann) => ({
+        id: ann.id,
+        hidden: annotation.isHidden(ann),
       }));
 
       return {

--- a/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/PropertiesCategorySelector.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/PropertiesCategorySelector.svelte
@@ -7,6 +7,7 @@
   import { selection } from "$lib/state/selection.svelte";
   import { viewport } from "$lib/state/viewport.svelte";
   import { getDriver } from "$lib/state/driver.svelte";
+  import { annotation } from "$lib/state/annotation.svelte";
 
   import type { IConfigValue } from "$idah/v2/types";
   import type { IVideoAnnotationValue } from "$lib/types";
@@ -40,6 +41,13 @@
   );
   let defaultMode = $derived(mode == "default" || !tools.has(mode));
 
+  // Derived disabled state using the annotation module
+  let disabled = $derived(
+    (selAnnotation && annotation.isLocked(selAnnotation.id)) ||
+    (defaultMode || mode == "entry:root" ? !!entryRoot?.value?.locked : false) ||
+    !["annotate", "review"].includes(getDriver().workflowStep)
+  );
+
   // Functions
   function categorySelection(shape_type: string, categoryId?: string) {
     if (categoryId) onEditValue({ category: categoryId }, shape_type);
@@ -65,9 +73,7 @@
               categorySelection(defaultMode ? "entry:root" : mode, selectedCategoryId)}
             onReSelectCategory={(reselectedCategoryId) => onReSelectCategory?.(reselectedCategoryId)}
             onEditValue={(value) => value && onEditValue(value, defaultMode ? "entry:root" : mode)}
-            disabled={selAnnotation?.locked ||
-              (defaultMode || mode == "entry:root" ? !!entryRoot?.value?.locked : false) ||
-              !["annotate", "review"].includes(getDriver().workflowStep)}
+            {disabled}
           />
         {/key}
       </SidebarGroupContent>

--- a/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/PropertiesCategorySelector.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/PropertiesCategorySelector.svelte
@@ -43,7 +43,7 @@
 
   // Derived disabled state using the annotation module
   let disabled = $derived(
-    (selAnnotation && annotation.isLocked(selAnnotation.id)) ||
+    (selAnnotation && annotation.isLocked(selAnnotation)) ||
     (defaultMode || mode == "entry:root" ? !!entryRoot?.value?.locked : false) ||
     !["annotate", "review"].includes(getDriver().workflowStep)
   );

--- a/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/menus.ts
+++ b/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/menus.ts
@@ -1,5 +1,6 @@
 import { EyeIcon, EyeOffIcon, LockIcon, LockOpenIcon, Trash2Icon, type Icon as IconType } from "@lucide/svelte";
 
+import { annotation } from "$lib/state/annotation.svelte";
 import { getDriver } from "$lib/state/driver.svelte";
 
 import type { IVideoAnnotationRecord } from "$lib/types";
@@ -37,7 +38,7 @@ export function getCategoryVisibilityAction(
 ): CategoryAction | null {
   if (items.length === 0) return null;
 
-  const isSomeHidden = items.some((item) => item.hidden);
+  const isSomeHidden = items.some((item) => annotation.isHidden(item.id));
 
   return {
     id: "visibility",
@@ -57,7 +58,7 @@ export function getCategoryEditabilityAction(
 ): CategoryAction | null {
   if (items.length === 0) return null;
 
-  const isSomeLocked = items.some((item) => item.locked);
+  const isSomeLocked = items.some((item) => annotation.isLocked(item.id));
 
   return {
     id: "editability",

--- a/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/menus.ts
+++ b/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/menus.ts
@@ -38,7 +38,7 @@ export function getCategoryVisibilityAction(
 ): CategoryAction | null {
   if (items.length === 0) return null;
 
-  const isSomeHidden = items.some((item) => annotation.isHidden(item.id));
+  const isSomeHidden = items.some((item) => annotation.isHidden(item));
 
   return {
     id: "visibility",
@@ -58,7 +58,7 @@ export function getCategoryEditabilityAction(
 ): CategoryAction | null {
   if (items.length === 0) return null;
 
-  const isSomeLocked = items.some((item) => annotation.isLocked(item.id));
+  const isSomeLocked = items.some((item) => annotation.isLocked(item));
 
   return {
     id: "editability",

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackBlockContextMenu.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackBlockContextMenu.svelte
@@ -17,6 +17,7 @@
   import { viewport } from "$lib/state/viewport.svelte";
   import { selection } from "$lib/state/selection.svelte";
   import { getDriver } from "$lib/state/driver.svelte";
+  import { annotation } from "$lib/state/annotation.svelte";
 
   // Props
   interface Props extends ContextMenuComponentProps {
@@ -26,9 +27,10 @@
   let { item, currentFrame }: Props = $props();
 
   // Variables
-  let { trackId, startRange, endRange, rawData: annotation } = $derived(item);
+  let { trackId, startRange, endRange, rawData } = $derived(item);
   let frame = $derived(currentFrame ?? viewport.video.currentFrame.value);
-  let isKeyframe = $derived(annotation.shape.frames.some((f) => f.frame === frame));
+  let isKeyframe = $derived(rawData.shape.frames.some((f) => f.frame === frame));
+  let annotationIsLocked = $derived(annotation.isLocked(rawData.id));
 
   let menus = $derived<Menus>({
     actions: {
@@ -47,10 +49,11 @@
               deleteKeyframe: {
                 label: `Delete keyframe`,
                 icon: Trash2Icon,
+                disabled: annotationIsLocked,
                 destructive: true,
                 onClick: () => {
                   getDriver().command.call("annotation.keyframe_delete", {
-                    annotationId: annotation.id,
+                    annotationId: rawData.id,
                     frame,
                   });
                 },
@@ -60,9 +63,10 @@
               addKeyframe: {
                 label: `Add keyframe`,
                 icon: FramerIcon,
+                disabled: annotationIsLocked,
                 onClick: () => {
                   getDriver().command.call("annotation.keyframe_add", {
-                    annotationId: annotation.id,
+                    annotationId: rawData.id,
                     selection: {
                       frame,
                       angle: 0,
@@ -75,9 +79,10 @@
         split: {
           label: `Split at frame ${frame + 1}`,
           icon: SquareSplitHorizontalIcon,
+          disabled: annotationIsLocked,
           onClick: () => {
             getDriver().command.call("annotation.split", {
-              annotationId: annotation.id,
+              annotationId: rawData.id,
               at: frame,
             });
           },
@@ -89,9 +94,10 @@
         delete: {
           label: `Delete annotation`,
           icon: Trash2Icon,
+          disabled: annotationIsLocked,
           destructive: true,
           onClick: () => {
-            selection.selectAnnotation(annotation);
+            selection.selectAnnotation(rawData);
             getDriver().command.call("selection.delete", {});
           },
         },

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackBlockContextMenu.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackBlockContextMenu.svelte
@@ -30,7 +30,7 @@
   let { trackId, startRange, endRange, rawData } = $derived(item);
   let frame = $derived(currentFrame ?? viewport.video.currentFrame.value);
   let isKeyframe = $derived(rawData.shape.frames.some((f) => f.frame === frame));
-  let annotationIsLocked = $derived(annotation.isLocked(rawData.id));
+  let annotationIsLocked = $derived(annotation.isLocked(rawData));
 
   let menus = $derived<Menus>({
     actions: {

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackBlockContextMenu.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackBlockContextMenu.svelte
@@ -112,16 +112,19 @@
 
     {#each Object.entries(group.items) as [menuKey, { label, icon: Icon, disabled, hidden, destructive, onClick }] (menuKey)}
       {#if !hidden}
-        <Button
-          variant={destructive ? "destructive-ghost" : "ghost"}
-          size="sm"
-          class="mx-1 justify-start"
-          {disabled}
-          onclick={onClick}
-        >
-          <Icon />
-          {label}
-        </Button>
+        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+        <div role="none" onclick={(e) => { if (disabled) e.stopPropagation(); }}>
+          <Button
+            variant={destructive ? "destructive-ghost" : "ghost"}
+            size="sm"
+            class="mx-1 w-full justify-start"
+            {disabled}
+            onclick={onClick}
+          >
+            <Icon />
+            {label}
+          </Button>
+        </div>
       {/if}
     {/each}
 

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackInfoContextMenu.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackInfoContextMenu.svelte
@@ -21,7 +21,7 @@
 
   // ── Track title context menus (existing) ──────────────────────────────
   let groupMenus = $derived(track ? getGroupContextMenus({ track }) : null);
-  let annotationIsLocked = $derived(trackId ? annotation.isLocked(trackId) : false);
+  let annotationIsLocked = $derived(trackId && items ? items.some(item => annotation.isLocked(item.rawData)) : false);
 
   // ── Empty-area extend menus (new) ─────────────────────────────────────
   let prevAnnotation = $derived.by<TimelineItem | undefined>(() => {

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackInfoContextMenu.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackInfoContextMenu.svelte
@@ -5,6 +5,7 @@
 
   import { getGroupContextMenus } from "$lib/components/App/Timeline/annotations/menus";
   import { getDriver } from "$lib/state/driver.svelte";
+  import { annotation } from "$lib/state/annotation.svelte";
 
   import type { ContextMenuComponentProps } from "$lib/components/App/ContextMenu/store";
   import type { TrackData, TimelineItem } from "$lib/components/App/Timeline/types";
@@ -20,6 +21,7 @@
 
   // ── Track title context menus (existing) ──────────────────────────────
   let groupMenus = $derived(track ? getGroupContextMenus({ track }) : null);
+  let annotationIsLocked = $derived(trackId ? annotation.isLocked(trackId) : false);
 
   // ── Empty-area extend menus (new) ─────────────────────────────────────
   let prevAnnotation = $derived.by<TimelineItem | undefined>(() => {
@@ -79,6 +81,7 @@
         variant="ghost"
         size="sm"
         class="mx-1 justify-start"
+        disabled={annotationIsLocked}
         onclick={() => {
           getDriver().command.call("annotation.extend_prev", {
             annotationId: prevAnnotation.rawData.id,
@@ -96,6 +99,7 @@
         variant="ghost"
         size="sm"
         class="mx-1 justify-start"
+        disabled={annotationIsLocked}
         onclick={() => {
           getDriver().command.call("annotation.extend_next", {
             annotationId: nextAnnotation.rawData.id,

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackInfoContextMenu.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackInfoContextMenu.svelte
@@ -57,16 +57,19 @@
 
       {#each Object.entries(group.items) as [menuKey, { label, icon: Icon, disabled, hidden, destructive, onClick }] (menuKey)}
         {#if !hidden}
-          <Button
-            variant={destructive ? "destructive-ghost" : "ghost"}
-            size="sm"
-            class="mx-1 justify-start"
-            {disabled}
-            onclick={onClick}
-          >
-            <Icon />
-            {label}
-          </Button>
+          <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+          <div role="none" onclick={(e) => { if (disabled) e.stopPropagation(); }}>
+            <Button
+              variant={destructive ? "destructive-ghost" : "ghost"}
+              size="sm"
+              class="mx-1 w-full justify-start"
+              {disabled}
+              onclick={onClick}
+            >
+              <Icon />
+              {label}
+            </Button>
+          </div>
         {/if}
       {/each}
 
@@ -77,39 +80,45 @@
   {:else if trackId && frame !== undefined}
     <!-- Empty track area context menu — extend actions -->
     {#if prevAnnotation}
-      <Button
-        variant="ghost"
-        size="sm"
-        class="mx-1 justify-start"
-        disabled={annotationIsLocked}
-        onclick={() => {
-          getDriver().command.call("annotation.extend_prev", {
-            annotationId: prevAnnotation.rawData.id,
-            frame,
-          });
-        }}
-      >
-        <ArrowRightToLineIcon />
-        Extend previous annotation to frame {frame + 1}
-      </Button>
+      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+      <div role="none" onclick={(e) => { if (annotationIsLocked) e.stopPropagation(); }}>
+        <Button
+          variant="ghost"
+          size="sm"
+          class="mx-1 w-full justify-start"
+          disabled={annotationIsLocked}
+          onclick={() => {
+            getDriver().command.call("annotation.extend_prev", {
+              annotationId: prevAnnotation.rawData.id,
+              frame,
+            });
+          }}
+        >
+          <ArrowRightToLineIcon />
+          Extend previous annotation to frame {frame + 1}
+        </Button>
+      </div>
     {/if}
 
     {#if nextAnnotation}
-      <Button
-        variant="ghost"
-        size="sm"
-        class="mx-1 justify-start"
-        disabled={annotationIsLocked}
-        onclick={() => {
-          getDriver().command.call("annotation.extend_next", {
-            annotationId: nextAnnotation.rawData.id,
-            frame,
-          });
-        }}
-      >
-        <ArrowLeftToLineIcon />
-        Extend next annotation to frame {frame + 1}
-      </Button>
+      <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+      <div role="none" onclick={(e) => { if (annotationIsLocked) e.stopPropagation(); }}>
+        <Button
+          variant="ghost"
+          size="sm"
+          class="mx-1 w-full justify-start"
+          disabled={annotationIsLocked}
+          onclick={() => {
+            getDriver().command.call("annotation.extend_next", {
+              annotationId: nextAnnotation.rawData.id,
+              frame,
+            });
+          }}
+        >
+          <ArrowLeftToLineIcon />
+          Extend next annotation to frame {frame + 1}
+        </Button>
+      </div>
     {/if}
 
     {#if !prevAnnotation && !nextAnnotation}

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackInfoHeader.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackInfoHeader.svelte
@@ -5,6 +5,7 @@
   import ConfirmModal from "$lib/components/ui/Overlays/modals/ConfirmModal.svelte";
   import ToolTooltip from "$lib/components/ui/Tooltips/ToolTooltip.svelte";
 
+  import { annotation } from "$lib/state/annotation.svelte";
   import { getDriver } from "$lib/state/driver.svelte";
   import { selection } from "$lib/state/selection.svelte";
 
@@ -17,11 +18,11 @@
   }
   let { annotations }: Props = $props();
 
-  // Vairables
+  // Variables
   let openConfirmDeleteAllDialog = $state(false);
 
-  const isAllHidden = $derived(annotations.every((a) => a.hidden));
-  const isAllLocked = $derived(annotations.every((a) => a.locked));
+  const isAllHidden = $derived(annotations.length > 0 && annotations.every((a) => annotation.isHidden(a.id)));
+  const isAllLocked = $derived(annotations.length > 0 && annotations.every((a) => annotation.isLocked(a.id)));
   const menus = $derived<Menus>({
     actions: {
       items: {

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackInfoHeader.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackInfoHeader.svelte
@@ -19,8 +19,8 @@
   let { annotations }: Props = $props();
 
   // Variables
-  const isAllHidden = $derived(annotations.length > 0 && annotations.every((a) => annotation.isHidden(a.id)));
-  const isAllLocked = $derived(annotations.length > 0 && annotations.every((a) => annotation.isLocked(a.id)));
+  const isAllHidden = $derived(annotations.length > 0 && annotations.every((ann) => annotation.isHidden(ann)));
+  const isAllLocked = $derived(annotations.length > 0 && annotations.every((ann) => annotation.isLocked(ann)));
   const menus = $derived<Menus>({
     actions: {
       items: {

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/menus.ts
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/menus.ts
@@ -1,5 +1,6 @@
 import { CrosshairIcon, EyeIcon, EyeOffIcon, LockIcon, LockOpenIcon, Trash2Icon } from "@lucide/svelte";
 
+import { annotation } from "$lib/state/annotation.svelte";
 import type { Menus } from "$lib/components/App/ContextMenu/types";
 import type { TrackData } from "$lib/components/App/Timeline/types";
 import { getDriver } from "$lib/state/driver.svelte";
@@ -7,8 +8,8 @@ import { selection } from "$lib/state/selection.svelte";
 
 export function getGroupContextMenus(props: { track: TrackData }): Menus {
   const { track } = props;
-  const isSomeHidden = track.items.some((item) => item.rawData.hidden);
-  const isSomeLocked = track.items.some((item) => item.rawData.locked);
+  const isSomeHidden = track.items.some((item) => annotation.isHidden(item.rawData.id));
+  const isSomeLocked = track.items.some((item) => annotation.isLocked(item.rawData.id));
 
   return {
     actions: {

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/menus.ts
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/menus.ts
@@ -10,8 +10,8 @@ import type { TrackData } from "$lib/components/App/Timeline/types";
 
 export function getGroupContextMenus(props: { track: TrackData }): Menus {
   const { track } = props;
-  const isSomeHidden = track.items.some((item) => annotation.isHidden(item.rawData.id));
-  const isSomeLocked = track.items.some((item) => annotation.isLocked(item.rawData.id));
+  const isSomeHidden = track.items.some((item) => annotation.isHidden(item.rawData));
+  const isSomeLocked = track.items.some((item) => annotation.isLocked(item.rawData));
 
   return {
     actions: {

--- a/plugins/idah-video/frontend/src/lib/components/App/VideoAnnotationWorkspace/VideoAnnotationWorkspace.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/VideoAnnotationWorkspace/VideoAnnotationWorkspace.svelte
@@ -409,7 +409,7 @@
 
   function updateAnnotationValue(ann: IVideoAnnotationRecord, value: AnnotationValue) {
     if (!editable) return;
-    if (ann && annotation.isLocked(ann.id)) return;
+    if (ann && annotation.isLocked(ann)) return;
 
     getDriver().command.call("annotation.update", { annotation: ann, value });
   }

--- a/plugins/idah-video/frontend/src/lib/components/App/VideoAnnotationWorkspace/VideoAnnotationWorkspace.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/VideoAnnotationWorkspace/VideoAnnotationWorkspace.svelte
@@ -16,6 +16,7 @@
   import { media } from "$lib/state/media.svelte";
   import { selection } from "$lib/state/selection.svelte";
   import { viewport } from "$lib/state/viewport.svelte";
+  import { annotation } from "$lib/state/annotation.svelte";
   import { VIDEO_BOUNDING_BOX as IDAH_VIDEO_BOUNDING_BOX, VIDEO_POLYGON as IDAH_VIDEO_POLYGON } from "$lib/types";
 
   import BottomPanel from "$lib/components/App/BottomPanel/BottomPanel.svelte";
@@ -384,10 +385,11 @@
     }
   }
 
-  function updateAnnotationValue(annotation: IVideoAnnotationRecord, value: AnnotationValue) {
-    if (annotation?.locked || !editable) return;
+  function updateAnnotationValue(ann: IVideoAnnotationRecord, value: AnnotationValue) {
+    if (!editable) return;
+    if (ann && annotation.isLocked(ann.id)) return;
 
-    getDriver().command.call("annotation.update", { annotation, value });
+    getDriver().command.call("annotation.update", { annotation: ann, value });
   }
 
   function selectAnnotation(annotation?: IVideoAnnotationRecord) {
@@ -454,8 +456,6 @@
         attributes: ann.value?.attributes ?? {},
       },
       metadata: ann.metadata ?? {},
-      hidden: ann.hidden ?? false,
-      locked: ann.locked ?? false,
       synced: ann.synced ?? true,
     })) as IVideoAnnotationRecord[];
   });

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/BBoxShape.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/BBoxShape.svelte
@@ -429,7 +429,9 @@
 
   {#if activeCursor && cursorPx && isEditing}
     <g style="pointer-events: none;">
-      <image href={activeCursor} x={cursorPx[0] - 18} y={cursorPx[1] - 18} width="36" height="36" />
+      <g transform="translate({cursorPx[0]}, {cursorPx[1]}) scale({1 / viewport.workspace.transform.scale})">
+        <image href={activeCursor} x="-18" y="-18" width="36" height="36" />
+      </g>
     </g>
   {/if}
 {/if}

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
@@ -96,7 +96,7 @@
     const f = viewport.video.currentFrame.value;
     const items = data.annotations?.items ?? [];
     return items.filter((ann) => {
-      if (annotation.isHidden(ann.id)) return false;
+      if (annotation.isHidden(ann)) return false;
       const s = ann.shape as { start?: number; end?: number };
       return s.start != null && s.end != null && f >= s.start && f <= s.end;
     });
@@ -375,7 +375,7 @@
           bind:this={_compRefs[i]}
           annotation={ann}
           selected={selection.isAnnotationSelected(ann.id)}
-          editable={viewport.mode === DEFAULT_MODE && selection.isAnnotationSelected(ann.id) && !annotation.isLocked(ann.id)}
+          editable={viewport.mode === DEFAULT_MODE && selection.isAnnotationSelected(ann.id) && !annotation.isLocked(ann)}
           cursor={sceneNormalizedCursor}
           mode={viewport.mode}
           onClick={() => handleClick(ann)}

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
@@ -23,6 +23,7 @@
   import Crosshair from "./Crosshair.svelte";
 
   import { BOUNDING_BOX_MODE, DEFAULT_MODE, NOTE_MODE, POLYGON_MODE, viewport } from "$lib/state/viewport.svelte";
+  import { getDriver } from "$lib/state/driver.svelte";
   import { selection } from "$lib/state/selection.svelte";
   import { data } from "$lib/state/data.svelte";
   import { media } from "$lib/state/media.svelte";
@@ -86,11 +87,12 @@
   // ── Component refs for tool selection ─────────────────────────────────
   let _compRefs: any[] = $state([]);
 
-  // Build a flat list of visible annotations (filtered by current frame)
+  // Build a flat list of visible annotations (filtered by current frame and hidden state)
   let visibleAnnotations = $derived.by<IAnnotationRecord[]>(() => {
     const f = viewport.video.currentFrame.value;
     const items = data.annotations?.items ?? [];
     return items.filter((ann) => {
+      if (ann.hidden) return false;
       const s = ann.shape as { start?: number; end?: number };
       return s.start != null && s.end != null && f >= s.start && f <= s.end;
     });
@@ -362,7 +364,7 @@
           bind:this={_compRefs[i]}
           annotation={ann}
           selected={selection.isAnnotationSelected(ann.id)}
-          editable={viewport.mode === DEFAULT_MODE && selection.isAnnotationSelected(ann.id)}
+          editable={viewport.mode === DEFAULT_MODE && selection.isAnnotationSelected(ann.id) && !ann.locked}
           cursor={sceneNormalizedCursor}
           mode={viewport.mode}
           onClick={() => handleClick(ann)}

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
@@ -23,7 +23,7 @@
   import Crosshair from "./Crosshair.svelte";
 
   import { BOUNDING_BOX_MODE, DEFAULT_MODE, NOTE_MODE, POLYGON_MODE, viewport } from "$lib/state/viewport.svelte";
-  import { getDriver } from "$lib/state/driver.svelte";
+
   import { selection } from "$lib/state/selection.svelte";
   import { data } from "$lib/state/data.svelte";
   import { media } from "$lib/state/media.svelte";

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
@@ -24,6 +24,7 @@
 
   import { BOUNDING_BOX_MODE, DEFAULT_MODE, NOTE_MODE, POLYGON_MODE, viewport } from "$lib/state/viewport.svelte";
 
+  import { annotation } from "$lib/state/annotation.svelte";
   import { selection } from "$lib/state/selection.svelte";
   import { data } from "$lib/state/data.svelte";
   import { media } from "$lib/state/media.svelte";
@@ -92,7 +93,7 @@
     const f = viewport.video.currentFrame.value;
     const items = data.annotations?.items ?? [];
     return items.filter((ann) => {
-      if (ann.hidden) return false;
+      if (annotation.isHidden(ann.id)) return false;
       const s = ann.shape as { start?: number; end?: number };
       return s.start != null && s.end != null && f >= s.start && f <= s.end;
     });
@@ -364,7 +365,7 @@
           bind:this={_compRefs[i]}
           annotation={ann}
           selected={selection.isAnnotationSelected(ann.id)}
-          editable={viewport.mode === DEFAULT_MODE && selection.isAnnotationSelected(ann.id) && !ann.locked}
+          editable={viewport.mode === DEFAULT_MODE && selection.isAnnotationSelected(ann.id) && !annotation.isLocked(ann.id)}
           cursor={sceneNormalizedCursor}
           mode={viewport.mode}
           onClick={() => handleClick(ann)}

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/VideoController.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/VideoController.svelte
@@ -71,7 +71,7 @@
   let disabledSplitButton = $derived.by(() => {
     const ann = selection.value?.type === "annotation" ? (selection.value as any).annotation : undefined;
     if (!ann) return true;
-    if (annotation.isLocked(ann.id)) return true;
+    if (annotation.isLocked(ann)) return true;
     if (ann.shape?.end < viewport.video.currentFrame.value) return true;
   });
 

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/VideoController.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/VideoController.svelte
@@ -28,6 +28,7 @@
   import ToolTooltip from "$lib/components/ui/Tooltips/ToolTooltip.svelte";
   import Video from "./Video.svelte";
 
+  import { annotation } from "$lib/state/annotation.svelte";
   import { getDriver } from "$lib/state/driver.svelte";
   import { media } from "$lib/state/media.svelte";
   import { selection } from "$lib/state/selection.svelte";
@@ -70,7 +71,7 @@
   let disabledSplitButton = $derived.by(() => {
     const ann = selection.value?.type === "annotation" ? (selection.value as any).annotation : undefined;
     if (!ann) return true;
-    if (ann.locked) return true;
+    if (annotation.isLocked(ann.id)) return true;
     if (ann.shape?.end < viewport.video.currentFrame.value) return true;
   });
 

--- a/plugins/idah-video/frontend/src/lib/state/annotation.svelte.ts
+++ b/plugins/idah-video/frontend/src/lib/state/annotation.svelte.ts
@@ -3,20 +3,29 @@
 //
 // Tracks which annotation IDs are currently hidden from the viewport and
 // which are locked (non-editable). Both lists are backed by Svelte 5 $state,
-// so any component reading `annotation.isHidden(id)` or
-// `annotation.isLocked(id)` reacts automatically to changes.
+// so any component reading `annotation.isHidden(ann)` or
+// `annotation.isLocked(ann)` reacts automatically to changes.
 //
 // Exposed as a plain object with query and mutation methods so components
 // use `annotation.toggleHidden(id, flag)` / `annotation.clearHidden()`
 // syntax.
 // ---------------------------------------------------------------------------
 
+import type { IAnnotationRecord } from "$idah/v2/types";
+
 let hiddenIds: string[] = $state([]);
 let lockedIds: string[] = $state([]);
 
 export const annotation = {
-  isLocked: (id: string) => lockedIds.includes(id),
-  isHidden: (id: string) => hiddenIds.includes(id),
+  isLocked: (annotation: IAnnotationRecord) => {
+    return lockedIds.includes(annotation.id) ||
+      (annotation.metadata?.group_id != null && lockedIds.includes(annotation.metadata.group_id));
+  },
+
+  isHidden: (annotation: IAnnotationRecord) => {
+    return hiddenIds.includes(annotation.id) ||
+      (annotation.metadata?.group_id != null && hiddenIds.includes(annotation.metadata.group_id));
+  },
 
   clearLocked: () => {
     lockedIds = [];

--- a/plugins/idah-video/frontend/src/lib/state/annotation.svelte.ts
+++ b/plugins/idah-video/frontend/src/lib/state/annotation.svelte.ts
@@ -17,14 +17,18 @@ let hiddenIds: string[] = $state([]);
 let lockedIds: string[] = $state([]);
 
 export const annotation = {
-  isLocked: (annotation: IAnnotationRecord) => {
-    return lockedIds.includes(annotation.id) ||
-      (annotation.metadata?.group_id != null && lockedIds.includes(annotation.metadata.group_id));
+  isLocked: (target: IAnnotationRecord | string) => {
+    if(typeof target === "string") return lockedIds.includes(target)
+
+    return lockedIds.includes(target.id) ||
+      (target.metadata?.group_id != null && lockedIds.includes(target.metadata.group_id));
   },
 
-  isHidden: (annotation: IAnnotationRecord) => {
-    return hiddenIds.includes(annotation.id) ||
-      (annotation.metadata?.group_id != null && hiddenIds.includes(annotation.metadata.group_id));
+  isHidden: (target: IAnnotationRecord | string) => {
+    if (typeof target === "string") return hiddenIds.includes(target)
+
+    return hiddenIds.includes(target.id) ||
+      (target.metadata?.group_id != null && hiddenIds.includes(target.metadata.group_id));
   },
 
   clearLocked: () => {

--- a/plugins/idah-video/frontend/src/lib/state/annotation.svelte.ts
+++ b/plugins/idah-video/frontend/src/lib/state/annotation.svelte.ts
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------------
+// annotation.svelte.ts — Reactive visibility & lock state for annotations
+//
+// Tracks which annotation IDs are currently hidden from the viewport and
+// which are locked (non-editable). Both lists are backed by Svelte 5 $state,
+// so any component reading `annotation.isHidden(id)` or
+// `annotation.isLocked(id)` reacts automatically to changes.
+//
+// Exposed as a plain object with query and mutation methods so components
+// use `annotation.toggleHidden(id, flag)` / `annotation.clearHidden()`
+// syntax.
+// ---------------------------------------------------------------------------
+
+let hiddenIds: string[] = $state([]);
+let lockedIds: string[] = $state([]);
+
+export const annotation = {
+  isLocked: (id: string) => lockedIds.includes(id),
+  isHidden: (id: string) => hiddenIds.includes(id),
+
+  clearLocked: () => {
+    lockedIds = [];
+  },
+
+  clearHidden: () => {
+    hiddenIds = [];
+  },
+
+  toggleLocked: (id: string, locked: boolean) => {
+    if (locked) {
+      if (!lockedIds.includes(id)) lockedIds.push(id);
+    } else {
+      lockedIds = lockedIds.filter((lockedId) => lockedId !== id);
+    }
+  },
+
+  toggleHidden: (id: string, hidden: boolean) => {
+    if (hidden) {
+      if (!hiddenIds.includes(id)) hiddenIds.push(id);
+    } else {
+      hiddenIds = hiddenIds.filter((hiddenId) => hiddenId !== id);
+    }
+  },
+};

--- a/plugins/idah-video/frontend/src/lib/state/annotation.test.ts
+++ b/plugins/idah-video/frontend/src/lib/state/annotation.test.ts
@@ -33,6 +33,38 @@ describe("annotation state", () => {
     });
   });
 
+  describe("isLocked (string overload)", () => {
+    it("returns true when the string id is locked", () => {
+      annotation.toggleLocked("string-1", true);
+      expect(annotation.isLocked("string-1")).toBe(true);
+    });
+
+    it("returns false when the string id is not locked", () => {
+      expect(annotation.isLocked("string-1")).toBe(false);
+    });
+
+    it("returns false when a different string id is locked", () => {
+      annotation.toggleLocked("string-1", true);
+      expect(annotation.isLocked("string-2")).toBe(false);
+    });
+  });
+
+  describe("isHidden (string overload)", () => {
+    it("returns true when the string id is hidden", () => {
+      annotation.toggleHidden("string-1", true);
+      expect(annotation.isHidden("string-1")).toBe(true);
+    });
+
+    it("returns false when the string id is not hidden", () => {
+      expect(annotation.isHidden("string-1")).toBe(false);
+    });
+
+    it("returns false when a different string id is hidden", () => {
+      annotation.toggleHidden("string-1", true);
+      expect(annotation.isHidden("string-2")).toBe(false);
+    });
+  });
+
   describe("toggleLocked", () => {
     it("locks an annotation", () => {
       annotation.toggleLocked(ann1.id, true);
@@ -169,6 +201,32 @@ describe("annotation state", () => {
 
     it("isHidden returns true when group_id is hidden", () => {
       const groupAnn = mockRecord("ann-group-child", "group-1");
+      annotation.toggleHidden("group-1", true);
+      expect(annotation.isHidden(groupAnn)).toBe(true);
+    });
+
+    it("isLocked returns true when own id is locked on a grouped annotation", () => {
+      const groupAnn = mockRecord("ann-group-child", "group-1");
+      annotation.toggleLocked("ann-group-child", true);
+      expect(annotation.isLocked(groupAnn)).toBe(true);
+    });
+
+    it("isHidden returns true when own id is hidden on a grouped annotation", () => {
+      const groupAnn = mockRecord("ann-group-child", "group-1");
+      annotation.toggleHidden("ann-group-child", true);
+      expect(annotation.isHidden(groupAnn)).toBe(true);
+    });
+
+    it("isLocked returns true when both own id and group_id are locked", () => {
+      const groupAnn = mockRecord("ann-group-child", "group-1");
+      annotation.toggleLocked("ann-group-child", true);
+      annotation.toggleLocked("group-1", true);
+      expect(annotation.isLocked(groupAnn)).toBe(true);
+    });
+
+    it("isHidden returns true when both own id and group_id are hidden", () => {
+      const groupAnn = mockRecord("ann-group-child", "group-1");
+      annotation.toggleHidden("ann-group-child", true);
       annotation.toggleHidden("group-1", true);
       expect(annotation.isHidden(groupAnn)).toBe(true);
     });

--- a/plugins/idah-video/frontend/src/lib/state/annotation.test.ts
+++ b/plugins/idah-video/frontend/src/lib/state/annotation.test.ts
@@ -3,6 +3,19 @@
 // ---------------------------------------------------------------------------
 import { describe, it, expect, beforeEach } from "vitest";
 import { annotation } from "./annotation.svelte";
+import type { IAnnotationRecord } from "$idah/v2/types";
+
+/** Create a minimal annotation record for testing purposes. */
+function mockRecord(id: string, group_id?: string): IAnnotationRecord {
+  return {
+    id,
+    shape: {},
+    metadata: group_id != null ? { group_id } : undefined,
+  };
+}
+
+const ann1 = mockRecord("ann-001");
+const ann2 = mockRecord("ann-002");
 
 describe("annotation state", () => {
   beforeEach(() => {
@@ -12,95 +25,95 @@ describe("annotation state", () => {
 
   describe("initial state", () => {
     it("reports no ids as locked", () => {
-      expect(annotation.isLocked("ann-001")).toBe(false);
+      expect(annotation.isLocked(ann1)).toBe(false);
     });
 
     it("reports no ids as hidden", () => {
-      expect(annotation.isHidden("ann-001")).toBe(false);
+      expect(annotation.isHidden(ann1)).toBe(false);
     });
   });
 
   describe("toggleLocked", () => {
     it("locks an annotation", () => {
-      annotation.toggleLocked("ann-001", true);
-      expect(annotation.isLocked("ann-001")).toBe(true);
+      annotation.toggleLocked(ann1.id, true);
+      expect(annotation.isLocked(ann1)).toBe(true);
     });
 
     it("unlocks a previously locked annotation", () => {
-      annotation.toggleLocked("ann-001", true);
-      annotation.toggleLocked("ann-001", false);
-      expect(annotation.isLocked("ann-001")).toBe(false);
+      annotation.toggleLocked(ann1.id, true);
+      annotation.toggleLocked(ann1.id, false);
+      expect(annotation.isLocked(ann1)).toBe(false);
     });
 
     it("does not affect other annotations when locking", () => {
-      annotation.toggleLocked("ann-001", true);
-      expect(annotation.isLocked("ann-002")).toBe(false);
+      annotation.toggleLocked(ann1.id, true);
+      expect(annotation.isLocked(ann2)).toBe(false);
     });
 
     it("does not affect other annotations when unlocking", () => {
-      annotation.toggleLocked("ann-001", true);
-      annotation.toggleLocked("ann-002", true);
-      annotation.toggleLocked("ann-001", false);
-      expect(annotation.isLocked("ann-002")).toBe(true);
-      expect(annotation.isLocked("ann-001")).toBe(false);
+      annotation.toggleLocked(ann1.id, true);
+      annotation.toggleLocked(ann2.id, true);
+      annotation.toggleLocked(ann1.id, false);
+      expect(annotation.isLocked(ann2)).toBe(true);
+      expect(annotation.isLocked(ann1)).toBe(false);
     });
 
     it("is idempotent when locking an already-locked id", () => {
-      annotation.toggleLocked("ann-001", true);
-      annotation.toggleLocked("ann-001", true);
-      expect(annotation.isLocked("ann-001")).toBe(true);
+      annotation.toggleLocked(ann1.id, true);
+      annotation.toggleLocked(ann1.id, true);
+      expect(annotation.isLocked(ann1)).toBe(true);
     });
 
     it("is idempotent when unlocking an already-unlocked id", () => {
-      annotation.toggleLocked("ann-001", false);
-      expect(annotation.isLocked("ann-001")).toBe(false);
+      annotation.toggleLocked(ann1.id, false);
+      expect(annotation.isLocked(ann1)).toBe(false);
     });
   });
 
   describe("toggleHidden", () => {
     it("hides an annotation", () => {
-      annotation.toggleHidden("ann-001", true);
-      expect(annotation.isHidden("ann-001")).toBe(true);
+      annotation.toggleHidden(ann1.id, true);
+      expect(annotation.isHidden(ann1)).toBe(true);
     });
 
     it("unhides a previously hidden annotation", () => {
-      annotation.toggleHidden("ann-001", true);
-      annotation.toggleHidden("ann-001", false);
-      expect(annotation.isHidden("ann-001")).toBe(false);
+      annotation.toggleHidden(ann1.id, true);
+      annotation.toggleHidden(ann1.id, false);
+      expect(annotation.isHidden(ann1)).toBe(false);
     });
 
     it("does not affect other annotations when hiding", () => {
-      annotation.toggleHidden("ann-001", true);
-      expect(annotation.isHidden("ann-002")).toBe(false);
+      annotation.toggleHidden(ann1.id, true);
+      expect(annotation.isHidden(ann2)).toBe(false);
     });
 
     it("does not affect other annotations when unhiding", () => {
-      annotation.toggleHidden("ann-001", true);
-      annotation.toggleHidden("ann-002", true);
-      annotation.toggleHidden("ann-001", false);
-      expect(annotation.isHidden("ann-002")).toBe(true);
-      expect(annotation.isHidden("ann-001")).toBe(false);
+      annotation.toggleHidden(ann1.id, true);
+      annotation.toggleHidden(ann2.id, true);
+      annotation.toggleHidden(ann1.id, false);
+      expect(annotation.isHidden(ann2)).toBe(true);
+      expect(annotation.isHidden(ann1)).toBe(false);
     });
 
     it("is idempotent when hiding an already-hidden id", () => {
-      annotation.toggleHidden("ann-001", true);
-      annotation.toggleHidden("ann-001", true);
-      expect(annotation.isHidden("ann-001")).toBe(true);
+      annotation.toggleHidden(ann1.id, true);
+      annotation.toggleHidden(ann1.id, true);
+      expect(annotation.isHidden(ann1)).toBe(true);
     });
 
     it("is idempotent when unhiding an already-visible id", () => {
-      annotation.toggleHidden("ann-001", false);
-      expect(annotation.isHidden("ann-001")).toBe(false);
+      annotation.toggleHidden(ann1.id, false);
+      expect(annotation.isHidden(ann1)).toBe(false);
     });
   });
 
   describe("clearLocked", () => {
     it("unlocks all locked annotations", () => {
-      annotation.toggleLocked("ann-001", true);
-      annotation.toggleLocked("ann-002", true);
+      annotation.toggleLocked(ann1.id, true);
+      annotation.toggleLocked(ann2.id, true);
       annotation.clearLocked();
-      expect(annotation.isLocked("ann-001")).toBe(false);
-      expect(annotation.isLocked("ann-002")).toBe(false);
+      expect(annotation.isLocked(ann1)).toBe(false);
+      expect(annotation.isLocked(ann2)).toBe(false);
     });
 
     it("is safe to call when nothing is locked", () => {
@@ -110,11 +123,11 @@ describe("annotation state", () => {
 
   describe("clearHidden", () => {
     it("unhides all hidden annotations", () => {
-      annotation.toggleHidden("ann-001", true);
-      annotation.toggleHidden("ann-002", true);
+      annotation.toggleHidden(ann1.id, true);
+      annotation.toggleHidden(ann2.id, true);
       annotation.clearHidden();
-      expect(annotation.isHidden("ann-001")).toBe(false);
-      expect(annotation.isHidden("ann-002")).toBe(false);
+      expect(annotation.isHidden(ann1)).toBe(false);
+      expect(annotation.isHidden(ann2)).toBe(false);
     });
 
     it("is safe to call when nothing is hidden", () => {
@@ -124,26 +137,64 @@ describe("annotation state", () => {
 
   describe("independent lock and hidden state", () => {
     it("tracks lock and hidden independently", () => {
-      annotation.toggleLocked("ann-001", true);
-      annotation.toggleHidden("ann-001", true);
-      expect(annotation.isLocked("ann-001")).toBe(true);
-      expect(annotation.isHidden("ann-001")).toBe(true);
+      annotation.toggleLocked(ann1.id, true);
+      annotation.toggleHidden(ann1.id, true);
+      expect(annotation.isLocked(ann1)).toBe(true);
+      expect(annotation.isHidden(ann1)).toBe(true);
     });
 
     it("clearing lock does not affect hidden state", () => {
-      annotation.toggleLocked("ann-001", true);
-      annotation.toggleHidden("ann-001", true);
+      annotation.toggleLocked(ann1.id, true);
+      annotation.toggleHidden(ann1.id, true);
       annotation.clearLocked();
-      expect(annotation.isLocked("ann-001")).toBe(false);
-      expect(annotation.isHidden("ann-001")).toBe(true);
+      expect(annotation.isLocked(ann1)).toBe(false);
+      expect(annotation.isHidden(ann1)).toBe(true);
     });
 
     it("clearing hidden does not affect lock state", () => {
-      annotation.toggleLocked("ann-001", true);
-      annotation.toggleHidden("ann-001", true);
+      annotation.toggleLocked(ann1.id, true);
+      annotation.toggleHidden(ann1.id, true);
       annotation.clearHidden();
-      expect(annotation.isHidden("ann-001")).toBe(false);
-      expect(annotation.isLocked("ann-001")).toBe(true);
+      expect(annotation.isHidden(ann1)).toBe(false);
+      expect(annotation.isLocked(ann1)).toBe(true);
+    });
+  });
+
+  describe("group_id integration", () => {
+    it("isLocked returns true when group_id is locked", () => {
+      const groupAnn = mockRecord("ann-group-child", "group-1");
+      annotation.toggleLocked("group-1", true);
+      expect(annotation.isLocked(groupAnn)).toBe(true);
+    });
+
+    it("isHidden returns true when group_id is hidden", () => {
+      const groupAnn = mockRecord("ann-group-child", "group-1");
+      annotation.toggleHidden("group-1", true);
+      expect(annotation.isHidden(groupAnn)).toBe(true);
+    });
+
+    it("isLocked prefers group_id over individual unlock when annotation id was removed", () => {
+      const groupAnn = mockRecord("ann-group-child", "group-1");
+      annotation.toggleLocked("group-1", true);
+      annotation.toggleLocked("ann-group-child", false);
+      expect(annotation.isLocked(groupAnn)).toBe(true);
+    });
+
+    it("isHidden prefers group_id over individual unhide when annotation id was removed", () => {
+      const groupAnn = mockRecord("ann-group-child", "group-1");
+      annotation.toggleHidden("group-1", true);
+      annotation.toggleHidden("ann-group-child", false);
+      expect(annotation.isHidden(groupAnn)).toBe(true);
+    });
+
+    it("isLocked returns false when no group_id and id is not locked", () => {
+      const standalone = mockRecord("standalone-001");
+      expect(annotation.isLocked(standalone)).toBe(false);
+    });
+
+    it("isHidden returns false when no group_id and id is not hidden", () => {
+      const standalone = mockRecord("standalone-001");
+      expect(annotation.isHidden(standalone)).toBe(false);
     });
   });
 });

--- a/plugins/idah-video/frontend/src/lib/state/annotation.test.ts
+++ b/plugins/idah-video/frontend/src/lib/state/annotation.test.ts
@@ -1,0 +1,149 @@
+// ---------------------------------------------------------------------------
+// annotation.test.ts — Unit tests for annotation visibility & lock state
+// ---------------------------------------------------------------------------
+import { describe, it, expect, beforeEach } from "vitest";
+import { annotation } from "./annotation.svelte";
+
+describe("annotation state", () => {
+  beforeEach(() => {
+    annotation.clearLocked();
+    annotation.clearHidden();
+  });
+
+  describe("initial state", () => {
+    it("reports no ids as locked", () => {
+      expect(annotation.isLocked("ann-001")).toBe(false);
+    });
+
+    it("reports no ids as hidden", () => {
+      expect(annotation.isHidden("ann-001")).toBe(false);
+    });
+  });
+
+  describe("toggleLocked", () => {
+    it("locks an annotation", () => {
+      annotation.toggleLocked("ann-001", true);
+      expect(annotation.isLocked("ann-001")).toBe(true);
+    });
+
+    it("unlocks a previously locked annotation", () => {
+      annotation.toggleLocked("ann-001", true);
+      annotation.toggleLocked("ann-001", false);
+      expect(annotation.isLocked("ann-001")).toBe(false);
+    });
+
+    it("does not affect other annotations when locking", () => {
+      annotation.toggleLocked("ann-001", true);
+      expect(annotation.isLocked("ann-002")).toBe(false);
+    });
+
+    it("does not affect other annotations when unlocking", () => {
+      annotation.toggleLocked("ann-001", true);
+      annotation.toggleLocked("ann-002", true);
+      annotation.toggleLocked("ann-001", false);
+      expect(annotation.isLocked("ann-002")).toBe(true);
+      expect(annotation.isLocked("ann-001")).toBe(false);
+    });
+
+    it("is idempotent when locking an already-locked id", () => {
+      annotation.toggleLocked("ann-001", true);
+      annotation.toggleLocked("ann-001", true);
+      expect(annotation.isLocked("ann-001")).toBe(true);
+    });
+
+    it("is idempotent when unlocking an already-unlocked id", () => {
+      annotation.toggleLocked("ann-001", false);
+      expect(annotation.isLocked("ann-001")).toBe(false);
+    });
+  });
+
+  describe("toggleHidden", () => {
+    it("hides an annotation", () => {
+      annotation.toggleHidden("ann-001", true);
+      expect(annotation.isHidden("ann-001")).toBe(true);
+    });
+
+    it("unhides a previously hidden annotation", () => {
+      annotation.toggleHidden("ann-001", true);
+      annotation.toggleHidden("ann-001", false);
+      expect(annotation.isHidden("ann-001")).toBe(false);
+    });
+
+    it("does not affect other annotations when hiding", () => {
+      annotation.toggleHidden("ann-001", true);
+      expect(annotation.isHidden("ann-002")).toBe(false);
+    });
+
+    it("does not affect other annotations when unhiding", () => {
+      annotation.toggleHidden("ann-001", true);
+      annotation.toggleHidden("ann-002", true);
+      annotation.toggleHidden("ann-001", false);
+      expect(annotation.isHidden("ann-002")).toBe(true);
+      expect(annotation.isHidden("ann-001")).toBe(false);
+    });
+
+    it("is idempotent when hiding an already-hidden id", () => {
+      annotation.toggleHidden("ann-001", true);
+      annotation.toggleHidden("ann-001", true);
+      expect(annotation.isHidden("ann-001")).toBe(true);
+    });
+
+    it("is idempotent when unhiding an already-visible id", () => {
+      annotation.toggleHidden("ann-001", false);
+      expect(annotation.isHidden("ann-001")).toBe(false);
+    });
+  });
+
+  describe("clearLocked", () => {
+    it("unlocks all locked annotations", () => {
+      annotation.toggleLocked("ann-001", true);
+      annotation.toggleLocked("ann-002", true);
+      annotation.clearLocked();
+      expect(annotation.isLocked("ann-001")).toBe(false);
+      expect(annotation.isLocked("ann-002")).toBe(false);
+    });
+
+    it("is safe to call when nothing is locked", () => {
+      expect(() => annotation.clearLocked()).not.toThrow();
+    });
+  });
+
+  describe("clearHidden", () => {
+    it("unhides all hidden annotations", () => {
+      annotation.toggleHidden("ann-001", true);
+      annotation.toggleHidden("ann-002", true);
+      annotation.clearHidden();
+      expect(annotation.isHidden("ann-001")).toBe(false);
+      expect(annotation.isHidden("ann-002")).toBe(false);
+    });
+
+    it("is safe to call when nothing is hidden", () => {
+      expect(() => annotation.clearHidden()).not.toThrow();
+    });
+  });
+
+  describe("independent lock and hidden state", () => {
+    it("tracks lock and hidden independently", () => {
+      annotation.toggleLocked("ann-001", true);
+      annotation.toggleHidden("ann-001", true);
+      expect(annotation.isLocked("ann-001")).toBe(true);
+      expect(annotation.isHidden("ann-001")).toBe(true);
+    });
+
+    it("clearing lock does not affect hidden state", () => {
+      annotation.toggleLocked("ann-001", true);
+      annotation.toggleHidden("ann-001", true);
+      annotation.clearLocked();
+      expect(annotation.isLocked("ann-001")).toBe(false);
+      expect(annotation.isHidden("ann-001")).toBe(true);
+    });
+
+    it("clearing hidden does not affect lock state", () => {
+      annotation.toggleLocked("ann-001", true);
+      annotation.toggleHidden("ann-001", true);
+      annotation.clearHidden();
+      expect(annotation.isHidden("ann-001")).toBe(false);
+      expect(annotation.isLocked("ann-001")).toBe(true);
+    });
+  });
+});

--- a/plugins/idah-video/frontend/src/lib/state/annotation.test.ts
+++ b/plugins/idah-video/frontend/src/lib/state/annotation.test.ts
@@ -173,20 +173,6 @@ describe("annotation state", () => {
       expect(annotation.isHidden(groupAnn)).toBe(true);
     });
 
-    it("isLocked prefers group_id over individual unlock when annotation id was removed", () => {
-      const groupAnn = mockRecord("ann-group-child", "group-1");
-      annotation.toggleLocked("group-1", true);
-      annotation.toggleLocked("ann-group-child", false);
-      expect(annotation.isLocked(groupAnn)).toBe(true);
-    });
-
-    it("isHidden prefers group_id over individual unhide when annotation id was removed", () => {
-      const groupAnn = mockRecord("ann-group-child", "group-1");
-      annotation.toggleHidden("group-1", true);
-      annotation.toggleHidden("ann-group-child", false);
-      expect(annotation.isHidden(groupAnn)).toBe(true);
-    });
-
     it("isLocked returns false when no group_id and id is not locked", () => {
       const standalone = mockRecord("standalone-001");
       expect(annotation.isLocked(standalone)).toBe(false);

--- a/plugins/idah-video/frontend/src/lib/state/data.svelte.ts
+++ b/plugins/idah-video/frontend/src/lib/state/data.svelte.ts
@@ -116,8 +116,6 @@ export type AnnotationItem = {
   shape: { type: string; start: number; end: number } & Record<string, unknown>;
   value?: { category?: string; label?: string; attributes?: Record<string, unknown>; [key: string]: unknown };
   metadata?: { id: string; createdAt: Date; updatedAt: Date; metadata?: Record<string, unknown>; [key: string]: unknown };
-  hidden?: boolean;
-  locked?: boolean;
   synced?: boolean;
   [key: string]: unknown;
 };

--- a/plugins/idah-video/frontend/src/lib/toolbar/index.ts
+++ b/plugins/idah-video/frontend/src/lib/toolbar/index.ts
@@ -23,8 +23,8 @@ export function initToolbar(driver: IIdahDriverV2): void {
     modes: ["default", "idah-video:bounding-box", "idah-video:polygon", "note"],
     group: "selection",
     onClick: (() =>
-      (driver.mode === "default") ? driver.setMode("idah-video:bounding-box") :
-        driver.setMode("default")),
+      (driver.mode === "idah-video:bounding-box") ? driver.setMode("default") :
+        driver.setMode("idah-video:bounding-box")),
     whenToggled: () => driver.mode === "idah-video:bounding-box",
   });
   t.add({
@@ -33,8 +33,8 @@ export function initToolbar(driver: IIdahDriverV2): void {
     modes: ["default", "idah-video:bounding-box", "idah-video:polygon", "note"],
     group: "selection",
     onClick: (() =>
-      (driver.mode === "default") ? driver.setMode("idah-video:polygon") :
-        driver.setMode("default")),
+      (driver.mode === "idah-video:polygon") ? driver.setMode("default") :
+        driver.setMode("idah-video:polygon")),
     whenToggled: () => driver.mode === "idah-video:polygon",
   });
   t.add({

--- a/plugins/idah-video/frontend/src/lib/types.ts
+++ b/plugins/idah-video/frontend/src/lib/types.ts
@@ -78,8 +78,6 @@ export interface IVideoAnnotationRecord extends IAnnotationRecord<
   IVideoAnnotationShape,
   IVideoAnnotationValue
 > {
-  locked?: boolean;
-  hidden?: boolean;
   synced?: boolean;
 }
 


### PR DESCRIPTION
* update hidden and locked state : add this on a state file
* disable split annotation short cut if locked
* groupe hidden and split annotation , created annotaion will be hidde too
* fix resize arrow size
* can switch directly between bounding box and polygon tool. if reclick on the same tools go to default