### PR TITLE
Fix: Improve email validation and form state management in project member invitations

### DIFF
--- a/app/frontend/src/lib/components/app/forms/fields/combobox/combobox-field.svelte
+++ b/app/frontend/src/lib/components/app/forms/fields/combobox/combobox-field.svelte
@@ -17,6 +17,7 @@
   interface Props extends SingleSelectDataSourceFieldBaseProps<T> {
     value: string | number | null;
     onInput?: () => void;
+    onEnter?: () => void;
   }
   let {
     dataSource,
@@ -38,6 +39,7 @@
     class: className,
     onSelected,
     onInput,
+    onEnter,
     slotLabel,
     slotChoice,
     slotInfo,
@@ -188,6 +190,9 @@
         )}
         oninput={onComboboxInput}
         onblur={onBlur}
+        onkeydown={(e) => {
+          if (e.key === "Enter") onEnter?.();
+        }}
         autofocus={false}
         {disabled}
         {placeholder}

--- a/app/frontend/src/lib/components/app/projects/members/forms/project-member-form.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/forms/project-member-form.svelte
@@ -11,10 +11,10 @@
   import { FieldGroup, FieldSet } from "@/components/ui/field";
 
   import {
-    ProjectMemberRecord,
-    projectMemberRoles,
-    projectMembersBackendDataSource,
-    type ProjectMemberRole,
+      ProjectMemberRecord,
+      projectMemberRoles,
+      projectMembersBackendDataSource,
+      type ProjectMemberRole,
   } from "@/data/model/dataset/projects/members/record";
   import { assignProjectMemberRoleSchema } from "@/data/model/dataset/projects/members/schema";
   import { accountsBackendDataSource } from "@/data/model/iam/accounts/record";
@@ -60,7 +60,12 @@
     members = members.filter((_, i) => i !== index);
   }
 
-  function checkEmailValidate(member: { email: string; role: ProjectMemberRole | null; errors?: string[] }): void {
+  function validateEmail(member: { email: string; role: ProjectMemberRole | null; errors?: string[] }): void {
+    if (!member.email) {
+      member.errors = [];
+      return;
+    }
+
     const validationResult = validateData(assignProjectMemberRoleSchema, {
       email: member.email,
     });
@@ -102,12 +107,12 @@
           onSelected={(selectedValue) => {
             member.email = (selectedValue ?? "") as string;
             if (selectedValue !== null) {
-              checkEmailValidate(member);
+              validateEmail(member);
             } else {
               member.errors = [];
             }
           }}
-          onEnter={() => checkEmailValidate(member)}
+          onEnter={() => validateEmail(member)}
         >
           {#snippet slotChoice({ choice })}
             {@const isAlreadyAdded =
@@ -157,7 +162,7 @@
         />
 
         <!-- REMOVE MEMBER BUTTON -->
-        <Button variant="ghost" size="icon" onclick={() => removeMember(index)}>
+        <Button variant="ghost" size="icon" class={index === 0 ? "mt-6" : ""} onclick={() => removeMember(index)}>
           <Trash2Icon />
         </Button>
       </div>

--- a/app/frontend/src/lib/components/app/projects/members/forms/project-member-form.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/forms/project-member-form.svelte
@@ -21,9 +21,11 @@
   import { cn } from "@/utils";
   import { getFieldErrors, validateData } from "@/utils/validate";
 
+  import type { AssignProjectMemberType } from "@/data/model/dataset/projects/members/type";
+
   // Props
   interface Props {
-    members: Array<{ email: string; role: ProjectMemberRole | null; errors?: string[] }>;
+    members: Array<AssignProjectMemberType>;
   }
   let { members = $bindable() }: Props = $props();
 
@@ -60,7 +62,7 @@
     members = members.filter((_, i) => i !== index);
   }
 
-  function selectEmail(member: { email: string; role: ProjectMemberRole | null; errors?: string[] }): void {
+  function selectEmail(member: AssignProjectMemberType): void {
     if (!member.email) {
       member.errors = [];
       return;
@@ -76,10 +78,7 @@
     }
   }
 
-  function handleEmailSelect(
-    member: { email: string; role: ProjectMemberRole | null; errors?: string[] },
-    selectedValue: string | number | null,
-  ): void {
+  function handleEmailSelect(member: AssignProjectMemberType, selectedValue: string | number | null): void {
     member.email = (selectedValue ?? "") as string;
     selectEmail(member);
   }

--- a/app/frontend/src/lib/components/app/projects/members/forms/project-member-form.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/forms/project-member-form.svelte
@@ -32,8 +32,6 @@
 
   let projectId = page.params.projectId as string;
   let projectMemberEmails: Array<string> = $state([]);
-  let selectedMemberEmails: Array<string> = $derived(members.map((member) => member.email));
-  let disabledMemberEmails: Array<string> = $derived([...projectMemberEmails, ...selectedMemberEmails]);
 
   // Lifecycle
   onMount(() => {
@@ -103,15 +101,17 @@
           errors={member.errors}
           onSelected={(selectedValue) => {
             member.email = (selectedValue ?? "") as string;
-            checkEmailValidate(member);
+            if (selectedValue !== null) {
+              checkEmailValidate(member);
+            } else {
+              member.errors = [];
+            }
           }}
-          onInput={() => {
-            checkEmailValidate(member);
-          }}
+          onEnter={() => checkEmailValidate(member)}
         >
           {#snippet slotChoice({ choice })}
             {@const isAlreadyAdded =
-              disabledMemberEmails.includes(String(choice.value)) && choice.value !== member.email}
+              projectMemberEmails.includes(String(choice.value)) && choice.value !== member.email}
             {@const isSelected = choice.value === member.email}
             <Combobox.Item
               class={cn(

--- a/app/frontend/src/lib/components/app/projects/members/forms/project-member-form.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/forms/project-member-form.svelte
@@ -75,6 +75,14 @@
       member.errors = [];
     }
   }
+
+  function handleEmailSelect(
+    member: { email: string; role: ProjectMemberRole | null; errors?: string[] },
+    selectedValue: string | number | null,
+  ): void {
+    member.email = (selectedValue ?? "") as string;
+    selectEmail(member);
+  }
 </script>
 
 {#snippet noLabel()}{/snippet}
@@ -104,14 +112,7 @@
           required
           value={member.email}
           errors={member.errors}
-          onSelected={(selectedValue) => {
-            member.email = (selectedValue ?? "") as string;
-            if (selectedValue !== null) {
-              selectEmail(member);
-            } else {
-              member.errors = [];
-            }
-          }}
+          onSelected={(selectedValue) => handleEmailSelect(member, selectedValue)}
           onEnter={() => selectEmail(member)}
         >
           {#snippet slotChoice({ choice })}

--- a/app/frontend/src/lib/components/app/projects/members/forms/project-member-form.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/forms/project-member-form.svelte
@@ -60,7 +60,7 @@
     members = members.filter((_, i) => i !== index);
   }
 
-  function validateEmail(member: { email: string; role: ProjectMemberRole | null; errors?: string[] }): void {
+  function selectEmail(member: { email: string; role: ProjectMemberRole | null; errors?: string[] }): void {
     if (!member.email) {
       member.errors = [];
       return;
@@ -107,12 +107,12 @@
           onSelected={(selectedValue) => {
             member.email = (selectedValue ?? "") as string;
             if (selectedValue !== null) {
-              validateEmail(member);
+              selectEmail(member);
             } else {
               member.errors = [];
             }
           }}
-          onEnter={() => validateEmail(member)}
+          onEnter={() => selectEmail(member)}
         >
           {#snippet slotChoice({ choice })}
             {@const isAlreadyAdded =
@@ -162,7 +162,14 @@
         />
 
         <!-- REMOVE MEMBER BUTTON -->
-        <Button variant="ghost" size="icon" class={index === 0 ? "mt-6" : ""} onclick={() => removeMember(index)}>
+        <Button
+          variant="ghost"
+          size="icon"
+          class={cn("", {
+            "mt-6": index === 0,
+          })}
+          onclick={() => removeMember(index)}
+        >
           <Trash2Icon />
         </Button>
       </div>

--- a/app/frontend/src/lib/components/app/projects/members/forms/project-member-form.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/forms/project-member-form.svelte
@@ -11,10 +11,10 @@
   import { FieldGroup, FieldSet } from "@/components/ui/field";
 
   import {
-      ProjectMemberRecord,
-      projectMemberRoles,
-      projectMembersBackendDataSource,
-      type ProjectMemberRole,
+    ProjectMemberRecord,
+    projectMemberRoles,
+    projectMembersBackendDataSource,
+    type ProjectMemberRole,
   } from "@/data/model/dataset/projects/members/record";
   import { assignProjectMemberRoleSchema } from "@/data/model/dataset/projects/members/schema";
   import { accountsBackendDataSource } from "@/data/model/iam/accounts/record";

--- a/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
@@ -40,6 +40,7 @@
   function closeThisModal(): void {
     open = false;
     submitting = false;
+    resetForm();
   }
 
   function resetForm(): void {
@@ -146,6 +147,18 @@
 
       if (!validated.success) {
         submitting = false;
+        return;
+      }
+
+      const emails = members.map((m) => m.email.toLowerCase());
+      const hasDuplicates = emails.some((email, i) => emails.indexOf(email) !== i);
+
+      if (hasDuplicates) {
+        submitting = false;
+        showToast.error({
+          title: "Duplicate emails",
+          description: "Each member must have a unique email address.",
+        });
         return;
       }
 

--- a/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/overlays/project-member-form-modal.svelte
@@ -7,11 +7,7 @@
   import DialogTitle from "@/components/ui/dialog/dialog-title.svelte";
 
   import { showToast } from "@/components/ui/toast/index.svelte";
-  import {
-    ProjectMemberRecord,
-    projectMembersBackendDataSource,
-    type ProjectMemberRole,
-  } from "@/data/model/dataset/projects/members/record";
+  import { ProjectMemberRecord, projectMembersBackendDataSource } from "@/data/model/dataset/projects/members/record";
   import { createMultipleProjectMembersSchema } from "@/data/model/dataset/projects/members/schema";
   import { AccountRecord, accountsBackendDataSource } from "@/data/model/iam/accounts/record";
   import { authStatus } from "@/security/AuthContext";
@@ -19,6 +15,7 @@
   import { refetches } from "@/utils/refetch";
 
   import type { FormModalBaseProps } from "@/components/app/overlays/modals/form-modal.types";
+  import type { AssignProjectMemberType } from "@/data/model/dataset/projects/members/type";
 
   // Props
   let { action, open = $bindable() }: FormModalBaseProps = $props();
@@ -28,9 +25,7 @@
 
   let projectId: string | undefined = $derived(page.params.projectId);
   let submitting: boolean = $state(false);
-  let members: Array<{ email: string; role: ProjectMemberRole | null; errors?: string[] }> = $state([
-    { email: "", role: null, errors: [] },
-  ]);
+  let members: Array<AssignProjectMemberType> = $state([{ email: "", role: null, errors: [] }]);
   let disabledSubmitButton: boolean = $derived.by(() => {
     const validated = createMultipleProjectMembersSchema.safeParse(members);
     return !validated.success;

--- a/app/frontend/src/lib/data/model/dataset/projects/members/record.ts
+++ b/app/frontend/src/lib/data/model/dataset/projects/members/record.ts
@@ -4,7 +4,7 @@ import { Transformers } from "@/data/model/transformers";
 
 import { ProjectRecord } from "@/data/model/dataset/projects/project-record";
 
-import type { LabelValue } from "@/components/app/types";
+import type { LabelValue } from "@/utils/types";
 
 @type("dataset:project_members")
 export class ProjectMemberRecord extends Record {

--- a/app/frontend/src/lib/data/model/dataset/projects/members/type.ts
+++ b/app/frontend/src/lib/data/model/dataset/projects/members/type.ts
@@ -1,0 +1,7 @@
+import type { ProjectMemberRole } from "@/data/model/dataset/projects/members/record";
+
+export interface AssignProjectMemberType {
+  email: string;
+  role: ProjectMemberRole | null;
+  errors?: string[];
+}


### PR DESCRIPTION
# Summary

Improved project member invitation flow by enhancing email validation, preventing duplicate entries, and ensuring form state is properly reset after submission.

# Changes

## `project-member-form-modal.svelte`

* Added duplicate email validation in `submit()` before calling `createProjectMember()`
* Duplicate emails are checked case-insensitively
* Displays an error toast when duplicate emails are detected
* Added `resetForm()` call in `closeThisModal()` to clear form state after successful submission

## `combobox-field.svelte`

* Added optional `onEnter` prop to support custom Enter key handling
* Updated `onkeydown` handler to invoke `onEnter?.()` when Enter is pressed
* Keeps the component generic while allowing parent forms to implement custom validation behavior

## `project-member-form.svelte`

* Connected `onEnter` handler to `checkEmailValidate()`
* Email validation now runs when:

  * Selecting an email option
  * Pressing Enter while typing in the email field

# Why

* Prevents users from accidentally inviting the same email multiple times in a single submission
* Provides immediate validation feedback when users press Enter
* Ensures the form starts in a clean state whenever the modal is reopened
* Preserves separation of concerns by keeping validation logic within the form while maintaining a reusable combobox component
