### PR TITLE
Timeline fixes & improvements

### DIFF
--- a/plugins/idah-video/frontend/src/lib/commands/annotation/split.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/split.ts
@@ -14,7 +14,7 @@
 // Shortcut: S
 // Active only when there's a selected annotation.
 // ---------------------------------------------------------------------------
-import type { IIdahDriverV2 } from "$idah/v2/types";
+import type { IAnnotationRecord, IIdahDriverV2 } from "$idah/v2/types";
 import type { AnnotationItem } from "$lib/state/data.svelte";
 import { data } from "$lib/state/data.svelte";
 import { selection } from "$lib/state/selection.svelte";
@@ -37,11 +37,6 @@ export interface AnnotationSplitProps {
   at: number;
 }
 
-function isAnnotationSelected(): boolean {
-  const sel = selection.value;
-  return !!sel && sel.type === "annotation";
-}
-
 export function register(driver: IIdahDriverV2): void {
   driver.command.register({
     name: command.name,
@@ -60,8 +55,12 @@ export function register(driver: IIdahDriverV2): void {
         at = props.at;
       } else {
         // Shortcut invocation — derive from current selection and viewport
-        const sel = selection.value;
-        if (sel && sel.type === "annotation") {
+        if (selection.hasSelection() && selection.isAnnotation()) {
+          const sel = selection.value as {
+            type: "annotation";
+            annotation: IAnnotationRecord<Record<string, unknown>, Record<string, unknown>>;
+          };
+
           annotationId = sel.annotation.id;
           at = viewport.video.currentFrame.value;
         }
@@ -161,6 +160,6 @@ export function register(driver: IIdahDriverV2): void {
       };
     },
     group: command.group,
-    activeWhen: isAnnotationSelected,
+    activeWhen: selection.hasSelection,
   });
 }

--- a/plugins/idah-video/frontend/src/lib/commands/annotation/split.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/split.ts
@@ -17,7 +17,7 @@
 import type { IAnnotationRecord, IIdahDriverV2 } from "$idah/v2/types";
 import type { AnnotationItem } from "$lib/state/data.svelte";
 import { data } from "$lib/state/data.svelte";
-import { selection } from "$lib/state/selection.svelte";
+import { selection, type IAnnotationSelection } from "$lib/state/selection.svelte";
 import { viewport } from "$lib/state/viewport.svelte";
 import type { IVideoAnnotationShape, IVideoFrameSelection } from "$lib/types";
 import { getInterpolatedFrame } from "$lib/utils/interpolation";
@@ -56,10 +56,7 @@ export function register(driver: IIdahDriverV2): void {
       } else {
         // Shortcut invocation — derive from current selection and viewport
         if (selection.isAnnotation()) {
-          const sel = selection.value as {
-            type: "annotation";
-            annotation: IAnnotationRecord<Record<string, unknown>, Record<string, unknown>>;
-          };
+          const sel = selection.value as IAnnotationSelection;
 
           annotationId = sel.annotation.id;
           at = viewport.video.currentFrame.value;

--- a/plugins/idah-video/frontend/src/lib/commands/annotation/split.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/split.ts
@@ -55,7 +55,7 @@ export function register(driver: IIdahDriverV2): void {
         at = props.at;
       } else {
         // Shortcut invocation — derive from current selection and viewport
-        if (selection.hasSelection() && selection.isAnnotation()) {
+        if (selection.isAnnotation()) {
           const sel = selection.value as {
             type: "annotation";
             annotation: IAnnotationRecord<Record<string, unknown>, Record<string, unknown>>;
@@ -160,6 +160,6 @@ export function register(driver: IIdahDriverV2): void {
       };
     },
     group: command.group,
-    activeWhen: selection.hasSelection,
+    activeWhen: selection.isAnnotation,
   });
 }

--- a/plugins/idah-video/frontend/src/lib/commands/group/delete.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/group/delete.ts
@@ -63,15 +63,13 @@ export function register(driver: IIdahDriverV2): void {
       return {
         command: { ...command },
         async do() {
-          for (const ann of snapshot) {
-            await data.annotations!.delete(ann.id);
-          }
+          const deletions = snapshot.map((ann) => data.annotations!.delete(ann.id));
+          await Promise.all(deletions);
         },
         async undo() {
           if (!data.annotations) return;
-          for (const ann of snapshot) {
-            await data.annotations!.create({ ...ann, id: ann.id });
-          }
+          const creations = snapshot.map((ann) => data.annotations!.create({ ...ann, id: ann.id }));
+          await Promise.all(creations);
         },
         isCombinable() {
           return false;

--- a/plugins/idah-video/frontend/src/lib/commands/index.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/index.ts
@@ -71,6 +71,7 @@ import { register as registerToggleDebugConsole } from "./display/toggle-debug-c
 import { register as registerToggleRenderMode } from "./display/toggle-render-mode";
 import { register as registerToggleTimeDisplay } from "./display/toggle-time-display";
 import { register as registerTimelineFocus } from "./timeline/focus";
+import { register as registerTimelineScrollToAnnotation } from "./timeline/scroll-to-annotation";
 import { register as registerTimelineZoomIn } from "./timeline/zoom-in";
 import { register as registerTimelineZoomOut } from "./timeline/zoom-out";
 
@@ -137,6 +138,7 @@ export function registerAllCommands(driver: IIdahDriverV2): void {
 
   // ── UI / Display ─────────────────────────────────────────────────────
   registerTimelineFocus(driver);
+  registerTimelineScrollToAnnotation(driver);
   registerTimelineZoomIn(driver);
   registerTimelineZoomOut(driver);
   registerToggleColorMode(driver);

--- a/plugins/idah-video/frontend/src/lib/commands/timeline/focus.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/timeline/focus.ts
@@ -84,16 +84,10 @@ export function register(driver: IIdahDriverV2): void {
       return {
         command: command as any,
         do() {
-          const handler = viewport.timeline._focusHandler;
-          if (handler) {
-            handler(Math.max(0, start - margin), end + margin);
-          } else {
-            // Fallback if Timeline hasn't mounted yet
-            viewport.timeline.range = {
-              startRange: Math.max(0, start - margin),
-              endRange: end + margin,
-            };
-          }
+          viewport.timeline.range = {
+            startRange: Math.max(0, start - margin),
+            endRange: end + margin,
+          };
         },
         isCombinable() {
           return false;

--- a/plugins/idah-video/frontend/src/lib/commands/timeline/scroll-to-annotation.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/timeline/scroll-to-annotation.ts
@@ -59,7 +59,7 @@ export function register(driver: IIdahDriverV2): void {
       }
 
       const { startRange, endRange } = viewport.timeline.range;
-      const margin = Math.max(10, Math.round((shape.end - shape.start) * 0.1));
+      const margin = Math.max(1, Math.round((endRange - startRange) * 0.1));
       const newStart = Math.max(0, shape.start - margin);
       const rangeWidth = endRange - startRange;
       const newEnd = newStart + rangeWidth;

--- a/plugins/idah-video/frontend/src/lib/commands/timeline/scroll-to-annotation.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/timeline/scroll-to-annotation.ts
@@ -1,0 +1,84 @@
+// ---------------------------------------------------------------------------
+// timeline.scroll_to_annotation — Pan the timeline to reveal the selected
+// annotation's start frame at the current zoom level.
+//
+// Shifts the viewport so the annotation's start frame sits ~10 frames from
+// the left edge. The visible range width (scale) is preserved unchanged.
+// The start is clamped to 0 when the margin would make it negative.
+// ---------------------------------------------------------------------------
+import { selection, type IAnnotationSelection } from "$lib/state/selection.svelte";
+import { viewport } from "$lib/state/viewport.svelte";
+import type { IIdahDriverV2, ICommandAction } from "$idah/v2/types";
+import type { IVideoAnnotationShape } from "$lib/types";
+
+export const command = {
+  name: "timeline.scroll_to_annotation",
+  group: "Timeline",
+  modes: ["default", "review"],
+  shortcut: null,
+  shortDescription: "Scroll timeline to annotation",
+  longDescription: "Pan the timeline to show the selected annotation's start frame without changing the zoom level",
+};
+
+export function register(driver: IIdahDriverV2): void {
+  driver.command.register({
+    name: command.name,
+    modes: command.modes,
+    shortcut: command.shortcut,
+    shortDescription: command.shortDescription,
+    longDescription: command.longDescription,
+    callback: (): ICommandAction => {
+      const sel = selection.value as IAnnotationSelection;
+
+      if (!selection.isAnnotation()) {
+        return {
+          command: command as any,
+          do() {},
+          isCombinable() {
+            return false;
+          },
+          combine(p: any) {
+            return p;
+          },
+        };
+      }
+
+      const shape = sel.annotation.shape as IVideoAnnotationShape | undefined;
+
+      if (!shape) {
+        return {
+          command: command as any,
+          do() {},
+          isCombinable() {
+            return false;
+          },
+          combine(p: any) {
+            return p;
+          },
+        };
+      }
+
+      const { startRange, endRange } = viewport.timeline.range;
+      const rangeWidth = endRange - startRange;
+      const newStart = Math.max(0, shape.start - 10);
+      const newEnd = newStart + rangeWidth;
+
+      return {
+        command: command as any,
+        do() {
+          viewport.timeline.range = {
+            startRange: newStart,
+            endRange: newEnd,
+          };
+        },
+        isCombinable() {
+          return false;
+        },
+        combine(p: any) {
+          return p;
+        },
+      };
+    },
+    group: command.group,
+  });
+}

--- a/plugins/idah-video/frontend/src/lib/commands/timeline/scroll-to-annotation.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/timeline/scroll-to-annotation.ts
@@ -59,8 +59,9 @@ export function register(driver: IIdahDriverV2): void {
       }
 
       const { startRange, endRange } = viewport.timeline.range;
+      const margin = Math.max(10, Math.round((shape.end - shape.start) * 0.1));
+      const newStart = Math.max(0, shape.start - margin);
       const rangeWidth = endRange - startRange;
-      const newStart = Math.max(0, shape.start - 10);
       const newEnd = newStart + rangeWidth;
 
       return {

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/Timeline.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/Timeline.svelte
@@ -8,12 +8,14 @@
   import TrackInfo from "$lib/components/App/Timeline/_TrackInfo.svelte";
 
   import { modKey } from "$lib/utils/browser";
-  import { selection } from "$lib/state/selection.svelte";
+  import { selection, type IAnnotationSelection } from "$lib/state/selection.svelte";
   import { ui } from "$lib/state/ui.svelte";
   import { media } from "$lib/state/media.svelte";
   import { TRACK_HEIGHT } from "$lib/components/App/Timeline/constants";
+  import { getAnnotationGroupId } from "$lib/types";
 
   import type { TimelineProps, Viewport } from "$lib/components/App/Timeline/types";
+  import type { IAnnotationRecord } from "$idah/v2/types";
 
   interface Props extends TimelineProps {
     toolbar?: Snippet;
@@ -459,6 +461,31 @@
     bodyScrollTop = bodyScrollEl.scrollTop;
   }
 
+  // Scroll vertically to show the selected annotation's track.
+  // Reads bodyScrollEl.scrollTop directly (not reactive bodyScrollTop) so this effect
+  // only re-runs on selection or items changes — not on every manual scroll.
+  $effect(() => {
+    const v = selection.value;
+    handleAnnotationScroll(v as IAnnotationSelection);
+  });
+
+  function handleAnnotationScroll(selectionValue: IAnnotationSelection) {
+    if (!selection.isAnnotation() || !bodyScrollEl) return;
+
+    const groupId = getAnnotationGroupId(selectionValue.annotation);
+    const trackIndex = items.findIndex((t) => t.id === groupId);
+    if (trackIndex === -1) return;
+
+    const trackTop = trackIndex * TRACK_HEIGHT;
+    const trackBottom = trackTop + TRACK_HEIGHT;
+    const currentScrollTop = bodyScrollEl.scrollTop;
+    const currentScrollBottom = currentScrollTop + bodyScrollClientHeight;
+
+    if (trackTop >= currentScrollTop && trackBottom <= currentScrollBottom) return;
+
+    bodyScrollEl.scrollTop = Math.max(0, trackTop - bodyScrollClientHeight / 2 + TRACK_HEIGHT / 2);
+  }
+
   // Calculate tracks height for content
   const tracksHeight = $derived(items.length * TRACK_HEIGHT);
 
@@ -536,13 +563,15 @@
     onscroll={handleBodyScroll}
   >
     <div class="timeline-main">
-      <div class="timeline-trackinfos-body" onwheel={handleBodyScroll} style="height: {tracksHeight}px;">
+      <div class="timeline-trackinfos-body" style="height: {tracksHeight}px;">
         {#each visibleTracks as track (track.id)}
-          {#if TrackInfoSlot}
-            {@render TrackInfoSlot({ track })}
-          {:else}
-            <TrackInfo {track} />
-          {/if}
+          <div class="timeline-trackinfo-row" style="top: {track.top}px;">
+            {#if TrackInfoSlot}
+              {@render TrackInfoSlot({ track })}
+            {:else}
+              <TrackInfo {track} />
+            {/if}
+          </div>
         {/each}
       </div>
 
@@ -693,6 +722,12 @@
     border-right: 1px solid #ccc;
     user-select: none;
     -webkit-user-select: none;
+  }
+
+  .timeline-trackinfo-row {
+    position: absolute;
+    left: 0;
+    right: 0;
   }
 
   /* Horizontal-only scroll viewport for the tracks area.

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/Timeline.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/Timeline.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, tick, type Snippet } from "svelte";
+  import { onMount, tick, untrack, type Snippet } from "svelte";
 
   import Caret from "$lib/components/App/Timeline/_Caret.svelte";
   import Ruler from "$lib/components/App/Timeline/_Ruler.svelte";
@@ -435,6 +435,18 @@
       viewport.endRange = clampedStart + rangeWidth;
       setScrollLeft(viewport.startRange * scale);
     }
+  });
+
+  // Sync DOM scroll position when viewport range is changed externally (e.g. focus command).
+  // untrack prevents the writes to _prevStartRange from re-triggering this effect.
+  let _prevStartRange = $state(-1);
+  $effect(() => {
+    const start = viewport.startRange;
+    if (start === _prevStartRange) return;
+    untrack(() => {
+      _prevStartRange = start;
+      setScrollLeft(start * scale);
+    });
   });
 
   // Vertical virtualization: track the body-scroll element's scroll position

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/Timeline.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/Timeline.svelte
@@ -11,7 +11,6 @@
   import { selection } from "$lib/state/selection.svelte";
   import { ui } from "$lib/state/ui.svelte";
   import { media } from "$lib/state/media.svelte";
-  import { viewport as globalViewport } from "$lib/state/viewport.svelte";
   import { TRACK_HEIGHT } from "$lib/components/App/Timeline/constants";
 
   import type { TimelineProps, Viewport } from "$lib/components/App/Timeline/types";
@@ -105,7 +104,7 @@
       const w = tracksViewportEl.clientWidth;
       if (w !== containerWidth) {
         containerWidth = w;
-        if (onDimensionsChange && w > 0 && remainingHeight > 0) {
+        if (onDimensionsChange && w > 0) {
           onDimensionsChange(w, remainingHeight);
         }
       }
@@ -122,13 +121,8 @@
   function applyZoom(newZoom: number, center?: number) {
     const newRange = length / newZoom;
 
-    // // Zoom from the given center, or fall back to viewport center
-    let zoomCenter: number = (viewport.startRange + viewport.endRange) / 2;
-
-    /** Note: This lead bugs on timeline but user want to zoom at the center of the selection */
-    // if (center !== undefined) {
-    //   zoomCenter = Math.max(1, center);
-    // }
+    const zoomCenter =
+      center !== undefined ? Math.max(0, Math.min(center, length)) : (viewport.startRange + viewport.endRange) / 2;
 
     let newStart = zoomCenter - newRange / 2;
     let newEnd = zoomCenter + newRange / 2;
@@ -146,32 +140,10 @@
     viewport.endRange = newEnd;
     clampViewport();
 
-    // Sync DOM scroll positions immediately after viewport change
-    setScrollLeft(viewport.startRange * scale);
-  }
-
-  // Expose focus handler so external commands (e.g. timeline.focus)
-  // can set the viewport range with proper clamping + DOM scroll sync.
-  async function handleFocusRange(start: number, end: number) {
-    viewport.startRange = start;
-    viewport.endRange = end;
-    clampViewport();
-
-    // Wait for Svelte to re-render the DOM so the ruler/tracks content
-    // has the correct width at the new scale. Otherwise the browser
-    // clamps scrollLeft to the old scrollWidth - clientWidth.
-    await tick();
-
-    // Compute scale locally from the new range — $derived scale hasn't
-    // been re-evaluated yet at this point in the synchronous call.
-    const newRange = viewport.endRange - viewport.startRange;
-    const newScale = containerWidth > 0 ? containerWidth / newRange : 1;
+    // Compute scale locally — $derived scale hasn't re-evaluated yet at this point
+    const newScale = containerWidth > 0 ? containerWidth / (viewport.endRange - viewport.startRange) : 1;
     setScrollLeft(viewport.startRange * newScale);
   }
-
-  // Expose focus handler on the global viewport timeline so external commands
-  // (e.g. timeline.focus) can set the range with proper clamping + DOM scroll sync.
-  globalViewport.timeline._focusHandler = handleFocusRange;
 
   // Expose functions to parent on mount
   onMount(() => {

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/TimelineZoom.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/TimelineZoom.svelte
@@ -35,10 +35,12 @@
   /** Max zoom = 80px per frame. */
   const zoomMax = $derived(containerWidth > 0 ? Math.max(zoomMin, (totalFrames * 80) / containerWidth) : zoomMin);
 
-  /** Clamped display value for the slider. */
-  const displayZoom = $derived(Math.max(zoomMin, Math.min(zoomMax, currentZoom)));
-
-  const sliderValue = $derived(Math.max(zoomMin, Math.min(zoomMax, currentZoom)));
+  // Round to step precision (0.1) so bits-ui never sees an off-step value and
+  // fires an internal snap that re-triggers onValueChange after zoom.
+  const SLIDER_STEP = 0.1;
+  const sliderValue = $derived(
+    Math.round(Math.max(zoomMin, Math.min(zoomMax, currentZoom)) / SLIDER_STEP) * SLIDER_STEP,
+  );
 
   // Current frame to use as zoom center
   const currentFrame = $derived(viewport.video.currentFrame.value);
@@ -46,12 +48,12 @@
   // --- Actions ---
 
   function zoomOut() {
-    const newZoom = Math.max(Math.round((displayZoom / ZOOM_FACTOR) * 10) / 10, zoomMin);
+    const newZoom = Math.max(Math.round((sliderValue / ZOOM_FACTOR) * 10) / 10, zoomMin);
     zoomFn?.(newZoom, currentFrame);
   }
 
   function zoomIn() {
-    const newZoom = Math.min(Math.round(displayZoom * ZOOM_FACTOR * 10) / 10, zoomMax);
+    const newZoom = Math.min(Math.round(sliderValue * ZOOM_FACTOR * 10) / 10, zoomMax);
     zoomFn?.(newZoom, currentFrame);
   }
 

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/_Track.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/_Track.svelte
@@ -10,6 +10,7 @@
   import { TRACK_HEIGHT } from "$lib/components/App/Timeline/constants";
   import { isInViewport } from "$lib/components/App/Timeline/utils";
   import { cn } from "$lib/utils";
+  import { selection } from "$lib/state/selection.svelte";
 
   import type { TimelineItem, Viewport } from "$lib/components/App/Timeline/types";
 
@@ -31,8 +32,6 @@
   );
 
   // ── Right-click on empty track area ───────────────────────────────────
-
-  import { selection } from "$lib/state/selection.svelte";
 
   function handleContextMenu(e: MouseEvent) {
     // Only handle clicks directly on the track div (not on children — TrackItem blocks handle their own)
@@ -74,12 +73,15 @@
 </script>
 
 <div
+  role="button"
+  tabindex="-1"
   class={cn("track border-b", {
     "border-primary bg-primary/10 border-t border-b": isSelected,
   })}
   style:height="{TRACK_HEIGHT}px"
   style="top: {top}px;"
   onclick={handleTrackClick}
+  onkeypress={() => {}}
   oncontextmenu={handleContextMenu}
 >
   {#each visibleItems as item, itemIndex (itemIndex)}

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_AnnotationTrackInfo.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_AnnotationTrackInfo.svelte
@@ -88,7 +88,7 @@
         <div class={cn("", alwaysShow ? "opacity-100" : "opacity-0 group-hover:opacity-100")}>
           <ToolTooltip {label}>
             {#snippet trigger()}
-              <Button variant="ghost" size="icon-sm" onclick={onClick}>
+              <Button variant="ghost" size="icon-sm" class="focus:outline-none" onclick={onClick}>
                 <Icon />
               </Button>
             {/snippet}

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackInfoContextMenu.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackInfoContextMenu.svelte
@@ -4,10 +4,10 @@
   import Separator from "$lib/components/ui/Separator/Separator.svelte";
 
   import { getGroupContextMenus } from "$lib/components/App/Timeline/annotations/menus";
+  import { getDriver } from "$lib/state/driver.svelte";
 
   import type { ContextMenuComponentProps } from "$lib/components/App/ContextMenu/store";
   import type { TrackData, TimelineItem } from "$lib/components/App/Timeline/types";
-  import { getDriver } from "$lib/state/driver.svelte";
 
   // Props — either `track` (title right-click) or `trackId`/`frame`/`items` (empty area right-click)
   interface Props extends ContextMenuComponentProps {

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/types.ts
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/types.ts
@@ -4,9 +4,6 @@ import type { Component, Snippet } from "svelte";
 export interface Viewport {
   startRange: number;
   endRange: number;
-  /** Internal — set by Timeline.svelte to expose its clamp+sync logic
-   *  to external callers such as the timeline.focus command. */
-  _focusHandler?: ((start: number, end: number) => void) | null;
 }
 
 export interface TimelineItem<T extends Record<string, unknown> = Record<string, unknown>> {

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
@@ -312,7 +312,7 @@
     if (selection.isAnnotationSelected(ann.id)) return;
 
     selection.selectAnnotation(ann);
-    // TODO: getDriver().command.call("timeline.scroll_to_annotation_viewport")
+    getDriver().command.call("timeline.scroll_to_annotation");
   }
 </script>
 

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
@@ -312,7 +312,7 @@
     if (selection.isAnnotationSelected(ann.id)) return;
 
     selection.selectAnnotation(ann);
-    viewport.video.currentFrame.value = ann.shape.start as number;
+    // TODO: getDriver().command.call("timeline.scroll_to_annotation_viewport")
   }
 </script>
 

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
@@ -312,7 +312,7 @@
     if (selection.isAnnotationSelected(ann.id)) return;
 
     selection.selectAnnotation(ann);
-    getDriver().command.call("timeline.focus");
+    viewport.video.currentFrame.value = ann.shape.start as number;
   }
 </script>
 

--- a/plugins/idah-video/frontend/src/lib/state/selection.svelte.ts
+++ b/plugins/idah-video/frontend/src/lib/state/selection.svelte.ts
@@ -5,8 +5,17 @@
 // ---------------------------------------------------------------------------
 import type { IAnnotationRecord } from "$idah/v2/types";
 
-let _selected: { type: "annotation"; annotation: IAnnotationRecord } | { type: "group"; groupId: string } | null =
-  $state(null);
+export interface IAnnotationSelection {
+  type: "annotation";
+  annotation: IAnnotationRecord;
+}
+
+export interface IAnnotationGroupSelection {
+  type: "group";
+  groupId: string;
+}
+
+let _selected: IAnnotationSelection | IAnnotationGroupSelection | null = $state(null);
 
 export const selection = {
   get value() {

--- a/plugins/idah-video/frontend/src/lib/state/viewport.svelte.ts
+++ b/plugins/idah-video/frontend/src/lib/state/viewport.svelte.ts
@@ -11,7 +11,9 @@ class Viewport {
   // Only mode needs special handling
   #mode = $state(DEFAULT_MODE);
 
-  get mode() { return this.#mode; }
+  get mode() {
+    return this.#mode;
+  }
   get isCreationMode() {
     return ["idah-video:polygon", "idah-video:bounding-box"].includes(this.#mode);
   }
@@ -25,11 +27,6 @@ class Viewport {
   timeline = $state({
     range: { startRange: 0, endRange: 0 },
     dimensions: [0, 0] as [number, number],
-    /**
-     * Internal — set by Timeline.svelte to expose its clamp+sync logic
-     * to external callers such as the timeline.focus command.
-     */
-    _focusHandler: null as ((start: number, end: number) => void) | null,
   });
 
   video = $state({


### PR DESCRIPTION
# Product Requirements Document
## Annotation Timeline — Bug Fixes & UX Improvements

**Document Status:** Completed  
**Version:** 1.0  
**Date:** May 19, 2026  

---

## 1. Overview

This document describes the requirements and acceptance criteria for a set of bug fixes and UX improvements targeting the annotation timeline component. These issues affected annotation management, timeline navigation, scroll behavior, and zoom controls across the video viewport and right sidebar.

---

## 2. Background & Problem Statement

Users reported multiple behavioral issues with the annotation timeline that degraded the editing experience. These ranged from missing confirmation dialogs on destructive actions to incorrect scroll and zoom behavior, introducing risk of data loss and creating confusing interactions when navigating between the video viewport and the timeline.

---

## 3. Scope

**In scope:** Annotation timeline, video viewport annotation overlay, right sidebar annotation panel, and timeline zoom/scroll controls.

**Out of scope:** Annotation data model changes, backend API changes, and new annotation feature development.

---

## 4. Requirements

### 4.1 Delete Confirmation for Single Annotation

**Problem:** When a user deletes a single annotation, no confirmation dialog is shown. This is inconsistent with expected behavior for destructive actions and creates risk of accidental data loss.

**Requirement:** A confirmation popup must appear whenever a user initiates deletion of a single annotation, prompting the user to confirm or cancel the action before it is executed.

**Acceptance Criteria:**
- Clicking the delete action on a single annotation triggers a confirmation dialog.
- The dialog clearly states which annotation will be deleted.
- Confirming the dialog proceeds with deletion; cancelling dismisses the dialog without any changes.
- The popup is consistent in style with other confirmation dialogs in the application.

---

### 4.2 Auto-Scroll to Newly Created Annotation

**Problem:** After creating a new annotation, the timeline does not automatically scroll to bring the newly created annotation into view, requiring the user to manually locate it.

**Requirement:** Upon creating a new annotation, the timeline must automatically scroll to the position of the newly created annotation.

**Acceptance Criteria:**
- Immediately after creation, the timeline scrolls to make the new annotation visible.
- The scroll behavior is smooth and does not cause flickering.
- The timeline scale (zoom level) is not affected by this scroll action.

---

### 4.3 Auto-Scroll to Selected Annotation from Viewport or Sidebar

**Problem:** When a user selects an annotation by clicking on its overlay in the video viewport, or by clicking it in the right sidebar, the timeline does not scroll to reflect that selection.

**Requirement:** Selecting an annotation from either the video viewport overlay or the right sidebar must cause the timeline to scroll to the corresponding annotation.

**Acceptance Criteria:**
- Clicking an annotation overlay in the video viewport scrolls the timeline to the selected annotation.
- Clicking an annotation in the right sidebar scrolls the timeline to the selected annotation.
- The timeline scale (zoom level) is not altered during this scroll action.
- The selected annotation is visually highlighted after the scroll.

---

### 4.4 Fix Timeline Flickering on Scroll

**Problem:** The timeline flickers when the user scrolls down, creating visual instability that disrupts the editing workflow.

**Requirement:** Timeline scrolling must be smooth and stable with no flickering under normal usage conditions.

**Acceptance Criteria:**
- Scrolling the timeline in any direction produces no visual flickering.
- Performance remains stable when scrolling through timelines with a large number of annotations.

---

### 4.5 Annotation Overlay Click Must Not Change Timeline Scale

**Problem:** Clicking on an annotation overlay in the video viewport and navigating the timeline back to the current frame also changes the timeline zoom scale. Root cause identified: the system was using a Focus action that fits the entire annotation duration into view, inadvertently altering the scale.

**Requirement:** When clicking on an annotation overlay in the viewport causes the timeline to navigate to the current frame, the timeline zoom scale must remain unchanged.

**Acceptance Criteria:**
- Clicking an annotation overlay in the viewport navigates the timeline to the relevant frame without changing the zoom scale.
- The Focus action (or equivalent) is not used for this navigation; a scroll-only approach is used instead.
- The timeline zoom level before and after the click remains identical.

---

### 4.6 Delete First Annotation in a Split Group Must Not Delete the Entire Group

**Problem:** When an annotation has been split into a group and the user deletes the first annotation in that group, the entire group is deleted instead of only the individual annotation.

**Requirement:** Deleting any individual annotation within a split group must delete only that annotation and must not affect other annotations in the group.

**Acceptance Criteria:**
- Deleting the first annotation in a split group removes only that annotation.
- The remaining annotations in the group are unaffected and remain correctly displayed.
- Deletion of any other annotation in the group (second, third, etc.) also removes only that individual item.
- The confirmation dialog (see 4.1) is shown before deletion proceeds.

---

### 4.7 Fix Zoom In/Out Button Behavior on Timeline Slider

**Problem:** Clicking the zoom in or zoom out button on the timeline slider immediately jumps the timeline to its maximum zoom-out level, instead of incrementally adjusting the scale up or down.

**Requirement:** The zoom in and zoom out buttons must incrementally adjust the timeline scale by a defined step value per click, rather than jumping to an extreme value.

**Acceptance Criteria:**
- Each click of the zoom in button increases the timeline scale by one consistent step.
- Each click of the zoom out button decreases the timeline scale by one consistent step.
- The zoom level never jumps to the minimum or maximum in a single click unless it is already one step away from that boundary.
- The slider position updates in sync with the zoom level after each click.

---

## 5. User Stories

| # | As a… | I want to… | So that… |
|---|--------|------------|----------|
| 1 | Video editor | See a confirmation before deleting an annotation | I don't accidentally lose annotation work |
| 2 | Video editor | Have the timeline scroll to a newly created annotation | I can immediately see and edit it without searching |
| 3 | Video editor | Have the timeline scroll when I select an annotation from the viewport or sidebar | I always know where the annotation sits in the timeline |
| 4 | Video editor | Scroll the timeline without flickering | The interface feels stable and professional |
| 5 | Video editor | Click an annotation overlay without the timeline zoom changing | My preferred zoom level is preserved during navigation |
| 6 | Video editor | Delete only one annotation from a split group | I can manage individual segments without affecting the rest |
| 7 | Video editor | Use zoom buttons to incrementally adjust the timeline scale | I have precise control over how much detail I see |

---

## 6. Out of Scope / Non-Goals

- Changes to how annotations are stored or structured in the data model.
- Redesign of the confirmation dialog component.
- Addition of undo/redo functionality (tracked separately).
- Changes to the annotation splitting or merging workflow beyond the bug fix in 4.6.

---

## 7. Dependencies

- Timeline scroll utilities must support programmatic scrolling without side effects on zoom state.
- The delete action handler must be refactored to distinguish between single-annotation deletion and group deletion.
- The Focus action used for viewport click navigation must be decoupled from the scroll-to-annotation behavior.

---

## 8. Risks & Considerations

| Risk | Likelihood | Mitigation |
|------|------------|------------|
| Refactoring Focus action may introduce regressions in other viewport interactions | Medium | Thorough regression testing across all viewport interaction paths |
| Scroll-to-annotation logic may conflict with manual scrolling state | Low | Implement debounce and only trigger on explicit selection events |
| Group deletion fix may require changes to how split groups are identified | Medium | Add unit tests for group membership and deletion boundary cases |

---

## 9. Acceptance Sign-Off Checklist

- [x] 4.1 — Confirmation popup shown on single annotation delete
- [x] 4.2 — Timeline scrolls to newly created annotation
- [x] 4.3 — Timeline scrolls when annotation selected from viewport or sidebar
- [x] 4.4 — No flickering during timeline scroll
- [x] 4.5 — Timeline scale unchanged when clicking annotation overlay in viewport
- [x] 4.6 — Deleting first annotation in split group deletes only that annotation
- [x] 4.7 — Zoom in/out buttons increment/decrement scale one step at a time
