### PR TITLE
IDAH Dataset Status Update Not Reflected On Datasets Page Without Reload

### DIFF
--- a/app/frontend/src/lib/data/model/dataset/entries/record.ts
+++ b/app/frontend/src/lib/data/model/dataset/entries/record.ts
@@ -119,7 +119,10 @@ export const entriesBackendDataSource = createBackendDataSource(EntryRecord, ent
 
     // Cache Management
     const cacheIndexKey = resourcePath(entriesBasePath, null, undefined);
+    // Note: Clear dataset cache as well so the Datasets list reflects the updated status on return.
+    const cacheDatasetIndexKey = resourcePath(datasetBasePath, null, undefined);
     clearCache(cacheIndexKey);
+    clearCache(cacheDatasetIndexKey);
 
     if (body && body.errors) {
       if (body.errors.length > 0) {
@@ -144,7 +147,10 @@ export const entriesBackendDataSource = createBackendDataSource(EntryRecord, ent
 
     // Cache Management
     const cacheIndexKey = resourcePath(entriesBasePath, null, undefined);
+    // Note: Clear dataset cache as well so the Datasets list reflects the updated status on return.
+    const cacheDatasetIndexKey = resourcePath(datasetBasePath, null, undefined);
     clearCache(cacheIndexKey);
+    clearCache(cacheDatasetIndexKey);
 
     if (body && body.errors) {
       if (body.errors.length > 0) {


### PR DESCRIPTION
## Summary
Clear the Datasets list cache when an entry is assigned or unassigned, so the
dataset status shown on the Datasets page reflects the change without a hard
reload.

## Why
Assigning/unassigning an entry changes the parent dataset's status on the
backend. The entries datasource only cleared the *entries* cache, while the
Datasets list (`datasetsBackendDataSource.list()`) serves from a separate
path-keyed cache. Returning to the Datasets page remounts and refetches, but the
cache still returned the stale dataset records — so the status looked unchanged
until a full page reload.

## Changes
- `entries/record.ts` `assign`: also clear the datasets list cache alongside the
  entries cache (mirrors the existing `submit` method).
- `entries/record.ts` `unassign`: same cache clear.

This is purely cache invalidation; there is no live re-render and no change to
the entries-page UX. The Datasets list simply fetches fresh data the next time it
is shown (breadcrumb click / browser back).

## Testing
Manual: assign/unassign an entry, then return to the Datasets list via breadcrumb
or back — the dataset status updates without a hard reload.

## Notes
- Scoped to **assign/unassign** only. The entry-delete case (which also affects
  dataset progress) is intentionally not included in this PR.
- Detail-header refresh (`$refetches.datasets.get`) is out of scope.
