### PR TITLE
Scroll timeline to current frame instead of annotation start

### DIFF
--- a/plugins/idah-video/frontend/src/lib/commands/timeline/scroll-to-annotation.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/timeline/scroll-to-annotation.ts
@@ -1,16 +1,19 @@
 // ---------------------------------------------------------------------------
-// timeline.scroll_to_annotation — Pan the timeline to reveal the selected
-// annotation's start frame at the current zoom level.
+// timeline.scroll_to_annotation — Pan the timeline to the current frame when
+// it is outside the viewport, keeping the current zoom level.
 //
-// Shifts the viewport so the annotation's start frame sits ~10 frames from
-// the left edge. The visible range width (scale) is preserved unchanged.
-// The end is clamped to totalFrames; when it would exceed, the start is also pulled back to preserve the viewport width.
+// If `viewport.video.currentFrame` is already visible within the viewport
+// range, the viewport is left unchanged — no unnecessary scrolling when the
+// user is already looking at the relevant part of the timeline.
+//
+// When the current frame is outside the viewport, it is centered horizontally
+// in the viewport, preserving the current zoom scale (range width). The result
+// is clamped to [0, totalFrames] so boundaries are handled gracefully.
 // ---------------------------------------------------------------------------
 import { selection, type IAnnotationSelection } from "$lib/state/selection.svelte";
 import { viewport } from "$lib/state/viewport.svelte";
 import { media } from "$lib/state/media.svelte";
 import type { IIdahDriverV2, ICommandAction } from "$idah/v2/types";
-import type { IVideoAnnotationShape } from "$lib/types";
 
 export const command = {
   name: "timeline.scroll_to_annotation",
@@ -18,7 +21,7 @@ export const command = {
   modes: ["default", "review"],
   shortcut: null,
   shortDescription: "Scroll timeline to annotation",
-  longDescription: "Pan the timeline to show the selected annotation's start frame without changing the zoom level",
+  longDescription: "Pan the timeline to show the current frame without changing the zoom level",
 };
 
 export function register(driver: IIdahDriverV2): void {
@@ -44,21 +47,6 @@ export function register(driver: IIdahDriverV2): void {
         };
       }
 
-      const shape = sel.annotation.shape as IVideoAnnotationShape | undefined;
-
-      if (!shape) {
-        return {
-          command: command as any,
-          do() {},
-          isCombinable() {
-            return false;
-          },
-          combine(p: any) {
-            return p;
-          },
-        };
-      }
-
       return {
         command: command as any,
         do() {
@@ -66,11 +54,21 @@ export function register(driver: IIdahDriverV2): void {
           const { startRange, endRange } = viewport.timeline.range;
           const rangeWidth = endRange - startRange;
           if (rangeWidth <= 0) return;
-          const margin = Math.max(1, Math.round(rangeWidth * 0.1));
 
-          let newStart = Math.max(0, shape.start - margin);
-          let newEnd = newStart + rangeWidth;
+          const currentFrame = viewport.video.currentFrame.value;
 
+          // If the current frame is already visible, don't shift the viewport
+          if (currentFrame >= startRange && currentFrame <= endRange) return;
+
+          // Center the current frame in the viewport, preserving zoom scale
+          let newStart = currentFrame - rangeWidth / 2;
+          let newEnd = currentFrame + rangeWidth / 2;
+
+          // Clamp to valid frame bounds
+          if (newStart < 0) {
+            newStart = 0;
+            newEnd = rangeWidth;
+          }
           if (newEnd > totalFrames) {
             newEnd = totalFrames;
             newStart = Math.max(0, totalFrames - rangeWidth);


### PR DESCRIPTION
- Skip scrolling when the current frame is already visible in the viewport
- Center the current frame horizontally when a scroll is needed, preserving zoom scale
- Remove the shape-dependency that blocked the command when no shape was attached