### PR TITLE
Dataset status revision

### DIFF
--- a/app/dataset/app/model/dataset.rb
+++ b/app/dataset/app/model/dataset.rb
@@ -167,13 +167,24 @@ module Dataset
       return if total_entries.zero?
 
       completed_entries = dataset[:entries_completed_count]
+      in_progress_entries = dataset[:entries_in_progress_count]
+
+      # Entries awaiting next-stage assignment (e.g. submitted, waiting for a
+      # reviewer) are back to "pending" status but have already been worked on.
+      # submitted_by_id distinguishes them from fresh, untouched entries.
+      submitted_entries = table.db[:entries]
+                               .where(dataset_id:)
+                               .exclude(submitted_by_id: nil)
+                               .count
 
       progress = completed_entries.to_f / total_entries
 
       if completed_entries >= total_entries
         completed!(dataset_id, progress)
-      else
+      elsif in_progress_entries.positive? || completed_entries.positive? || submitted_entries.positive?
         in_progress!(dataset_id, progress)
+      else
+        pending!(dataset_id, progress)
       end
     end
 
@@ -224,6 +235,13 @@ module Dataset
     def in_progress!(dataset_id, progress)
       no_event do
         update!(dataset_id, { progress: progress, status: "in_progress" })
+      end
+    end
+
+    event(name: "pending")
+    def pending!(dataset_id, progress)
+      no_event do
+        update!(dataset_id, { progress: progress, status: "pending" })
       end
     end
 

--- a/app/dataset/app/model/dataset.rb
+++ b/app/dataset/app/model/dataset.rb
@@ -169,13 +169,11 @@ module Dataset
       completed_entries = dataset[:entries_completed_count]
       in_progress_entries = dataset[:entries_in_progress_count]
 
-      # Entries awaiting next-stage assignment (e.g. submitted, waiting for a
-      # reviewer) are back to "pending" status but have already been worked on.
-      # submitted_by_id distinguishes them from fresh, untouched entries.
-      submitted_entries = table.db[:entries]
-                               .where(dataset_id:)
-                               .exclude(submitted_by_id: nil)
-                               .count
+      # Entries that have been submitted at least once have already been worked
+      # on, even if they are back to "pending" status awaiting a next stage
+      # (e.g. submitted, waiting for a reviewer). The counter is maintained by
+      # the dataset entry-counters trigger.
+      submitted_entries = dataset[:entries_submitted_count]
 
       progress = completed_entries.to_f / total_entries
 

--- a/app/dataset/app/model/dataset_spec.rb
+++ b/app/dataset/app/model/dataset_spec.rb
@@ -10,4 +10,83 @@ RSpec.describe Dataset, database: true do
       expect(subject).to be_a(Dataset::Repository)
     end
   end
+
+  describe "#update_progress!" do
+    let(:auth_context) { Verse::Auth::Context[:system] }
+
+    subject { Dataset::Repository.new(auth_context) }
+
+    let(:entry_repo) { Entry::Repository.new(auth_context) }
+    let(:project_repo) { Project::Repository.new(auth_context) }
+
+    let!(:project_id) do
+      project_repo.create(
+        name: "Test Project",
+        description: "A test project",
+        created_by_email: "user@example.com",
+        organization_id: 1
+      )
+    end
+
+    let!(:dataset_id) do
+      subject.create(
+        modality: "video",
+        labels: ["cat", "dog"],
+        labeling_configuration: {},
+        workflow_configuration: {},
+        project_id:
+      )
+    end
+
+    # The DB counter trigger only adjusts completed/in_progress counts on a
+    # status change (UPDATE), so entries must be created pending then transitioned.
+    def add_entry(status)
+      id = entry_repo.create({ project_id:, dataset_id:, status: "pending", wf_step: "start" })
+      entry_repo.update!(id, { status: }) unless status == "pending"
+      id
+    end
+
+    it "stays pending when entries exist but none are assigned or completed" do
+      add_entry("pending")
+      subject.update_progress!(dataset_id)
+      expect(subject.find!(dataset_id).status).to eq("pending")
+    end
+
+    it "becomes in_progress when an entry is assigned (in_progress)" do
+      add_entry("in_progress")
+      subject.update_progress!(dataset_id)
+      expect(subject.find!(dataset_id).status).to eq("in_progress")
+    end
+
+    it "stays in_progress when a submitted entry is pending (awaiting review)" do
+      id = entry_repo.create({ project_id:, dataset_id:, status: "pending", wf_step: "review" })
+      entry_repo.update!(id, { submitted_by_id: 1, submitted_by_email: "a@example.com" })
+
+      subject.update_progress!(dataset_id)
+      expect(subject.find!(dataset_id).status).to eq("in_progress")
+    end
+
+    it "becomes in_progress when some but not all entries are completed" do
+      add_entry("completed")
+      add_entry("pending")
+      subject.update_progress!(dataset_id)
+      expect(subject.find!(dataset_id).status).to eq("in_progress")
+    end
+
+    it "becomes completed when all entries are completed" do
+      add_entry("completed")
+      subject.update_progress!(dataset_id)
+      expect(subject.find!(dataset_id).status).to eq("completed")
+    end
+
+    it "reopens a completed dataset to in_progress when a new unassigned entry is added" do
+      add_entry("completed")
+      subject.update_progress!(dataset_id)
+      expect(subject.find!(dataset_id).status).to eq("completed")
+
+      add_entry("pending")
+      subject.update_progress!(dataset_id)
+      expect(subject.find!(dataset_id).status).to eq("in_progress")
+    end
+  end
 end

--- a/app/dataset/app/service/entry/service.rb
+++ b/app/dataset/app/service/entry/service.rb
@@ -107,6 +107,7 @@ module Entry
         entry = entries.find!(id)
         member = project_members.find_by({ account_id: assigned_to_id, project_id: entry.project_id })
         entries.assign(id, assigned_to_id, member&.email)
+        system_datasets_repo.update_progress!(entry.dataset_id)
         entries.find!(id)
       end
     end
@@ -114,7 +115,9 @@ module Entry
     def unassign_member(id)
       entries.transaction do
         entries.unassign(id)
-        entries.find!(id)
+        entry = entries.find!(id)
+        system_datasets_repo.update_progress!(entry.dataset_id)
+        entry
       end
     end
 
@@ -130,6 +133,7 @@ module Entry
 
         # Use read scope when updating as anyone with read access can select
         entries.select(entry.id)
+        system_datasets_repo.update_progress!(entry.dataset_id)
         entries.find!(entry.id)
       end
     end

--- a/app/dataset/app/service/entry/service_spec.rb
+++ b/app/dataset/app/service/entry/service_spec.rb
@@ -317,11 +317,17 @@ RSpec.describe Entry::Service, database: true do
       expect(updated_entry.assigned_to_id).to eq(2)
       expect(updated_entry.status).to eq("in_progress")
     end
+
+    it "moves the dataset to in_progress" do
+      subject.assign_member(entry.id, 2)
+
+      expect(dataset_repo.find!(dataset_id).status).to eq("in_progress")
+    end
   end
 
   describe "#unassign_member" do
     before do
-      repo.update!(entry.id, { assigned_to_id: 2, status: "in_progress" })
+      subject.assign_member(entry.id, 2)
     end
 
     it "clears the assigned member and sets status to pending" do
@@ -330,6 +336,14 @@ RSpec.describe Entry::Service, database: true do
       updated_entry = repo.find!(entry.id)
       expect(updated_entry.assigned_to_id).to be_nil
       expect(updated_entry.status).to eq("pending")
+    end
+
+    it "moves the dataset back to pending when the last assignment is removed" do
+      expect(dataset_repo.find!(dataset_id).status).to eq("in_progress")
+
+      subject.unassign_member(entry.id)
+
+      expect(dataset_repo.find!(dataset_id).status).to eq("pending")
     end
   end
 

--- a/app/dataset/db/migrations/20260626000000_add_entries_submitted_count_to_datasets.rb
+++ b/app/dataset/db/migrations/20260626000000_add_entries_submitted_count_to_datasets.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:datasets) do
+      add_column :entries_submitted_count, Integer, null: false, default: 0
+    end
+
+    # Maintain entries_submitted_count alongside the existing dataset counters.
+    # It counts entries that have been submitted at least once (submitted_by_id
+    # set), so the counter is increment-only on update: it fires the first time
+    # submitted_by_id becomes non-NULL and is never decremented if it is later
+    # cleared.
+    #
+    # NOTE: existing datasets keep entries_submitted_count = 0 until the count is
+    # corrected on the server; this migration only wires up future maintenance.
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION update_dataset_entry_counters()
+      RETURNS TRIGGER AS $$
+      BEGIN
+        -- Handle INSERT
+        IF (TG_OP = 'INSERT') THEN
+          UPDATE datasets
+          SET entries_total_count = entries_total_count + 1,
+              entries_submitted_count =
+                entries_submitted_count
+                + CASE WHEN NEW.submitted_by_id IS NOT NULL THEN 1 ELSE 0 END
+          WHERE id = NEW.dataset_id;
+          RETURN NEW;
+        END IF;
+
+        -- Handle UPDATE
+        IF (TG_OP = 'UPDATE') THEN
+          -- Only update if status changed
+          IF (OLD.status != NEW.status) THEN
+            -- Increment counters in dataset
+            UPDATE datasets
+            SET entries_completed_count = entries_completed_count + CASE WHEN NEW.status = 'completed' OR NEW.status = 'errored' THEN 1 ELSE 0 END,
+                entries_in_progress_count =
+                  entries_in_progress_count
+                  + CASE WHEN NEW.status = 'in_progress' THEN 1 ELSE 0 END
+                  - CASE WHEN OLD.status = 'in_progress' THEN 1 ELSE 0 END
+            WHERE id = NEW.dataset_id;
+          END IF;
+
+          -- Count the entry the first time it gets submitted, never decrement
+          IF (OLD.submitted_by_id IS NULL AND NEW.submitted_by_id IS NOT NULL) THEN
+            UPDATE datasets
+            SET entries_submitted_count = entries_submitted_count + 1
+            WHERE id = NEW.dataset_id;
+          END IF;
+
+          RETURN NEW;
+        END IF;
+
+        -- Handle DELETE
+        IF (TG_OP = 'DELETE') THEN
+          UPDATE datasets
+          SET entries_total_count = entries_total_count - 1,
+              entries_completed_count = entries_completed_count - CASE WHEN OLD.status = 'completed' OR OLD.status = 'errored' THEN 1 ELSE 0 END,
+              entries_in_progress_count = entries_in_progress_count - CASE WHEN OLD.status = 'in_progress' THEN 1 ELSE 0 END,
+              entries_submitted_count = entries_submitted_count - CASE WHEN OLD.submitted_by_id IS NOT NULL THEN 1 ELSE 0 END
+          WHERE id = OLD.dataset_id;
+          RETURN OLD;
+        END IF;
+
+        RETURN NULL;
+      END;
+      $$ LANGUAGE plpgsql;
+    SQL
+  end
+
+  down do
+    # Restore the original trigger function (without submitted-count handling).
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION update_dataset_entry_counters()
+      RETURNS TRIGGER AS $$
+      BEGIN
+        -- Handle INSERT
+        IF (TG_OP = 'INSERT') THEN
+          UPDATE datasets
+          SET entries_total_count = entries_total_count + 1
+          WHERE id = NEW.dataset_id;
+          RETURN NEW;
+        END IF;
+
+        -- Handle UPDATE
+        IF (TG_OP = 'UPDATE') THEN
+          -- Only update if status changed
+          IF (OLD.status != NEW.status) THEN
+            -- Increment counters in dataset
+            UPDATE datasets
+            SET entries_completed_count = entries_completed_count + CASE WHEN NEW.status = 'completed' OR NEW.status = 'errored' THEN 1 ELSE 0 END,
+                entries_in_progress_count =
+                  entries_in_progress_count
+                  + CASE WHEN NEW.status = 'in_progress' THEN 1 ELSE 0 END
+                  - CASE WHEN OLD.status = 'in_progress' THEN 1 ELSE 0 END
+            WHERE id = NEW.dataset_id;
+          END IF;
+          RETURN NEW;
+        END IF;
+
+        -- Handle DELETE
+        IF (TG_OP = 'DELETE') THEN
+          UPDATE datasets
+          SET entries_total_count = entries_total_count - 1,
+              entries_completed_count = entries_completed_count - CASE WHEN OLD.status = 'completed' OR OLD.status = 'errored' THEN 1 ELSE 0 END,
+              entries_in_progress_count = entries_in_progress_count - CASE WHEN OLD.status = 'in_progress' THEN 1 ELSE 0 END
+          WHERE id = OLD.dataset_id;
+          RETURN OLD;
+        END IF;
+
+        RETURN NULL;
+      END;
+      $$ LANGUAGE plpgsql;
+    SQL
+
+    alter_table(:datasets) do
+      drop_column :entries_submitted_count
+    end
+  end
+end


### PR DESCRIPTION
- Dataset status should be changed to `In Progress` if there's an assigned entry
- Dataset should stay as `Pending` as an entry is added but not assigned
- Dataset should stay as `In Progress` if entry is submitted and goes into pending to wait for reviewer assignment because at least one of the entries in that dataset has been processed
- Dataset should be changed from `Completed` to `In Progress` if it was completed then a new entry is added (not assigned yet) because at least one of the entries in that dataset has been processed