### PR TITLE
IDAH - Update polygon closing cursor in Image Plugin

### DIFF
--- a/plugins/idah-image/frontend/src/lib/components/App/Viewport/Shapes/Polygon/utils.ts
+++ b/plugins/idah-image/frontend/src/lib/components/App/Viewport/Shapes/Polygon/utils.ts
@@ -146,20 +146,28 @@ export function computeScaleFactor(centroid: Point, dragStart: Point, currentCur
 /**
  * Check if a normalized cursor is within `hitRadiusPx` pixels of the first polygon draft point.
  * Used to determine when to close a polygon during creation.
+ *
+ * @param cursor - normalized cursor position [0-1]
+ * @param mediaWidth - media width in pixels
+ * @param mediaHeight - media height in pixels
+ * @param points - polygon draft points as normalized coordinates [0-1]
+ * @param viewportScale - current viewport zoom scale (media pixels → screen pixels)
  */
 export function nearFirstPolygonPoint(
   cursor: Point,
   mediaWidth: number,
   mediaHeight: number,
   points: Point[],
+  viewportScale: number = 1,
 ): boolean {
   if (points.length < 3) return false;
-  const CLOSE_RADIUS_PX = 7;
-  const CLOSE_RADIUS_SQ = CLOSE_RADIUS_PX * CLOSE_RADIUS_PX;
+  const screenToMediaScale = 1 / viewportScale;
+  const closeRadiusMediaPx = 7 * screenToMediaScale;
+  const closeRadiusMediaPxSq = closeRadiusMediaPx * closeRadiusMediaPx;
   const first = points[0];
   const dx = Math.abs(cursor[0] - first[0]) * mediaWidth;
   const dy = Math.abs(cursor[1] - first[1]) * mediaHeight;
-  return dx * dx + dy * dy < CLOSE_RADIUS_SQ;
+  return dx * dx + dy * dy < closeRadiusMediaPxSq;
 }
 
 /** SVG data URL for a dot sight crosshair cursor (crosshair with a central dot). */

--- a/plugins/idah-image/frontend/src/lib/components/App/Viewport/Shapes/PolygonCreateShape.svelte
+++ b/plugins/idah-image/frontend/src/lib/components/App/Viewport/Shapes/PolygonCreateShape.svelte
@@ -9,12 +9,14 @@
   // Used by ShapesContainer in polygon build mode.
   // ---------------------------------------------------------------------------
 
+  import { onMount } from "svelte";
+
   import { draft as polygonDraft } from "$lib/commands/annotation/polygon.add_point.svelte";
   import { getDriver } from "$lib/state/driver.svelte";
   import { viewport } from "$lib/state/viewport.svelte";
-  import type { Point } from "$lib/utils/math/point";
-  import { onMount } from "svelte";
   import { nearFirstPolygonPoint } from "./Polygon/utils";
+
+  import type { Point } from "$lib/utils/math/point";
 
   // ── Props ──────────────────────────────────────────────────────────────
   type Props = {
@@ -43,7 +45,9 @@
    */
   export function handleMouseDown(cursor: Point): boolean {
     // ── Close polygon (click near first point with ≥3 points) ──────────
-    if (nearFirstPolygonPoint(cursor, mediaWidth, mediaHeight, polygonDraft.points)) {
+    if (
+      nearFirstPolygonPoint(cursor, mediaWidth, mediaHeight, polygonDraft.points, viewport.workspace.transform.scale)
+    ) {
       const pts = [...polygonDraft.points];
       polygonDraft.reset();
       // Route through onSelection so the workspace can apply pendingValue (selected category)

--- a/plugins/idah-image/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
+++ b/plugins/idah-image/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
@@ -194,7 +194,14 @@
 
   // ── Check if cursor is hovering the first polygon draft point ────────
   let hoveringFirstPoint = $derived(
-    isPolygonMode && nearFirstPolygonPoint(sceneNormalizedCursor, media.width, media.height, polygonDraft.points),
+    isPolygonMode &&
+      nearFirstPolygonPoint(
+        sceneNormalizedCursor,
+        media.width,
+        media.height,
+        polygonDraft.points,
+        viewport.workspace.transform.scale,
+      ),
   );
 
   // ── Cursor class ─────────────────────────────────────────────────────


### PR DESCRIPTION
**Image Plugin**

- Fix polygon closing hit radius calculation to account for viewport scale.
- Ensure the polygon close/snap area remains consistent across all zoom levels.
- Prevent the closing hit area from becoming too small when zoomed in or too large when zoomed out.