### PR TITLE
Frontend & Plugin: streamline media info retrieval

### DIFF
--- a/app/frontend/src/lib/data/model/media/medias/medias-record.ts
+++ b/app/frontend/src/lib/data/model/media/medias/medias-record.ts
@@ -1,10 +1,10 @@
 import { createBackendDataSource, resourcePath } from "@/data/BackendDataSource";
 import { clearCache } from "@/data/Cache";
-import { parseSingleElementError, parseCollectionReturn } from "@/data/model/json_api";
+import { parseSingleElementError, parseCollectionReturn, parseSingleElementReturn } from "@/data/model/json_api";
 import { field, Record, RecordFactory, type } from "@/data/model/Record";
 import { showErrorToast } from "@/utils/error/error.toasts";
 
-import type { CollectionResponse, JsonApiErrorResponse, JsonApiMeta } from "@/data/model/types";
+import type { CollectionResponse, JsonApiErrorResponse, JsonApiMeta, RecordResponse } from "@/data/model/types";
 import type { Hash } from "@/utils/types";
 
 // A file the backend did not turn into a media record: either intentionally

--- a/app/frontend/src/lib/plugin/v2/driver/index.ts
+++ b/app/frontend/src/lib/plugin/v2/driver/index.ts
@@ -14,7 +14,6 @@ import type {
   INotesDriverV2,
   IProjectInfo,
   IShapeConfig,
-  IStatsDriverV2,
   ISyncErrorEvent,
   ISyncEvent,
   Unsubscribe,
@@ -364,39 +363,20 @@ export async function createIdahDriverV2(entryId: string): Promise<IIdahDriverV2
   };
 
   // Get media info
-  let mediaInfo: IMediaInfo;
-  try {
-    const mediaRes = (await mediaBackendDataSource.getInfo({
-      resource: entry.resource,
-    })) as RecordResponse<MediaRecord>;
+  const mediaRes = (await mediaBackendDataSource.getInfo({
+    resource: entry.resource,
+  })) as RecordResponse<MediaRecord>;
 
-    const m = mediaRes.data;
-    mediaInfo = {
-      id: entry.id,
-      resource: m.resource,
-      key: m.key,
-      mime_type: m.mime_type,
-      filename: m.filename,
-      meta: m.meta,
-      url:
-        entry.dataset.modality === "idah-video"
-          ? `${import.meta.env.VITE_IDAH_HOST}/api/v1/media/medias/files/${entry.resource}/master.m3u8`
-          : `${import.meta.env.VITE_IDAH_HOST}/api/v1/media/medias/files/${entry.resource}/processed.webp`,
-    };
-  } catch {
-    mediaInfo = {
-      id: entry.id,
-      resource: entry.resource,
-      key: "",
-      mime_type: "",
-      filename: entry.name,
-      meta: {},
-      url:
-        entry.dataset.modality === "idah-video"
-          ? `${import.meta.env.VITE_IDAH_HOST}/api/v1/media/medias/files/${entry.resource}/master.m3u8`
-          : `${import.meta.env.VITE_IDAH_HOST}/api/v1/media/medias/files/${entry.resource}/processed.webp`,
-    };
-  }
+  const m = mediaRes.data;
+  const mediaInfo = {
+    id: entry.id,
+    resource: m.resource,
+    key: m.key,
+    mime_type: m.mime_type,
+    filename: m.filename,
+    meta: m.meta,
+    url: `${import.meta.env.VITE_IDAH_HOST}/api/v1/media/medias/files/${entry.resource}`,
+  };
 
   const driver = new IdahDriverV2({
     id: entry.id,

--- a/app/frontend/src/lib/plugin/v2/types.ts
+++ b/app/frontend/src/lib/plugin/v2/types.ts
@@ -48,8 +48,7 @@ export interface IMediaInfo {
   mime_type: string;
   filename: string;
   meta: Record<string, unknown>;
-  /** Optional explicit URL (overrides the auto-generated path from resource/key). */
-  url?: string;
+  url: string;
 }
 
 // ─── Sync event ───────────────────────────────────────────────────────────

--- a/plugins/idah-image/frontend/src/lib/state/media.svelte.ts
+++ b/plugins/idah-image/frontend/src/lib/state/media.svelte.ts
@@ -14,8 +14,6 @@ function readMeta(): Record<string, unknown> {
   return readMedia()?.meta ?? {};
 }
 
-const MEDIA_BASE = "/medias/files";
-
 export const media = {
   get dimensions(): number[] {
     return [this.width, this.height];
@@ -36,12 +34,7 @@ export const media = {
   get format(): string {
     return readMedia()?.mime_type ?? "";
   },
-  /** Construct the download URL from the media's resource and key, or use an explicit url. */
   get url(): string {
-    const m = readMedia();
-    if (!m) return "";
-    if (m.url) return m.url;
-    const path = m.key ? `${m.resource}/${m.key}` : m.resource;
-    return `${MEDIA_BASE}/${path}`;
+    return readMedia()?.url ?? "";
   },
 };

--- a/plugins/idah-image/frontend/src/lib/state/media.test.ts
+++ b/plugins/idah-image/frontend/src/lib/state/media.test.ts
@@ -47,26 +47,8 @@ describe("media state", () => {
     expect(media.format).toBe("image/jpeg");
   });
 
-  it("returns url from the driver media when url is set", () => {
+  it("returns url from the driver media", () => {
     expect(media.url).toBe("/medias/master.jpg");
-  });
-
-  it("constructs url from resource/key when url is not set", () => {
-    mockMedia.url = "";
-    mockMedia.key = "subdir/image.jpg";
-    expect(media.url).toBe("/medias/files/mock-entry-001/subdir/image.jpg");
-  });
-
-  it("constructs url from resource only when key is empty", () => {
-    mockMedia.url = "";
-    mockMedia.key = "";
-    expect(media.url).toBe("/medias/files/mock-entry-001");
-  });
-
-  it("returns empty string for url when driver returns null", () => {
-    // getDriver is already a vi.fn() via the vi.mock factory
-    (getDriver as ReturnType<typeof vi.fn>).mockReturnValueOnce(null);
-    expect(media.url).toBe("");
   });
 });
 

--- a/plugins/idah-video/frontend/src/lib/components/App/VideoAnnotationWorkspace/VideoAnnotationWorkspace.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/VideoAnnotationWorkspace/VideoAnnotationWorkspace.svelte
@@ -429,18 +429,6 @@
     }
   }
 
-  function selectAnnotationGroup(annotationGroup: AnnotationGroup<IVideoAnnotationRecord>, selectedFrame?: number) {
-    selection.selectGroup(annotationGroup.groupId);
-
-    if (isNoteMode) return;
-
-    const firstAnnotation = annotationGroup.annotations[0];
-    if (selectedFrame && firstAnnotation?.shape.type && editable) {
-      viewport.mode = firstAnnotation.shape.type;
-      selectClosestAnnotation(annotationGroup, selectedFrame);
-    }
-  }
-
   function selectClosestAnnotation(annotationGroup: AnnotationGroup<IVideoAnnotationRecord>, frame: number) {
     const closestAnnotation = findClosestAnnotationInGroup({
       annotationGroup,
@@ -494,7 +482,13 @@
     return Promise.resolve(viewportAnnotations);
   });
 
-  function showNewNotePopup(params: { anchorType: "entry" | "annotation"; position?: Record<string, unknown>; annotationId?: string | null; screenX?: number; screenY?: number }) {
+  function showNewNotePopup(params: {
+    anchorType: "entry" | "annotation";
+    position?: Record<string, unknown>;
+    annotationId?: string | null;
+    screenX?: number;
+    screenY?: number;
+  }) {
     const { anchorType, position, annotationId, screenX, screenY } = params;
     const driver = getDriver();
     driver.notes.requestCreateNote({

--- a/plugins/idah-video/frontend/src/lib/state/media.svelte.ts
+++ b/plugins/idah-video/frontend/src/lib/state/media.svelte.ts
@@ -15,8 +15,6 @@ function readMeta(): Record<string, unknown> {
   return readMedia()?.meta ?? {};
 }
 
-const MEDIA_BASE = "/medias/files";
-
 export const media = {
   get duration(): number {
     const val = readMeta().duration as number;
@@ -47,12 +45,7 @@ export const media = {
   get id(): string {
     return readMedia()?.id ?? "";
   },
-  /** Construct the download URL from the media's resource and key, or use an explicit url. */
   get url(): string {
-    const m = readMedia();
-    if (!m) return "";
-    if (m.url) return m.url;
-    const path = m.key ? `${m.resource}/${m.key}` : m.resource;
-    return `${MEDIA_BASE}/${path}`;
+    return readMedia()?.url ?? "";
   },
 };

--- a/plugins/idah-video/frontend/src/lib/state/media.test.ts
+++ b/plugins/idah-video/frontend/src/lib/state/media.test.ts
@@ -59,26 +59,8 @@ describe("media state", () => {
     expect(media.id).toBe("mock-entry-001");
   });
 
-  it("returns url from the driver media when url is set", () => {
+  it("returns url from the driver media", () => {
     expect(media.url).toBe("/medias/master.m3u8");
-  });
-
-  it("constructs url from resource/key when url is not set", () => {
-    mockMedia.url = "";
-    mockMedia.key = "subdir/video.mp4";
-    expect(media.url).toBe("/medias/files/mock-entry-001/subdir/video.mp4");
-  });
-
-  it("constructs url from resource only when key is empty", () => {
-    mockMedia.url = "";
-    mockMedia.key = "";
-    expect(media.url).toBe("/medias/files/mock-entry-001");
-  });
-
-  it("returns empty string for url when driver returns null", () => {
-    // getDriver is already a vi.fn() via the vi.mock factory
-    (getDriver as ReturnType<typeof vi.fn>).mockReturnValueOnce(null);
-    expect(media.url).toBe("");
   });
 });
 


### PR DESCRIPTION
## Frontend & Plugin: Streamline Media Info Retrieval and Enforce URL Presence

### What Changed
- Simplified how media information (file URLs, metadata, etc.) is retrieved and passed around the application
- Made the media URL required (non-optional) in the `IMediaInfo` interface to prevent undefined URL errors
- Cleaned up redundant code in media state management across video and image plugins

### Why It Matters
- Prevents bugs where media files fail to load because their URLs are missing
- Reduces complexity by removing unnecessary intermediate data transformations
- Makes the codebase more maintainable by consolidating media URL handling in one place