### PR TITLE
Properties sidebar improvements - extended

### DIFF
--- a/plugins/idah-video/frontend/src/lib/commands/annotation/delete.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/delete.ts
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------------
+// annotation.delete — Delete a specific annotation
+// Undoable: restores the annotation.
+//
+// Usage:
+//   driver.command.call("annotation.delete", {
+//     annotationId: "some-id"
+//   });
+// ---------------------------------------------------------------------------
+import { data, type AnnotationItem } from "$lib/state/data.svelte";
+import { selection } from "$lib/state/selection.svelte";
+import type { IIdahDriverV2 } from "$idah/v2/types";
+import { noopAction } from "..";
+
+export const command = {
+  name: "annotation.delete",
+  group: undefined,
+  modes: [] as string[],
+  shortcut: null,
+  shortDescription: null,
+  longDescription: null,
+};
+
+export interface AnnotationDeleteProps {
+  annotationId: string;
+}
+
+export function register(driver: IIdahDriverV2): void {
+  driver.command.register({
+    name: command.name,
+    modes: command.modes,
+    shortcut: command.shortcut,
+    shortDescription: command.shortDescription,
+    longDescription: command.longDescription,
+    callback: (opts?: Record<string, unknown>) => {
+      const props = opts as unknown as AnnotationDeleteProps | undefined;
+      if (!props || !props.annotationId || !data.annotations) return noopAction(command);
+
+      const record = data.annotations.items.find((a) => a.id === props.annotationId) as AnnotationItem;
+      if (!record) return noopAction(command);
+
+      return {
+        command: { ...command },
+        async do() {
+          const sel = selection.value;
+          if (sel?.type === "annotation" && (sel.annotation as AnnotationItem).id === props.annotationId) {
+            selection.deselect();
+          }
+
+          await data.annotations!.delete(props.annotationId);
+        },
+        async undo() {
+          if (!data.annotations) return;
+          await data.annotations!.create({ ...record, id: record.id });
+        },
+        isCombinable() { return false; },
+        combine(p) { return p; },
+      };
+    },
+    group: command.group,
+  });
+}

--- a/plugins/idah-video/frontend/src/lib/commands/annotation/delete.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/delete.ts
@@ -8,7 +8,7 @@
 //   });
 // ---------------------------------------------------------------------------
 import { data, type AnnotationItem } from "$lib/state/data.svelte";
-import { selection } from "$lib/state/selection.svelte";
+import { selection, type IAnnotationSelection } from "$lib/state/selection.svelte";
 import type { IIdahDriverV2 } from "$idah/v2/types";
 import { noopAction } from "..";
 
@@ -42,8 +42,8 @@ export function register(driver: IIdahDriverV2): void {
       return {
         command: { ...command },
         async do() {
-          const sel = selection.value;
-          if (sel?.type === "annotation" && (sel.annotation as AnnotationItem).id === props.annotationId) {
+          const sel = selection.value as IAnnotationSelection;
+          if (selection.isAnnotation() && sel.annotation.id === props.annotationId) {
             selection.deselect();
           }
 

--- a/plugins/idah-video/frontend/src/lib/commands/annotation/updateGroupCategory.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/updateGroupCategory.ts
@@ -38,10 +38,10 @@ export function register(driver: IIdahDriverV2): void {
       const props = opts as unknown as UpdateGroupCategoryProps | undefined;
       if (!props || !data.annotations) return noopAction(command);
 
-      // Find all annotations in this group by checking metadata.group_id
+      // Find all annotations in this group by checking metadata.group_id (with id fallback)
       const allItems = data.annotations.items;
       const groupAnnotations = allItems.filter(
-        (ann) => (ann as any).metadata?.group_id === props.groupId
+        (ann) => ((ann as any).metadata?.group_id ?? ann.id) === props.groupId
       );
 
       if (groupAnnotations.length === 0) return noopAction(command);

--- a/plugins/idah-video/frontend/src/lib/commands/index.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/index.ts
@@ -52,6 +52,7 @@ import { register as registerNoteAdd } from "./note/add";
 import { register as registerNoteGoto } from "./note/goto";
 
 import { register as registerAnnotationAdd } from "./annotation/add";
+import { register as registerAnnotationDelete } from "./annotation/delete";
 import { register as registerAnnotationDeleteAll } from "./annotation/delete_all";
 import { register as registerAnnotationExtendNext } from "./annotation/extend_next";
 import { register as registerAnnotationExtendPrev } from "./annotation/extend_prev";
@@ -118,6 +119,7 @@ export function registerAllCommands(driver: IIdahDriverV2): void {
 
   // ── Annotation ────────────────────────────────────────────────────────
   registerAnnotationAdd(driver);
+  registerAnnotationDelete(driver);
   registerAnnotationDeleteAll(driver);
   registerAnnotationToggleVisibilityAll(driver);
   registerAnnotationToggleEditabilityAll(driver);

--- a/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/PropertiesCategorySelector.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/PropertiesCategorySelector.svelte
@@ -13,7 +13,7 @@
 
   // Props
   let {
-    sidebarWidthRem = 15,
+    sidebarWidthRem = 20,
     annotationId,
     annotationValue,
     onEditValue,

--- a/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
@@ -195,8 +195,7 @@
         icon: Trash2Icon,
         onclick: (e: MouseEvent) => {
           e.stopPropagation();
-          selection.selectAnnotation(ann);
-          getDriver().command.call("selection.delete", {});
+          getDriver().command.call("annotation.delete", { annotationId: ann.id });
         }
       }
     ];

--- a/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
@@ -6,15 +6,12 @@
   import Badge from "$lib/components/ui/Badge/Badge.svelte";
   import Icon from "$lib/components/ui/Icon";
 
-  import { EyeIcon, EyeOffIcon, LockIcon, LockOpenIcon, Trash2Icon } from "@lucide/svelte";
+  import { CrosshairIcon, Trash2Icon } from "@lucide/svelte";
 
   import polygonIconSvg from "$lib/assets/icons/polygon.svg?raw";
   import vectorSquareIconSvg from "$lib/assets/icons/vector-square.svg?raw";
 
-  import ToolTooltip from "$lib/components/ui/Tooltips/ToolTooltip.svelte";
-  import Button from "$lib/components/ui/Button/Button.svelte";
-
-  import { cn } from "$lib/utils";
+  import CategoryAction from "$lib/components/App/CategorySelector/Category/_CategoryAction.svelte";
 
   import BooleanProperty from "$lib/components/App/SelectionPanel/Properties/_BooleanProperty.svelte";
   import IntegerProperty from "$lib/components/App/SelectionPanel/Properties/_IntegerProperty.svelte";
@@ -182,6 +179,28 @@
     onReSelectCategory?.(reselectedCategoryId);
   }
 
+  function getAnnotationActions(ann: IVideoAnnotationRecord) {
+    return [
+      {
+        label: "Focus",
+        icon: CrosshairIcon,
+        onclick: (e: MouseEvent) => {
+          e.stopPropagation();
+          selection.selectAnnotation(ann);
+          getDriver().command.call("timeline.focus");
+        }
+      },
+      {
+        label: "Delete",
+        icon: Trash2Icon,
+        onclick: (e: MouseEvent) => {
+          e.stopPropagation();
+          selection.selectAnnotation(ann);
+          getDriver().command.call("selection.delete", {});
+        }
+      }
+    ];
+  }
 </script>
 
 {#snippet shapeIcon(color: string | null | undefined)}
@@ -240,10 +259,8 @@
       <div class="flex items-center gap-2">
         <Text weight="semibold">Annotations</Text>
         <Badge variant="secondary">{currentFrameAnnotations.length}</Badge>
+        <Text size="sm" class="text-muted-foreground ml-auto">on Frame: {currentFrame + 1}</Text>
       </div>
-      <Text size="sm" class="text-muted-foreground">
-        on Frame: {currentFrame}
-      </Text>
       <div class="flex flex-col gap-1">
       <Separator class="my-2" />
 {#each currentFrameAnnotations as ann (ann.id)}
@@ -254,6 +271,7 @@
   {@const annGroupId = ann.metadata?.group_id ?? ann.id}
   {@const annGroupIdLastPart = annGroupId.split("-").pop()}
   {@const annDisplayName = annCategory ? `${annCategory.label}-${annGroupIdLastPart}` : (ann.value?.category ?? "Uncategorized")}
+  {@const annParentLabel = annCategory ? categoryValueToLabel(annCategory.id) : ""}
   <div class="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs hover:bg-accent">
     <button
       class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left"
@@ -264,77 +282,23 @@
       {:else}
         <Icon src={vectorSquareIconSvg} color={annColor} />
       {/if}
-      <span class="truncate">{annDisplayName}</span>
+      <div class="flex flex-col min-w-0">
+        {#if annParentLabel.length > 0}
+          <span class="text-xs text-muted-foreground truncate">{annParentLabel}</span>
+        {/if}
+        <span class="truncate">{annDisplayName}</span>
+      </div>
     </button>
 
     <div class="ml-auto flex shrink-0 items-center gap-0">
-      <!-- BUTTON::HIDE/SHOW -->
-      <div class={cn("", ann.hidden ? "flex" : "hidden group-hover:flex")}>
-        <ToolTooltip label={"Hide / Show"}>
-          {#snippet trigger()}
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              onclick={(e: MouseEvent) => {
-                e.stopPropagation();
-                getDriver().command.call("annotation.update", {
-                  annotation: ann,
-                  value: { hidden: !ann.hidden },
-                });
-              }}
-            >
-              {#if ann.hidden}
-                <EyeOffIcon />
-              {:else}
-                <EyeIcon />
-              {/if}
-            </Button>
-          {/snippet}
-        </ToolTooltip>
-      </div>
-
-      <!-- BUTTON::LOCK/UNLOCK -->
-      <div class={cn("", ann.locked ? "flex" : "hidden group-hover:flex")}>
-        <ToolTooltip label={"Lock / Unlock"}>
-          {#snippet trigger()}
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              onclick={(e: MouseEvent) => {
-                e.stopPropagation();
-                getDriver().command.call("annotation.update", {
-                  annotation: ann,
-                  value: { locked: !ann.locked },
-                });
-              }}
-            >
-              {#if ann.locked}
-                <LockIcon />
-              {:else}
-                <LockOpenIcon />
-              {/if}
-            </Button>
-          {/snippet}
-        </ToolTooltip>
-      </div>
-
-      <!-- BUTTON::DELETE -->
-      <div class="hidden group-hover:flex">
-        <ToolTooltip label="Delete">
-          {#snippet trigger()}
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              onclick={(e: MouseEvent) => {
-                e.stopPropagation();
-                getDriver().command.call("annotation.delete", { annotationId: ann.id });
-              }}
-            >
-              <Trash2Icon />
-            </Button>
-          {/snippet}
-        </ToolTooltip>
-      </div>
+      {#each getAnnotationActions(ann) as { label, icon: Icon, onclick }}
+        <CategoryAction
+          {label}
+          icon={Icon}
+          onclick={(e) => onclick(e)}
+          class = "opacity-0 group-hover:opacity-100 transition-opacity"
+        />
+      {/each}
     </div>
   </div>
 {/each}

--- a/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
@@ -241,7 +241,11 @@
         <Text weight="semibold">Annotations</Text>
         <Badge variant="secondary">{currentFrameAnnotations.length}</Badge>
       </div>
+      <Text size="sm" class="text-muted-foreground">
+        on Frame: {currentFrame}
+      </Text>
       <div class="flex flex-col gap-1">
+      <Separator class="my-2" />
 {#each currentFrameAnnotations as ann (ann.id)}
   {@const annShapeType = ann.shape.type as string}
   {@const annConfig = getDriver().config[annShapeType]}
@@ -266,7 +270,7 @@
     <div class="ml-auto flex shrink-0 items-center gap-0">
       <!-- BUTTON::HIDE/SHOW -->
       <div class={cn("", ann.hidden ? "flex" : "hidden group-hover:flex")}>
-        <ToolTooltip label={ann.hidden ? "Show" : "Hide"}>
+        <ToolTooltip label={"Hide / Show"}>
           {#snippet trigger()}
             <Button
               variant="ghost"
@@ -291,7 +295,7 @@
 
       <!-- BUTTON::LOCK/UNLOCK -->
       <div class={cn("", ann.locked ? "flex" : "hidden group-hover:flex")}>
-        <ToolTooltip label={ann.locked ? "Unlock" : "Lock"}>
+        <ToolTooltip label={"Lock / Unlock"}>
           {#snippet trigger()}
             <Button
               variant="ghost"
@@ -336,7 +340,6 @@
 {/each}
       </div>
     </section>
-    <Separator class="my-2" />
   {/if}
 
   {#if config}

--- a/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
@@ -259,7 +259,7 @@
       <div class="flex items-center gap-2">
         <Text weight="semibold">Annotations</Text>
         <Badge variant="secondary">{currentFrameAnnotations.length}</Badge>
-        <Text size="sm" class="text-muted-foreground ml-auto">on Frame: {currentFrame + 1}</Text>
+        <Text size="sm" class="text-muted-foreground ml-auto">on Frame : {currentFrame + 1}</Text>
       </div>
       <div class="flex flex-col gap-1">
       <Separator class="my-2" />

--- a/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
@@ -182,7 +182,7 @@
   function getAnnotationActions(ann: IVideoAnnotationRecord) {
     return [
       {
-        label: "Focus",
+        label: "Focus Annotation",
         icon: CrosshairIcon,
         onclick: (e: MouseEvent) => {
           e.stopPropagation();
@@ -191,7 +191,7 @@
         }
       },
       {
-        label: "Delete",
+        label: "Delete Annotation",
         icon: Trash2Icon,
         onclick: (e: MouseEvent) => {
           e.stopPropagation();

--- a/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
@@ -295,7 +295,7 @@
         <CategoryAction
           {label}
           icon={Icon}
-          onclick={(e) => onclick(e)}
+          {onclick}
           class = "opacity-0 group-hover:opacity-100 transition-opacity"
         />
       {/each}

--- a/plugins/idah-video/frontend/src/lib/components/App/VideoAnnotationWorkspace/VideoAnnotationWorkspace.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/VideoAnnotationWorkspace/VideoAnnotationWorkspace.svelte
@@ -279,6 +279,12 @@
     } else if (selAnnotation) {
       selection.selectAnnotation({ ...selAnnotation, value: annotationValue } as any);
       if (requirementFullfilled) updateAnnotationValue($state.snapshot(selAnnotation), $state.snapshot(value));
+    } else if (selGroup) {
+      // Update category for all annotations in the group
+      getDriver().command.call("annotation.updateGroupCategory", {
+        groupId: selGroup.groupId,
+        categoryIdToBeUpdate: value.category,
+      });
     } else if (valueMode !== "entry:root") {
       // Sidebar category click: store category and enter drawing mode
       pendingValue = value;
@@ -481,23 +487,7 @@
   }
 
   async function reSelectCategory(reselectedCategoryId: string) {
-    if (selGroup) {
-      // Update category for all annotations in the group
-      getDriver().command.call("annotation.updateGroupCategory", {
-        groupId: selGroup.groupId,
-        categoryIdToBeUpdate: reselectedCategoryId,
-      });
-    } else if (selAnnotation) {
-      // Update category for a single annotation
-      getDriver().command.call("annotation.update", {
-        annotation: selAnnotation,
-        value: { category: reselectedCategoryId },
-      });
-    } else {
-      return;
-    }
-
-    // Update the currently selected annotation value to reflect the category change in the properties sidebar
+    // onEditValue handles the update for both selAnnotation and selGroup cases
     onEditValue({ category: reselectedCategoryId }, mode);
   }
 </script>

--- a/plugins/idah-video/frontend/src/lib/components/App/VideoAnnotationWorkspace/VideoAnnotationWorkspace.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/VideoAnnotationWorkspace/VideoAnnotationWorkspace.svelte
@@ -221,7 +221,7 @@
 
   async function removeAnnotation(annotationId: string) {
     if (!editable) return;
-    getDriver().command.call("selection.delete", { annotationId });
+    getDriver().command.call("annotation.delete", { annotationId });
   }
 
   async function addSelection(id: string, selection: IVideoFrameSelection) {


### PR DESCRIPTION
Improvements
- [x] When nothing is selected, display all visible annotations of the current frame
  - [x] add minor details like current frame, root category name, etc.
- [x] Delete/hide/lock on annotation list
  - [x] recheck functionality once annotation state is handled
- ~Utilise showConfirmDialog for delete~

Bugs/Issues
- [x] When selecting annotation group in timeline, Category dropdown is empty and Cannot edit category for entire group.