### PR TITLE
IDAH - Project description not displayed on Project page

### DIFF
--- a/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/+layout.svelte
+++ b/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/+layout.svelte
@@ -39,9 +39,7 @@
   // Records
   let project: ProjectRecord = $state(new ProjectRecord());
 
-  $effect(() => {
-    setContext("project", project);
-  });
+  setContext("project", project);
 
   // Lifecycle
   onMount(async () => {
@@ -60,13 +58,14 @@
   });
 
   // Functions
-  async function fetchProject() {
+  async function fetchProject(): Promise<ProjectRecord> {
     const projectRes = await projectsBackendDataSource.get(projectId, {
       fields: {
-        [ProjectRecord.type]: ["name"],
+        [ProjectRecord.type]: ["name", "description"],
       },
     });
-    project = projectRes.data;
+    Object.assign(project, projectRes.data);
+
     return project;
   }
 
@@ -92,6 +91,7 @@
               <Text size="h2" weight="semibold">{project.name}</Text>
               <ProjectDropdownMenu {projectId} align="center" />
             </div>
+            <Text size="sm">{project.description}</Text>
           {/snippet}
         </PageHeader>
 

--- a/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/+layout.svelte
+++ b/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/+layout.svelte
@@ -91,7 +91,7 @@
               <Text size="h2" weight="semibold">{project.name}</Text>
               <ProjectDropdownMenu {projectId} align="center" />
             </div>
-            <Text size="sm">{project.description}</Text>
+            <Text class="text-muted-foreground" size="sm">{project.description}</Text>
           {/snippet}
         </PageHeader>
 

--- a/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/+layout.svelte
+++ b/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/+layout.svelte
@@ -91,7 +91,10 @@
               <Text size="h2" weight="semibold">{project.name}</Text>
               <ProjectDropdownMenu {projectId} align="center" />
             </div>
-            <Text class="text-muted-foreground" size="sm">{project.description}</Text>
+
+            {#if project.description}
+              <Text class="text-muted-foreground" size="sm">{project.description}</Text>
+            {/if}
           {/snippet}
         </PageHeader>
 


### PR DESCRIPTION
## Summary

Fix an issue where the project description was not displayed on the Project page.

## Root Cause

The Project page only requested the project name from the backend and did not include the `description` field in the project fetch request. As a result, the project description was unavailable for rendering in the page header.

## Changes

* Updated the project fetch request to include the `description` field.
* Added project description rendering below the project name in the page header.
* Ensured the description is displayed consistently across Project pages after data is loaded.

## Testing

* Verified that projects with descriptions display the description correctly on the Project page.
* Verified that projects without descriptions continue to load without errors.
* Confirmed that existing Project page functionality remains unchanged.
