### PR TITLE
Plugin: fix idah-video detect hls frame offset

### DIFF
--- a/plugins/idah-video/backends/media/idah_video/processor/ffmpeg.rb
+++ b/plugins/idah-video/backends/media/idah_video/processor/ffmpeg.rb
@@ -86,6 +86,15 @@ module IdahVideo
 
         args += ["-threads", encoding_threads] if encoding_threads
 
+        # Start the output timeline at PTS 0. The MPEG-TS muxer otherwise applies
+        # a default ~1.4s mux preload/delay, so the first frame lands at 1.4s
+        # instead of 0. Players (hls.js) only partially rebase that, leaving a
+        # residual offset that throws off frame-accurate seeking. Zeroing both
+        # makes new streams start clean. (Legacy streams and any source-side
+        # residual are still handled by the frontend's startOffset anchor.)
+        args += ["-muxdelay", "0"]
+        args += ["-muxpreload", "0"]
+
         # HLS output format and settings
         args += ["-f", "hls"] # Output format: HLS
         args += ["-hls_time", streaming_time_per_segment.to_s]  # Target segment duration

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/VIDEO.md
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/VIDEO.md
@@ -96,14 +96,18 @@ data (debounced so rapid key presses don't trigger a dozen upgrades).
 
 ### Frame numbering
 
-The browser's video element thinks in time (seconds), but the annotation app
-thinks in frames (frame 0, 1, 2, etc.). A small conversion layer translates
-between them.
+The browser thinks in seconds, the app thinks in frames. Frame `f` maps to
+`startOffset + f/fps` seconds, and back the other way by rounding. A tiny epsilon
+is added so a seek lands just *inside* the target frame instead of on its
+boundary (which can make the decoder paint the neighbouring frame).
 
-Internally, the video is one-based (starting at frame 1), so frame 0 in the app
-maps to 1/fps seconds in the browser (e.g., if the video is 30 fps, frame 0 is
-at 0.033 seconds). We also add a tiny extra offset to avoid landing exactly on
-fragment boundaries, which can cause timing issues.
+`startOffset` matters because the media timeline doesn't always start at zero:
+hls.js leaves a small sub-second residual when it rebases an MPEG-TS stream, so
+frame 0 can sit a fraction of a second in (≈0.021s) rather than at `t=0`. Assume
+zero and every seek lands one frame early — frame 1 paints frame 0's pixels. So
+we measure it: once the first frame is buffered (`loadeddata`), we read
+`buffered.start(0)` and anchor all conversions to it. Captured once; it's the
+same across quality levels and is simply 0 for plain (non-HLS) files.
 
 ## States
 

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Video.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Video.svelte
@@ -32,13 +32,24 @@
   let hasRVFC = false;
 
   // ── Frame ↔ time helpers ─────────────────────────────────────────
-  // Frames are 0-based; the browser uses seconds. Index f maps to t = f/fps
-  // (first frame at t=0), plus a tiny epsilon to avoid frame/fragment boundaries.
+  // Frames are 0-based; the browser works in seconds. Crucially, the media
+  // timeline does NOT necessarily start at t=0: for HLS (MPEG-TS) hls.js rebases
+  // the stream and leaves a sub-second residual, so frame 0 actually sits at
+  // buffered.start(0) (≈0.021s here), not at zero. `startOffset` captures that
+  // (see onMount) and anchors all frame↔time math to it; plain files start at 0,
+  // so it stays 0. Without this anchor every paused seek lands one frame early —
+  // frame 1 paints frame 0's pixels — because f/fps falls inside frame (f−1)'s
+  // presentation interval [offset+(f−1)/fps, offset+f/fps).
+  let startOffset = 0;
+  // Index f maps to t = startOffset + f/fps (first frame at startOffset), plus a
+  // tiny epsilon to land just inside the frame, clear of its boundary. Rounding
+  // (not floor) maps a frame-aligned time straight back to its index, tolerating
+  // the float error introduced by subtracting the offset.
   function timeToFrame(t: number) {
-    return Math.max(0, Math.min(Math.floor(t * fps), media.totalFrames - 1));
+    return Math.max(0, Math.min(Math.round((t - startOffset) * fps), media.totalFrames - 1));
   }
   function frameToTime(f: number) {
-    return (f + 0.001) / fps;
+    return startOffset + (f + 0.001) / fps;
   }
 
   // ── RAF loop (playback only) ──────────────────────────────────────
@@ -239,12 +250,22 @@
       viewport.video.loading.buffering = false;
     };
 
+    // Anchor the frame↔time helpers to the real media start (see startOffset).
+    // `loadeddata` guarantees the first frame's data is appended, so buffered
+    // holds the true frame-0 time; detach once captured (it never changes).
+    const handleLoadedData = () => {
+      if (videoElement.buffered.length === 0) return;
+      startOffset = videoElement.buffered.start(0);
+      videoElement.removeEventListener("loadeddata", handleLoadedData);
+    };
+
     const handleResize = () => onResize();
     videoElement.addEventListener("seeked", handleSeeked);
     videoElement.addEventListener("play", handlePlay);
     videoElement.addEventListener("pause", handlePause);
     videoElement.addEventListener("waiting", handleWaiting);
     videoElement.addEventListener("playing", handlePlaying);
+    videoElement.addEventListener("loadeddata", handleLoadedData);
     videoElement.addEventListener("resize", handleResize);
 
     // HLS streams get a VideoStreamHandler (HQ buffering while paused, adaptive
@@ -283,6 +304,7 @@
       videoElement.removeEventListener("pause", handlePause);
       videoElement.removeEventListener("waiting", handleWaiting);
       videoElement.removeEventListener("playing", handlePlaying);
+      videoElement.removeEventListener("loadeddata", handleLoadedData);
       videoElement.removeEventListener("resize", handleResize);
       streamHandler?.destroy();
     };


### PR DESCRIPTION
## Summary

Fixed a frame-accurate seeking bug in the HLS video player. The root cause: hls.js rebases the MPEG-TS stream but leaves a small residual offset (~0.021s), so frame 0 doesn't actually sit at t=0. Without accounting for this, every paused seek landed one frame early.

The fix introduces a startOffset anchor captured from buffered.start(0) on loadeddata. All frame↔time math now uses that anchor (startOffset + f/fps) instead of assuming t=0. Plain files are unaffected (offset stays 0). Also zeroed out ffmpeg's muxer preload/delay (-muxdelay 0 -muxpreload 0) on newly encoded streams to minimize the offset at the source.