### PR TITLE
IDAH - Timeline - Focus Function Issues

### DIFF
--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/TimelineZoom.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/TimelineZoom.svelte
@@ -42,19 +42,32 @@
     Math.round(Math.max(zoomMin, Math.min(zoomMax, currentZoom)) / SLIDER_STEP) * SLIDER_STEP,
   );
 
-  // Current frame to use as zoom center
-  const currentFrame = $derived(viewport.video.currentFrame.value);
-
   // --- Actions ---
 
   function zoomOut() {
     const newZoom = Math.max(Math.round((sliderValue / ZOOM_FACTOR) * 10) / 10, zoomMin);
-    zoomFn?.(newZoom, currentFrame);
+    zoomFn?.(newZoom, viewport.video.currentFrame.value);
   }
 
   function zoomIn() {
     const newZoom = Math.min(Math.round(sliderValue * ZOOM_FACTOR * 10) / 10, zoomMax);
-    zoomFn?.(newZoom, currentFrame);
+    zoomFn?.(newZoom, viewport.video.currentFrame.value);
+  }
+
+  // Named (not inline) so it has a stable reference across renders.
+  // An inline `(v) => zoomFn?.(v, currentFrame)` where currentFrame is $derived would
+  // make it a template dep — Svelte recreates the arrow each frame tick, bits-ui
+  // receives a new onValueChange prop and may fire it, triggering applyZoom spuriously.
+  //
+  // Guard: skip when v is within half a step of sliderValue. When bits-ui fires
+  // onValueChange for a programmatic viewport change (focus, keyboard zoom, snap-on-add),
+  // sliderValue has already re-derived to the new value, so the delta is ~0 → no-op.
+  // Strict equality is unsafe here: Math.round(x/0.1)*0.1 can produce 0.30000000000000004
+  // while bits-ui produces 0.3, so we use half-step tolerance (0.05) instead.
+  // Real user drags produce at least a full step (0.1) → delta > threshold → pass through.
+  function handleSliderZoom(v: number) {
+    if (Math.abs(v - sliderValue) < SLIDER_STEP / 2) return;
+    zoomFn?.(v, viewport.video.currentFrame.value);
   }
 
   function cmdShortcut(name: string): string | undefined {
@@ -75,11 +88,11 @@
   <Slider
     type="single"
     class="w-40"
-    min={0}
-    max={100}
-    step={0.1}
+    min={zoomMin}
+    max={zoomMax}
+    step={SLIDER_STEP}
     value={sliderValue}
-    onValueChange={(v) => zoomFn?.(v, currentFrame)}
+    onValueChange={handleSliderZoom}
   />
 
   <ToolTooltip label="Zoom In" shortcut={cmdShortcut("timeline.zoom_in")}>

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/TimelineZoom.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/TimelineZoom.svelte
@@ -54,17 +54,7 @@
     zoomFn?.(newZoom, viewport.video.currentFrame.value);
   }
 
-  // Named (not inline) so it has a stable reference across renders.
-  // An inline `(v) => zoomFn?.(v, currentFrame)` where currentFrame is $derived would
-  // make it a template dep — Svelte recreates the arrow each frame tick, bits-ui
-  // receives a new onValueChange prop and may fire it, triggering applyZoom spuriously.
-  //
-  // Guard: skip when v is within half a step of sliderValue. When bits-ui fires
-  // onValueChange for a programmatic viewport change (focus, keyboard zoom, snap-on-add),
-  // sliderValue has already re-derived to the new value, so the delta is ~0 → no-op.
-  // Strict equality is unsafe here: Math.round(x/0.1)*0.1 can produce 0.30000000000000004
-  // while bits-ui produces 0.3, so we use half-step tolerance (0.05) instead.
-  // Real user drags produce at least a full step (0.1) → delta > threshold → pass through.
+  // guards against bits-ui's spurious onValueChange fires by skipping values within half a step (0.05) of current,
   function handleSliderZoom(v: number) {
     if (Math.abs(v - sliderValue) < SLIDER_STEP / 2) return;
     zoomFn?.(v, viewport.video.currentFrame.value);

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackBlockContextMenu.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackBlockContextMenu.svelte
@@ -38,7 +38,11 @@
         focus: {
           label: "Focus",
           icon: CrosshairIcon,
-          onClick: () => getDriver().command.call("timeline.focus"),
+          onClick: () => {
+            /** Select an annotation before focus it */
+            selection.selectAnnotation(rawData);
+            getDriver().command.call("timeline.focus");
+          },
         },
       },
     },
@@ -113,7 +117,12 @@
     {#each Object.entries(group.items) as [menuKey, { label, icon: Icon, disabled, hidden, destructive, onClick }] (menuKey)}
       {#if !hidden}
         <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-        <div role="none" onclick={(e) => { if (disabled) e.stopPropagation(); }}>
+        <div
+          role="none"
+          onclick={(e) => {
+            if (disabled) e.stopPropagation();
+          }}
+        >
           <Button
             variant={destructive ? "destructive-ghost" : "ghost"}
             size="sm"


### PR DESCRIPTION
# Plan: Fix focus.ts → Timeline reactive chain edge cases

## Context

When `focus.ts` fires (Ctrl+F), it directly mutates `viewport.timeline.range`. This propagates through two independent reactive paths in `Timeline.svelte` and `TimelineZoom.svelte`, creating edge cases where:

- `setScrollLeft()` can be called more than once per focus invocation
- `applyZoom()` can be called spuriously by `TimelineZoom`'s `onValueChange`

---

## Root-Cause Trace

### Path 1 — Timeline.svelte `$effect` (Effect B)

```
focus.ts: viewport.timeline.range = { startRange: X, endRange: Y }
  → viewport.startRange changes
  → Effect B fires (line 445–452): reads viewport.startRange, calls setScrollLeft()  ✓ (once)
```

Effect B itself is fine. It uses `_prevStartRange` + `untrack()` so it fires at most once per unique `startRange` value.

**However**, if the TimelineZoom path (below) fails, `applyZoom()` mutates `viewport.startRange` again, which triggers Effect B a second time → `setScrollLeft()` called twice total from Effect B + once directly inside `applyZoom()` = **3 calls**.

---

### Path 2 — TimelineZoom.svelte `handleSliderZoom` (the broken path)

```
focus.ts mutates viewport.timeline.range
  → sliderValue re-derives in TimelineZoom (currentZoom changes)
  → Slider.svelte $effect: internalValue = value (new sliderValue)
  → bits-ui detects bind:value change → fires onValueChange(v)
  → handleSliderZoom(v) runs
  → Guard: if (v === sliderValue) return   ← CAN FAIL (two reasons below)
  → zoomFn(v) → applyZoom(v)              ← spurious call!
```

---

## Two Concrete Guard Failures

### Bug 1 — Float strict-equality (`v === sliderValue`)

`sliderValue` is computed as `Math.round(x / 0.1) * 0.1`. This can produce values like `0.30000000000000004`. bits-ui internally does its own rounding and may produce `0.3`. Strict `===` fails → guard misses → `applyZoom()` is called.

### Bug 2 — Slider `max={100}` hardcoded vs dynamic `zoomMax`

The slider in `TimelineZoom.svelte` is:
```svelte
<Slider min={0} max={100} step={0.1} value={sliderValue} ... />
```

But `sliderValue` (= `currentZoom`) can exceed 100 when `zoomMax > 100` (e.g., a 1440-frame video in a 1000px container → `zoomMax = 115.2`). bits-ui clamps `v` to 100 before firing `onValueChange`. Guard: `100 !== 150` → fails completely → `applyZoom(100)` called with wrong zoom.

---

## Full Edge-Case Scenario When Both Bugs Are Present

```
focus.ts fires
  ├── Effect B: setScrollLeft() #1               (correct)
  └── onValueChange fires with v=100, sliderValue=150
        guard fails → applyZoom(100)
          ├── setScrollLeft() #2                 (wrong zoom)
          └── viewport.startRange changes
                → Effect B fires again
                    setScrollLeft() #3           (redundant)
```

---

## Solution

Two targeted changes, both in `TimelineZoom.svelte`. No changes to `Timeline.svelte`, `focus.ts`, or shared components.

### Fix 1 — Correct the slider `min`/`max` to match the actual zoom range

**File:** `plugins/idah-video/frontend/src/lib/components/App/Timeline/TimelineZoom.svelte`

```diff
 <Slider
   type="single"
   class="w-40"
-  min={0}
-  max={100}
+  min={zoomMin}
+  max={zoomMax}
   step={SLIDER_STEP}
   value={sliderValue}
   onValueChange={handleSliderZoom}
 />
```

This ensures bits-ui never clamps `sliderValue` before passing it to `onValueChange`. The thumb position now correctly tracks the full zoom range.

### Fix 2 — Replace strict `===` guard with half-step tolerance

**File:** `plugins/idah-video/frontend/src/lib/components/App/Timeline/TimelineZoom.svelte`

```diff
 function handleSliderZoom(v: number) {
-  if (v === sliderValue) return;
+  if (Math.abs(v - sliderValue) < SLIDER_STEP / 2) return;  // ~0.05
   zoomFn?.(v);
 }
```

`SLIDER_STEP / 2 = 0.05` is safely below any intentional zoom step (0.1), so real user drags still pass through. Floating-point jitter (typically < 1e-15) is rejected.

---

## Why These Two Fixes Are Sufficient

- Fix 1 eliminates the clamping case (largest-magnitude guard failure)
- Fix 2 eliminates the float-precision case (subtle guard failure)
- Together, `handleSliderZoom` becomes a true no-op for all programmatic viewport changes
- With no spurious `applyZoom()` call, `viewport.startRange` is not mutated a second time
- Effect B fires exactly once → `setScrollLeft()` called exactly once per focus invocation

No `$effect` loops. No architecture changes. No changes to Timeline.svelte or Slider.svelte.

---

## Verification

1. Open any annotated video, select an annotation, press **Ctrl+F** (focus).
2. Confirm the timeline snaps to the annotation's range visually (scroll + zoom).
3. Open DevTools console, add a temporary `console.count('setScrollLeft')` inside `setScrollLeft()` in Timeline.svelte.
4. Press Ctrl+F again — should log **exactly 1** per invocation.
5. Drag the zoom slider manually — should still zoom correctly throughout full range.
6. Zoom in past zoomMax=100 (small viewport, many frames) then press Ctrl+F — should not snap to zoom=100.

## Critical Files

| File | Change |
|------|--------|
| `plugins/idah-video/frontend/src/lib/components/App/Timeline/TimelineZoom.svelte` | Fix `min`/`max` props + tolerance guard (lines 41–43, 67–71, 88–96) |