### PR TITLE
Prevent deletion of annotations and annotation groups when group is locked

### DIFF
--- a/plugins/idah-video/frontend/src/lib/commands/annotation/delete.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/delete.ts
@@ -12,6 +12,7 @@ import { selection, type IAnnotationSelection } from "$lib/state/selection.svelt
 import type { IIdahDriverV2 } from "$idah/v2/types";
 import { noopAction } from "..";
 import { isEditable } from "$lib/state/editor.svelte";
+import { annotation } from "$lib/state/annotation.svelte";
 
 export const command = {
   name: "annotation.delete",
@@ -40,6 +41,8 @@ export function register(driver: IIdahDriverV2): void {
 
       const record = data.annotations.items.find((a) => a.id === props.annotationId) as AnnotationItem;
       if (!record) return noopAction(command);
+      // Locked annotations (or those belonging to a locked group) must not be deletable.
+      if (annotation.isLocked(record)) return noopAction(command);
 
       return {
         command: { ...command },

--- a/plugins/idah-video/frontend/src/lib/commands/annotation/delete_all.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/delete_all.ts
@@ -10,6 +10,7 @@ import type { AnnotationItem } from "$lib/state/data.svelte";
 import { data } from "$lib/state/data.svelte";
 import { isEditable } from "$lib/state/editor.svelte";
 import { noopAction } from "..";
+import { annotation } from "$lib/state/annotation.svelte";
 
 export const command = {
   name: "annotation.delete_all",
@@ -33,6 +34,8 @@ export function register(driver: IIdahDriverV2): void {
 
       const snapshot: AnnotationItem[] = [...data.annotations.items];
       if (snapshot.length === 0) return noopAction(command);
+      // Block delete-all entirely when any annotation belongs to a locked group — partial deletion is not allowed.
+      if (snapshot.some((ann) => annotation.isLocked(ann))) return noopAction(command);
 
       return {
         command: { ...command },

--- a/plugins/idah-video/frontend/src/lib/commands/category/delete.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/category/delete.ts
@@ -25,6 +25,7 @@ import { data } from "$lib/state/data.svelte";
 import { isEditable } from "$lib/state/editor.svelte";
 import { isCategoryMatch } from "$lib/utils/category";
 import { noopAction } from "..";
+import { annotation } from "$lib/state/annotation.svelte";
 
 export const command = {
   name: "annotation.delete_category",
@@ -79,6 +80,8 @@ export function register(driver: IIdahDriverV2): void {
       if (categoryAnnotations.length === 0) {
         return noopAction(command);
       }
+      // Block category deletion if any annotation in the category belongs to a locked group.
+      if (categoryAnnotations.some((ann) => annotation.isLocked(ann))) return noopAction(command);
 
       const snapshot = [...categoryAnnotations];
 

--- a/plugins/idah-video/frontend/src/lib/commands/group/delete.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/group/delete.ts
@@ -13,6 +13,7 @@ import { data } from "$lib/state/data.svelte";
 import { noopAction } from "..";
 import { selection } from "$lib/state/selection.svelte";
 import { isEditable } from "$lib/state/editor.svelte";
+import { annotation } from "$lib/state/annotation.svelte";
 
 export const command = {
   name: "annotation.delete_group",
@@ -60,6 +61,8 @@ export function register(driver: IIdahDriverV2): void {
       }
 
       if (groupAnnotations.length === 0) return noopAction(command);
+      // Locked groups must not be deletable.
+      if (annotation.isLocked(props.groupId)) return noopAction(command);
 
       const snapshot = [...groupAnnotations];
 

--- a/plugins/idah-video/frontend/src/lib/commands/group/delete.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/group/delete.ts
@@ -61,8 +61,8 @@ export function register(driver: IIdahDriverV2): void {
       }
 
       if (groupAnnotations.length === 0) return noopAction(command);
-      // Locked groups must not be deletable.
-      if (annotation.isLocked(props.groupId)) return noopAction(command);
+      // Locked groups must not be deletable — check member annotations so individually-locked annotations are also caught.
+      if (groupAnnotations.some((ann) => annotation.isLocked(ann))) return noopAction(command);
 
       const snapshot = [...groupAnnotations];
 

--- a/plugins/idah-video/frontend/src/lib/commands/selection/delete.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/selection/delete.ts
@@ -8,6 +8,7 @@ import { data, type AnnotationItem } from "$lib/state/data.svelte";
 import type { IIdahDriverV2 } from "$idah/v2/types";
 import { noopAction } from "..";
 import { isEditable } from "$lib/state/editor.svelte";
+import { annotation } from "$lib/state/annotation.svelte";
 
 export const command = {
   name: "selection.delete",
@@ -32,6 +33,8 @@ export function register(driver: IIdahDriverV2): void {
 
       if (sel.type === "annotation") {
         const record = sel.annotation as AnnotationItem;
+        // Locked annotations (or those belonging to a locked group) must not be deletable.
+        if (annotation.isLocked(record)) return noopAction(command);
         return {
           command: { ...command },
           async do() {
@@ -57,6 +60,8 @@ export function register(driver: IIdahDriverV2): void {
         (ann) => (ann as any).metadata?.group_id === groupId || ann.id === groupId,
       );
       if (records.length === 0) return noopAction(command);
+      // Block group deletion if any member annotation belongs to a locked group.
+      if (records.some((r) => annotation.isLocked(r))) return noopAction(command);
 
       return {
         command: { ...command },

--- a/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/menus.ts
+++ b/plugins/idah-video/frontend/src/lib/components/App/CategorySelector/menus.ts
@@ -98,12 +98,14 @@ export function getCategoryDeleteAction(
   const { items } = opts;
   if (items.length === 0) return null;
 
+  const isSomeLocked = items.some((item) => annotation.isLocked(item));
+
   return {
     id: "delete",
     label: "Delete category annotations",
     icon: Trash2Icon,
     destructive: true,
-    disabled: !isEditable(),
+    disabled: !isEditable() || isSomeLocked,
     onClick: async (e: MouseEvent) => {
       e.stopPropagation();
       onClickDelete();

--- a/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
@@ -192,11 +192,12 @@
           getDriver().command.call("timeline.focus");
         },
       },
-      ...(isEditable() && !annotation.isLocked(ann)
+      ...(isEditable()
         ? [
             {
               label: "Delete Annotation",
               icon: Trash2Icon,
+              disabled: annotation.isLocked(ann),
               onclick: (e: MouseEvent) => {
                 e.stopPropagation();
                 getDriver().command.call("annotation.delete", { annotationId: ann.id });
@@ -301,13 +302,10 @@
             </button>
 
             <div class="ml-auto flex shrink-0 items-center gap-0">
-              {#each getAnnotationActions(ann) as { label, icon: Icon, onclick }}
-                <CategoryAction
-                  {label}
-                  icon={Icon}
-                  {onclick}
-                  class="opacity-0 transition-opacity group-hover:opacity-100"
-                />
+              {#each getAnnotationActions(ann) as { label, icon: Icon, disabled, onclick }}
+                <div class="opacity-0 transition-opacity group-hover:opacity-100">
+                  <CategoryAction {label} icon={Icon} {disabled} {onclick} />
+                </div>
               {/each}
             </div>
           </div>

--- a/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/SelectionPanel.svelte
@@ -23,6 +23,7 @@
   import { getDriver } from "$lib/state/driver.svelte";
   import { selection } from "$lib/state/selection.svelte";
   import { isEditable } from "$lib/state/editor.svelte";
+  import { annotation } from "$lib/state/annotation.svelte";
   import { viewport } from "$lib/state/viewport.svelte";
   import { compareGroups, categoryValueToLabel } from "$lib/utils/annotation";
   import { VIDEO_POLYGON } from "$lib/types";
@@ -191,7 +192,7 @@
           getDriver().command.call("timeline.focus");
         },
       },
-      ...(isEditable()
+      ...(isEditable() && !annotation.isLocked(ann)
         ? [
             {
               label: "Delete Annotation",

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackInfoHeader.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackInfoHeader.svelte
@@ -22,6 +22,7 @@
   // Variables
   const isAllHidden = $derived(annotations.length > 0 && annotations.every((ann) => annotation.isHidden(ann)));
   const isAllLocked = $derived(annotations.length > 0 && annotations.every((ann) => annotation.isLocked(ann)));
+  const isSomeLocked = $derived(annotations.some((ann) => annotation.isLocked(ann)));
   const menus = $derived<Menus>({
     actions: {
       items: {
@@ -42,7 +43,7 @@
         "delete-all": {
           label: "Delete all annotations",
           icon: Trash2Icon,
-          disabled: !isEditable(),
+          disabled: !isEditable() || isSomeLocked,
           onClick: () => {
             showConfirmDialog({
               title: "Delete all annotations",

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/menus.ts
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/menus.ts
@@ -47,7 +47,7 @@ export function getGroupContextMenus(props: { track: TrackData }): Menus {
           label: "Delete group",
           icon: Trash2Icon,
           destructive: true,
-          disabled: !isEditable(),
+          disabled: !isEditable() || isSomeLocked,
           onClick: () => {
             showConfirmDialog({
               title: "Delete annotation group",


### PR DESCRIPTION
Prevent users from deleting locked annotations and groups by:
- Adding isLocked checks in delete command handlers (annotation, group, category, all)
- Disabling delete UI buttons when any annotation in selection is locked
- Blocking delete-all entirely when any annotation belongs to a locked group