### PR TITLE
fix: improve category sidebar

### DIFF
--- a/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/_CategoryTree.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/_CategoryTree.svelte
@@ -243,7 +243,7 @@
   <Collapsible open={openStates[category.id] || false}>
     {#if db && category}
       {@const annotations = items.filter((a) => a.value?.category?.startsWith(category.id))}
-      {@const { count } = groupFilteredAnnotations(annotations)}
+      {@const count = annotations.length}
 
       <CollapsibleTrigger
         class={cn("text-secondary-foreground flex w-full rounded-md text-xs", {

--- a/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/_CategoryTree.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/_CategoryTree.svelte
@@ -350,8 +350,8 @@
             })}
 
             <!-- Icon Actions -->
-            {#if mode == DEFAULT_MODE && !selAnnotation}
-              <div class="ml-auto flex content-center items-center gap-0">
+            <div class="ml-auto flex content-center items-center gap-0">
+              {#if mode == DEFAULT_MODE && !selAnnotation}
                 {#each actions as { label, icon, onClick, alwaysShow }, index (index)}
                   <CategoryAction
                     {label}
@@ -366,15 +366,15 @@
                     })}
                   ></CategoryAction>
                 {/each}
+              {/if}
 
-                <AnnotationCountBadge
-                  class={cn("mr-2 ml-1 opacity-0", {
-                    "opacity-100": view === "sidebar" && count > 0,
-                  })}
-                  {count}
-                />
-              </div>
-            {/if}
+              <AnnotationCountBadge
+                class={cn("mr-2 ml-1 opacity-0", {
+                  "opacity-100": view === "sidebar" && count > 0,
+                })}
+                {count}
+              />
+            </div>
           </SidebarMenuItem>
         </div>
       </CollapsibleTrigger>

--- a/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/_CategoryTree.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/_CategoryTree.svelte
@@ -19,15 +19,15 @@
 
   import { groupAnnotations } from "$lib/components/App/VideoAnnotationWorkspace/utils/group-annotation.svelte";
   import { selection } from "$lib/state/selection.svelte";
-  import { viewport } from "$lib/state/viewport.svelte";
+  import { DEFAULT_MODE, viewport } from "$lib/state/viewport.svelte";
   import { VIDEO_BOUNDING_BOX as IDAH_VIDEO_BOUNDING_BOX, VIDEO_POLYGON as IDAH_VIDEO_POLYGON } from "$lib/types";
 
+  import { getCategoryActions } from "$lib/components/App/CategorySelector/menus";
   import { getDriver } from "$lib/state/driver.svelte";
 
   import type { IConfigValue } from "$idah/v2/types";
   import type { AnnotationItem, DataStore } from "$lib/state/data.svelte";
   import type { IVideoAnnotationRecord } from "$lib/types";
-  import { getCategoryActions } from "./menus";
 
   type AnnotationGroup<T> = { groupId: string; annotations: T[] };
   type CategoryDefinition = IConfigValue & {
@@ -359,9 +359,9 @@
                     e.stopPropagation();
                     onClick(e);
                   }}
-                  class={cn({
+                  class={cn("opacity-0", {
                     "opacity-100": alwaysShow,
-                    "opacity-0 group-hover:opacity-100": !alwaysShow,
+                    "group-hover:opacity-100": !alwaysShow && mode == DEFAULT_MODE,
                   })}
                 ></CategoryAction>
               {/each}

--- a/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/_CategoryTree.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/_CategoryTree.svelte
@@ -351,7 +351,7 @@
 
             <!-- Icon Actions -->
             <div class="ml-auto flex content-center items-center gap-0">
-              {#if mode == DEFAULT_MODE && !selAnnotation}
+              {#if mode == DEFAULT_MODE}
                 {#each actions as { label, icon, onClick, alwaysShow }, index (index)}
                   <CategoryAction
                     {label}

--- a/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/_CategoryTree.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/_CategoryTree.svelte
@@ -350,29 +350,31 @@
             })}
 
             <!-- Icon Actions -->
-            <div class="ml-auto flex content-center items-center gap-0">
-              {#each actions as { label, icon, onClick, alwaysShow }, index (index)}
-                <CategoryAction
-                  {label}
-                  {icon}
-                  onclick={(e) => {
-                    e.stopPropagation();
-                    onClick(e);
-                  }}
-                  class={cn("opacity-0", {
-                    "opacity-100": alwaysShow,
-                    "group-hover:opacity-100": !alwaysShow && mode == DEFAULT_MODE && !selAnnotation,
-                  })}
-                ></CategoryAction>
-              {/each}
+            {#if mode == DEFAULT_MODE && !selAnnotation}
+              <div class="ml-auto flex content-center items-center gap-0">
+                {#each actions as { label, icon, onClick, alwaysShow }, index (index)}
+                  <CategoryAction
+                    {label}
+                    {icon}
+                    onclick={(e) => {
+                      e.stopPropagation();
+                      onClick(e);
+                    }}
+                    class={cn("opacity-0", {
+                      "opacity-100": alwaysShow,
+                      "group-hover:opacity-100": !alwaysShow,
+                    })}
+                  ></CategoryAction>
+                {/each}
 
-              <AnnotationCountBadge
-                class={cn("mr-2 ml-1 opacity-0", {
-                  "opacity-100": view === "sidebar" && count > 0,
-                })}
-                {count}
-              />
-            </div>
+                <AnnotationCountBadge
+                  class={cn("mr-2 ml-1 opacity-0", {
+                    "opacity-100": view === "sidebar" && count > 0,
+                  })}
+                  {count}
+                />
+              </div>
+            {/if}
           </SidebarMenuItem>
         </div>
       </CollapsibleTrigger>

--- a/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/_CategoryTree.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/_CategoryTree.svelte
@@ -361,7 +361,7 @@
                   }}
                   class={cn("opacity-0", {
                     "opacity-100": alwaysShow,
-                    "group-hover:opacity-100": !alwaysShow && mode == DEFAULT_MODE,
+                    "group-hover:opacity-100": !alwaysShow && mode == DEFAULT_MODE && !selAnnotation,
                   })}
                 ></CategoryAction>
               {/each}


### PR DESCRIPTION
**Left sidebar:**
- [x] Action icons (hide/lock/delete) shouldn’t appear in create/edit mode