### PR TITLE
IDAH - Polygon feature - update cursor

### DIFF
--- a/plugins/idah-video/frontend/src/lib/assets/icons/add-cursor.svg
+++ b/plugins/idah-video/frontend/src/lib/assets/icons/add-cursor.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="16" cy="16" r="6.5" fill="black" stroke="white"/>
+<circle cx="16" cy="16" r="6.5" fill="#22C55E" stroke="white"/>
 <path d="M3.19128 2.35518L13.32 6.5574L14.3365 6.9794L13.3504 7.46729L9.00661 9.61612L7.32917 13.3191L6.83091 14.4185L2.12553 1.91311L3.19128 2.35518Z" fill="black" stroke="white"/>
 <path d="M17 15H20V17H17V20H15V17H12V15H15V12H17V15Z" fill="white"/>
 </svg>

--- a/plugins/idah-video/frontend/src/lib/assets/icons/add-cursor.svg
+++ b/plugins/idah-video/frontend/src/lib/assets/icons/add-cursor.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <circle cx="16" cy="16" r="6.5" fill="black" stroke="white"/>
 <path d="M3.19128 2.35518L13.32 6.5574L14.3365 6.9794L13.3504 7.46729L9.00661 9.61612L7.32917 13.3191L6.83091 14.4185L2.12553 1.91311L3.19128 2.35518Z" fill="black" stroke="white"/>
-<rect x="20" y="15" width="2" height="8" transform="rotate(90 20 15)" fill="white"/>
+<path d="M17 15H20V17H17V20H15V17H12V15H15V12H17V15Z" fill="white"/>
 </svg>

--- a/plugins/idah-video/frontend/src/lib/assets/icons/remove-cursor.svg
+++ b/plugins/idah-video/frontend/src/lib/assets/icons/remove-cursor.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="16" cy="16" r="6.5" fill="black" stroke="white"/>
+<circle cx="16" cy="16" r="6.5" fill="#EF4444" stroke="white"/>
 <path d="M3.19128 2.35518L13.32 6.5574L14.3365 6.9794L13.3504 7.46729L9.00661 9.61612L7.32917 13.3191L6.83091 14.4185L2.12553 1.91311L3.19128 2.35518Z" fill="black" stroke="white"/>
 <rect x="20" y="15" width="2" height="8" transform="rotate(90 20 15)" fill="white"/>
 </svg>

--- a/plugins/idah-video/frontend/src/lib/components/App/VideoAnnotationWorkspace/VideoAnnotationWorkspace.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/VideoAnnotationWorkspace/VideoAnnotationWorkspace.svelte
@@ -73,6 +73,22 @@
   let pendingValue: AnnotationValue = $state({});
   let annotationValue: AnnotationValue = $derived.by(() => selAnnotation?.value || pendingValue || {});
 
+  /** Whether the user can confirm the current annotation creation (has category + all required properties filled). */
+  let canConfirm = $derived.by(() => {
+    if (!editable || isNoteMode) return false;
+
+    if (mode === "entry:root") {
+      if (!pendingValue.category || pendingValue.category === "") return false;
+      const properties = getDriver().getFilteredConfig(mode, pendingValue as unknown as Record<string, unknown>)?.properties ?? [];
+      return requiredFullfilled(pendingValue, properties);
+    }
+
+    if (!shapeSelectionArgs) return false;
+    if (!pendingValue.category || pendingValue.category === "") return false;
+    const properties = getDriver().getFilteredConfig(shapeSelectionArgs[0], pendingValue as unknown as Record<string, unknown>)?.properties ?? [];
+    return requiredFullfilled(pendingValue, properties);
+  });
+
   let length = $state(0);
   let tools: {
     name: string;
@@ -510,7 +526,6 @@
       onkeydown={(e) => {
         if (e.key === "Enter" && !e.shiftKey) {
           e.preventDefault();
-          const canConfirm = shapeSelectionArgs !== undefined || mode === "entry:root";
           if (!canConfirm) return;
           showPopOver = false;
           if (mode === "entry:root") {
@@ -576,10 +591,10 @@
                 onShapeSelection("entry:root", viewport.video.currentFrame.value);
                 break;
               default:
-                if (shapeSelectionArgs) confirmCreateAnnotation(...shapeSelectionArgs);
+                if (shapeSelectionArgs && pendingValue.category) confirmCreateAnnotation(...shapeSelectionArgs);
             }
           }}
-          disabled={shapeSelectionArgs == undefined && "entry:root" != mode}
+          disabled={!canConfirm}
         >
           Confirm
         </Button>

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/BBoxShape.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/BBoxShape.svelte
@@ -367,7 +367,7 @@
     fill={color}
     fill-opacity={selected ? 0.6 : 0.3}
     stroke={color.replace("0.5", "1")}
-    stroke-width={selected ? 3 : 1.5}
+    stroke-width={selected ? 1.5 : 1}
     style:transform-origin="{displayCentroid[0] * w}px {displayCentroid[1] * h}px"
     style:transform="rotate({currentAngle()}rad)"
     vector-effect="non-scaling-stroke"

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/BoundingBox/_BBoxHandler.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/BoundingBox/_BBoxHandler.svelte
@@ -75,9 +75,9 @@
   });
 
   // ── Sizes (scaled by invScale) ────────────────────────────────────────
-  let R = $derived(7 * invScale); // outer visible handle radius
-  let R_hovered = $derived(9 * invScale); // hover-expanded radius
-  let R_hit = $derived(10 * invScale); // interactive hit zone radius
+  let R = $derived(6 * invScale); // outer visible handle radius
+  let R_hovered = $derived(8 * invScale); // hover-expanded radius
+  let R_hit = $derived(8 * invScale); // interactive hit zone radius
   let R_center_dot = $derived(2.5 * invScale);
   let R_rotate = $derived(7 * invScale);
   let R_rotate_hovered = $derived(9 * invScale);

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/Polygon/_PolygonHandler.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/Polygon/_PolygonHandler.svelte
@@ -5,8 +5,10 @@
   import { polygonVertexHandles, polygonEdgeMidpoints, polygonCentroid, scaleCursorSVG } from "./utils";
   import BoxSelector from "./_BoxSelector.svelte";
   import removeCursorSvg from "$lib/assets/icons/remove-cursor.svg?raw";
+  import addCursorSvg from "$lib/assets/icons/add-cursor.svg?raw";
 
   const removeCursorCss = `url("data:image/svg+xml,${encodeURIComponent(removeCursorSvg)}") 2 2,pointer`;
+  const addCursorCss = `url("data:image/svg+xml,${encodeURIComponent(addCursorSvg)}") 2 2,pointer`;
 
   type Props = {
     vertices: Point[];
@@ -85,7 +87,7 @@
     points={`${cx},${cy - R_edge_hit} ${cx + R_edge_hit},${cy} ${cx},${cy + R_edge_hit} ${cx - R_edge_hit},${cy}`}
     fill="transparent"
     style:outline="none"
-    style:cursor={isEditing ? "default" : "copy"}
+    style:cursor={isEditing ? "default" : addCursorCss}
     onmouseenter={() => (hoveredEdgeIndex = i)}
     onmouseleave={() => (hoveredEdgeIndex = undefined)}
     onmousedown={(e) => { e.stopPropagation(); onAddVertex(i); }}

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/Polygon/_PolygonHandler.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/Polygon/_PolygonHandler.svelte
@@ -51,7 +51,7 @@
   let R = $derived(6 * invScale);
   let R_hovered = $derived(8 * invScale);
   let R_hit = $derived(8 * invScale);
-  let R_edge = $derived(4 * invScale);
+  let R_edge = $derived(3 * invScale);
   let R_edge_hovered = $derived(6 * invScale);
   let R_edge_hit = $derived(8 * invScale);
   let R_dot = $derived(2 * invScale);
@@ -77,9 +77,7 @@
   <polygon
     points={`${cx},${cy - r} ${cx + r},${cy} ${cx},${cy + r} ${cx - r},${cy}`}
     fill="grey"
-    fill-opacity={isHovered ? 0.5 : 0.2}
-    stroke="grey"
-    stroke-width={S_line}
+    stroke="white"
     stroke-linejoin="round"
     pointer-events="none"
   />
@@ -99,6 +97,15 @@
   {@const isHovered = hoveredVertexIndex === i}
   {@const isSelected = selectedIndices.has(i)}
   {@const curR = isHovered || isSelected ? R_hovered : R}
+  <!-- White halo for contrast → expands on hover -->
+  <circle
+    cx={point[0] * w}
+    cy={point[1] * h}
+    r={isHovered ? R_hovered : R_hit}
+    fill="white"
+    fill-opacity={isHovered ? 0.8 : 0.6}
+    pointer-events="none"
+  />
   <circle
     cx={point[0] * w}
     cy={point[1] * h}

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/Polygon/_PolygonHandler.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/Polygon/_PolygonHandler.svelte
@@ -58,10 +58,10 @@
   let S_line = $derived(2 * invScale);
 
   // Scale handle sizes
-  let R_scale = $derived(7 * invScale);
-  let R_scale_hovered = $derived(9 * invScale);
-  let R_scale_hit = $derived(10 * invScale);
-  let R_scale_dot = $derived(2.5 * invScale);
+  let R_scale = $derived(6 * invScale);
+  let R_scale_hovered = $derived(8 * invScale);
+  let R_scale_hit = $derived(8 * invScale);
+  let R_scale_dot = $derived(2 * invScale);
 
   let vertexHandles = $derived(polygonVertexHandles(vertices));
   let edgeMidpoints = $derived(polygonEdgeMidpoints(vertices));
@@ -164,6 +164,15 @@
 {/each}
 
 <!-- Scale handle at centroid -->
+  <!-- White halo for contrast → expands on hover -->
+<circle
+  cx={centroid[0] * w}
+  cy={centroid[1] * h}
+  r={hoveredScale ? R_scale_hovered : R_scale_hit}
+  fill="white"
+  fill-opacity={hoveredScale ? 0.8 : 0.6}
+  pointer-events="none"
+/>
 <circle
   cx={centroid[0] * w}
   cy={centroid[1] * h}
@@ -187,7 +196,7 @@
   r={R_scale_hit}
   fill="transparent"
   style:outline="none"
-  style:cursor={isEditing ? "none" : `url('${scaleCursorSVG(color)}') 18 18, nesw-resize`}
+  style:cursor={isEditing ? "none" : `url('${scaleCursorSVG("black")}') 18 18, nesw-resize`}
   onmouseenter={() => (hoveredScale = true)}
   onmouseleave={() => (hoveredScale = false)}
   onmousedown={(e) => { e.stopPropagation(); onStartScale(); }}

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/Polygon/utils.ts
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/Polygon/utils.ts
@@ -140,7 +140,7 @@ export function nearFirstPolygonPoint(
 /** SVG data URL for a dot sight crosshair cursor (crosshair with a central dot). */
 export function scaleCursorSVG(color: string): string {
   return `data:image/svg+xml;base64,${btoa(`
-    <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 24 24" fill="none">
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
       <circle cx="12" cy="12" r="2" fill="${color}"/>
       <line x1="12" y1="3" x2="12" y2="9" stroke="${color}" stroke-width="1.5" stroke-linecap="round"/>
       <line x1="12" y1="15" x2="12" y2="21" stroke="${color}" stroke-width="1.5" stroke-linecap="round"/>

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/PolygonCreateShape.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/PolygonCreateShape.svelte
@@ -13,6 +13,7 @@
   import type { Point } from "$lib/utils/math/point";
   import { draft as polygonDraft } from "$lib/commands/annotation/polygon.add_point.svelte";
   import { getDriver } from "$lib/state/driver.svelte";
+  import { viewport } from "$lib/state/viewport.svelte";
   import { nearFirstPolygonPoint } from "./Polygon/utils";
 
   // ── Props ──────────────────────────────────────────────────────────────
@@ -25,6 +26,11 @@
   };
 
   let { cursor, mediaWidth, mediaHeight, frame, onSelection }: Props = $props();
+
+  // Keep points at fixed screen size regardless of zoom
+  let invScale = $derived(1 / viewport.workspace.transform.scale);
+  let R_vertex = $derived(5 * invScale);
+  let R_ring = $derived(8 * invScale);
 
   // ── Exported mouse handler ────────────────────────────────────────────
   /**
@@ -68,7 +74,7 @@
     fill="none"
     stroke="rgba(246, 64, 43, 0.8)"
     stroke-width="2"
-    stroke-dasharray="4,2"
+    stroke-dasharray="6,3"
     vector-effect="non-scaling-stroke"
   />
 
@@ -79,8 +85,8 @@
     x2={cursorPos[0] * mediaWidth}
     y2={cursorPos[1] * mediaHeight}
     stroke="rgba(246, 64, 43, 0.4)"
-    stroke-width="1.5"
-    stroke-dasharray="3,3"
+    stroke-width="2"
+    stroke-dasharray="6,3"
     vector-effect="non-scaling-stroke"
   />
 
@@ -89,7 +95,7 @@
     <circle
       cx={p[0] * mediaWidth}
       cy={p[1] * mediaHeight}
-      r={4}
+      r={R_vertex}
       fill="rgba(246, 64, 43, 0.9)"
       stroke="white"
       stroke-width="1.5"
@@ -101,7 +107,7 @@
   <circle
     cx={pts[0][0] * mediaWidth}
     cy={pts[0][1] * mediaHeight}
-    r={6}
+    r={R_ring}
     fill="none"
     stroke="rgba(246, 64, 43, 0.9)"
     stroke-width="2"

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/PolygonShape.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/PolygonShape.svelte
@@ -252,7 +252,7 @@
     fill={color}
     fill-opacity={selected ? 0.6 : 0.3}
     stroke={color.replace("0.5", "1")}
-    stroke-width={selected ? 3 : 1.5}
+    stroke-width={selected ? 1.5 : 1}
     vector-effect="non-scaling-stroke"
     style:outline="none"
     onmouseenter={() => (over = true)}


### PR DESCRIPTION
Polygon
* change  imaginary point to a solid point to make it more different from other points.
* When creating polygon, its border and points are smaller
* update add and removed cursor
Bounding Box
* Change the point styling to be the same as Polygon
* When the bounding box is selected, its border is same as when not selected 

Both 
- When creating a new annotation (by clicking a tool from top bar), the Properties are not yet validated. Now I can create annotation without entering required properties.
- When selecting the tool (not category) to create annotation, I can still create it without selecting a category.