### PR TITLE
[CU-869dgzqfb] feat(entries): update role-based member assignment for entry stage

### DIFF
--- a/app/dataset/app/model/entry.rb
+++ b/app/dataset/app/model/entry.rb
@@ -120,10 +120,11 @@ module Entry
               AND (
                 -- All with roles
                 pm.role IN :with_roles OR
-                -- Annotators can access only assigned entries
+                -- Annotators can access only assigned annotate-stage entries
                 (
                   (pm.role IN :annotator_roles)
                   AND entries.assigned_to_id = :account_id
+                  AND entries.wf_step = 'annotate'
                 ) OR
                 -- Reviewers can access assigned and unassigned entries not submitted by themselves in review step
                 (

--- a/app/dataset/app/service/annotation/permission_spec.rb
+++ b/app/dataset/app/service/annotation/permission_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Annotation::Service, database: true do
       dataset_id: first_dataset_id,
       priority: 1,
       resource: "http://example.com/first.mp4",
-      wf_step: "start",
+      wf_step: "annotate",
       status: "pending",
       assigned_to_id: annotator_account_id
     )

--- a/app/dataset/app/service/entry/permission_spec.rb
+++ b/app/dataset/app/service/entry/permission_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Entry::Service, database: true do
       dataset_id: first_dataset_id,
       priority: 1,
       resource: "http://example.com/first.mp4",
-      wf_step: "start",
+      wf_step: "annotate",
       status: "pending",
       assigned_to_id: annotator_account_id,
     )

--- a/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
@@ -44,6 +44,8 @@
         openConfirmDeleteEntryModal = true;
       },
       isAssigned: !!entry.assigned_to_id,
+      isAssignDisabled: entry.wf_step === "done",
+      isUnassignDisabled: entry.wf_step === "done",
     }).filter((m) => m.label !== "Set Priority"),
   );
 
@@ -132,9 +134,9 @@
 
     <DropdownMenuContent align="end">
       <DropdownMenuGroup>
-        {#each menus as { label, icon: Icon, action, hidden, destructive }, index (index)}
+        {#each menus as { label, icon: Icon, action, hidden, destructive, disabled }, index (index)}
           {#if !hidden}
-            <DropdownMenuItem variant={destructive ? "destructive" : "default"} onclick={action}>
+            <DropdownMenuItem variant={destructive ? "destructive" : "default"} {disabled} onclick={action}>
               <Icon class="size-4" />
               {label}
             </DropdownMenuItem>

--- a/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.ts
+++ b/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.ts
@@ -8,21 +8,25 @@ interface Params {
   onSetPriority: () => Promise<void> | void;
   onDelete: () => Promise<void> | void;
   isAssigned?: boolean;
+  isAssignDisabled?: boolean;
+  isUnassignDisabled?: boolean;
 }
 export function getEntryDropdownMenuActions(params: Params): IDropdownMenuItem[] {
-  const { onAssign, onUnassign, onSetPriority, onDelete, isAssigned } = params;
+  const { onAssign, onUnassign, onSetPriority, onDelete, isAssigned, isAssignDisabled, isUnassignDisabled } = params;
 
   return [
     {
       label: "Assign to",
       icon: UserRoundPlusIcon,
       action: onAssign,
+      disabled: isAssignDisabled,
     },
     {
       label: "Unassign",
       icon: UserRoundPlusIcon,
       action: onUnassign,
       hidden: !isAssigned,
+      disabled: isUnassignDisabled,
     },
     {
       label: "Set Priority",

--- a/app/frontend/src/lib/components/app/datasets/entries/forms/assign-entry-form.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/forms/assign-entry-form.svelte
@@ -3,9 +3,13 @@
 
   import SingleSelectDatasourceField from "@/components/app/forms/fields/select/single/single-select-datasource-field.svelte";
   import { FieldGroup, FieldSet } from "@/components/ui/field";
+  import { CheckIcon } from "@lucide/svelte";
+  import { CommandItem } from "@/components/ui/command";
+  import { cn } from "@/utils";
+  import ProjectMemberRoleBadge from "@/components/app/projects/members/badges/project-member-role-badge.svelte";
 
   import { EntryRecord } from "@/data/model/dataset/entries/record";
-  import { projectMembersBackendDataSource } from "@/data/model/dataset/projects/members/record";
+  import { projectMembersBackendDataSource, ProjectMemberRecord } from "@/data/model/dataset/projects/members/record";
 
   import type { FormBaseProps } from "@/components/app/forms/form.types";
 
@@ -44,7 +48,7 @@
         filters: {
           project_id: projectId,
           enabled: true,
-          role__in: wfStep === "review" ? ["reviewer", "project_owner"] : ["annotator", "project_owner"],
+          role__in: wfStep === "review" ? ["reviewer", "project_owner"] : ["annotator", "reviewer", "project_owner"],
         },
       }}
       searchable
@@ -53,6 +57,33 @@
       onSelected={(value: string | number | null) => {
         assignedToAccountId = value as number;
       }}
-    ></SingleSelectDatasourceField>
+    >
+      {#snippet slotTriggerValue({ selectedChoice })}
+        {#if selectedChoice}
+          <div class="flex min-w-0 flex-1 items-center gap-2">
+            <span class="truncate">{selectedChoice.label}</span>
+            <div class="ml-auto shrink-0">
+              <ProjectMemberRoleBadge projectMemberRecord={selectedChoice.data as ProjectMemberRecord} />
+            </div>
+          </div>
+        {/if}
+      {/snippet}
+
+      {#snippet slotChoice({ choice, select })}
+        <CommandItem onclick={() => select(choice)}>
+          <CheckIcon
+            class={cn("mr-2 size-4 shrink-0", {
+              "opacity-0": choice.value != assignedToAccountId,
+            })}
+          />
+          <div class="flex min-w-0 flex-1 items-center gap-2">
+            <span class="truncate">{choice.label}</span>
+            <div class="ml-auto shrink-0">
+              <ProjectMemberRoleBadge projectMemberRecord={choice.data as ProjectMemberRecord} />
+            </div>
+          </div>
+        </CommandItem>
+      {/snippet}
+    </SingleSelectDatasourceField>
   </FieldGroup>
 </FieldSet>

--- a/app/frontend/src/lib/components/app/projects/members/badges/project-member-role-badge.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/badges/project-member-role-badge.svelte
@@ -6,14 +6,14 @@
 
   // Props
   interface Props {
-    projectMemberRecord: ProjectMemberRecord;
+    projectMemberRecord: ProjectMemberRecord | undefined;
   }
   let { projectMemberRecord }: Props = $props();
 
   // Variables
-  let foundRole = $derived(projectMemberRoles.find((role) => role.value === projectMemberRecord.role));
+  let foundRole = $derived(projectMemberRoles.find((role) => role.value === projectMemberRecord?.role));
 </script>
 
 <Badge variant="outline" rounded="full">
-  {foundRole ? foundRole.label : humanize(projectMemberRecord.role)}
+  {foundRole ? foundRole.label : humanize(projectMemberRecord?.role ?? "")}
 </Badge>

--- a/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/datasets/[datasetId]/entries/+page.svelte
+++ b/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/datasets/[datasetId]/entries/+page.svelte
@@ -60,6 +60,7 @@
   import type { CollectionResponse } from "@/data/model/types";
   import type { ProjectMemberScope } from "@/security/types";
   import type { Hash } from "@/utils/types";
+  import { ExportsBackendDataSource } from "@/data/model/sync/exports/record";
 
   // Contexts
   const project: ProjectRecord = getContext("project");
@@ -113,9 +114,16 @@
   let itemsPerPage: number = $state(10);
   let selectedEntryIds: string[] = $state([]);
   let selectedRowsCount: number = $derived(selectedEntryIds.length);
-  let selectedToUnassignedEntryIdsCount: number = $derived(
-    response.data.filter((entry) => selectedEntryIds.includes(entry.id) && entry.assigned_to?.id).length,
+  let assignableEntryIds: string[] = $derived(
+    selectedEntryIds.filter((id) => response.data.find((e) => e.id === id)?.wf_step !== "done"),
   );
+  let unAssignableEntryIds: string[] = $derived(
+    selectedEntryIds.filter((id) => {
+      const entry = response.data.find((e) => e.id === id);
+      return entry?.wf_step !== "done" && entry?.assigned_to_id !== null;
+    }),
+  );
+  let selectedToUnassignedEntryIdsCount: number = $derived(unAssignableEntryIds.length);
   let openNewEntryModal: boolean = $state(false);
   let openAssignEntryFormModal: boolean = $state(false);
   let openSetPriorityModal: boolean = $state(false);
@@ -178,6 +186,8 @@
         openConfirmDeleteEntriesModal = true;
       },
       isAssigned: checkEntriesAssignedToAnyone(selectedEntryIds),
+      isAssignDisabled: assignableEntryIds.length === 0,
+      isUnassignDisabled: unAssignableEntryIds.length === 0,
     }),
   );
 
@@ -295,7 +305,7 @@
 
   async function unAssignEntries(): Promise<void> {
     try {
-      for (const entryId of selectedEntryIds) {
+      for (const entryId of unAssignableEntryIds) {
         await entriesBackendDataSource.update(entryId, {
           attributes: {
             assigned_to_id: null,
@@ -303,9 +313,7 @@
         });
       }
 
-      const selectedToUnassignedRows = response.data.filter(
-        (entry) => selectedEntryIds.includes(entry.id) && entry.assigned_to_id,
-      );
+      const selectedToUnassignedRows = response.data.filter((entry) => unAssignableEntryIds.includes(entry.id));
       const description =
         selectedToUnassignedEntryIdsCount > 1
           ? `${selectedToUnassignedRows.length} entries have been unassigned.`
@@ -454,9 +462,9 @@
 
               <DropdownMenuContent>
                 <DropdownMenuGroup>
-                  {#each bulkActions as { label, icon: Icon, action, hidden }, index (index)}
+                  {#each bulkActions as { label, icon: Icon, action, disabled, hidden }, index (index)}
                     {#if !hidden}
-                      <DropdownMenuItem onclick={action}>
+                      <DropdownMenuItem {disabled} onclick={action}>
                         <Icon class="mr-2 size-4" />
                         {label}
                       </DropdownMenuItem>
@@ -518,9 +526,11 @@
 <!-- MODAL::ASSIGN ANNOTATOR  -->
 <AssignEntryFormModal
   action="update"
-  entryIds={selectedEntryIds}
+  entryIds={assignableEntryIds}
   onAssigned={resetSelectedRows}
-  entryRecord={selectedRowsCount === 1 ? response.data.find((entry) => entry.id === selectedEntryIds[0]) : undefined}
+  entryRecord={assignableEntryIds.length === 1
+    ? response.data.find((entry) => entry.id === assignableEntryIds[0])
+    : undefined}
   bind:open={openAssignEntryFormModal}
 />
 


### PR DESCRIPTION
## What
Updates role-based rules for assigning members to entries, what entries
each role sees on the Entries page, and guards against actions on
completed entries.

## Why
The previous logic was too restrictive — only annotators could be
assigned to annotate-stage entries, and only reviewers to review-stage
entries. The nested-role system means reviewers should also be eligible
for annotate-stage work. Annotators should only see entries in their
active stage. Done entries should not be assignable.

## How
**Assignment eligibility**
- `assign-entry-form.svelte`: Added `"reviewer"` to the `role__in`
  filter for annotate-stage entries

**Role badge in assignment selector**
- `assign-entry-form.svelte`: Added `slotChoice` and `slotTriggerValue`
  snippets to show a role badge next to each member's email — both in
  the dropdown list and in the trigger after selection
- `project-member-role-badge.svelte`: Made `projectMemberRecord` prop
  accept `undefined` to support the slot usage

**Backend visibility**
- `entry.rb`: Added `entries.wf_step = 'annotate'` to the annotator
  scope — annotators only see annotate-stage entries assigned to them

**Done-entry guarding (per-entry dropdown)**
- `entry-dropdown-menu.ts`: Added `isAssignDisabled` / `isUnassignDisabled`
  params; both are set to `true` when `wf_step === 'done'`
- `entry-dropdown-menu.svelte`: Wires `disabled` prop to `DropdownMenuItem`

**Done-entry guarding (bulk actions)**
- `+page.svelte`: Added `assignableEntryIds` (selected, not done) and
  `unAssignableEntryIds` (selected, not done, assigned) derived state
- Bulk Assign disabled when `assignableEntryIds` is empty; bulk Unassign
  disabled when `unAssignableEntryIds` is empty
- `unAssignEntries()` loops over `unAssignableEntryIds`; assign modal
  receives `assignableEntryIds`
- Confirm dialog count now reflects only entries that will actually be
  unassigned (`unAssignableEntryIds.length`)

## Testing
1. As **Project Owner**, open an annotate-stage entry → "Assign member"
   → verify annotators, reviewers, and project owners appear with role badges
2. As **Project Owner**, open a review-stage entry → "Assign member"
   → verify only reviewers and project owners appear
3. Open a done entry → verify Assign to and Unassign are grayed out in
   the dropdown menu
4. Select a mix of done and non-done entries → bulk Assign/Unassign
   should only act on non-done entries; confirm dialog shows correct count
5. Log in as **Annotator** → Entries page shows only annotate-stage
   entries assigned to that user
6. Log in as **Reviewer** → Entries page shows annotate-stage entries
   assigned to them + unassigned review-stage entries

---
Closes CU-869dgzqfb