### PR TITLE
Add Entry Stage Badge and Disable Non-Functional Clicks on Editor Toolbar

### DIFF
--- a/app/frontend/src/lib/plugin/layout/header/annotation-header-bar-actions.svelte
+++ b/app/frontend/src/lib/plugin/layout/header/annotation-header-bar-actions.svelte
@@ -27,20 +27,21 @@
   } from "@/components/ui/dropdown-menu";
   import { getShortcutLabel } from "@/components/ui/kbd/utils";
 
+  import Text from "@/components/ui/text/Text.svelte";
   import EntryStatsModal from "@/plugin/v2/components/entry-stats-modal.svelte";
 
-  import writableWithLocal from "@/utils/writableWithLocal";
-  import type { IDropdownMenus } from "@/components/app/dropdown-menus/types";
-  import type { IIdahDriverV2 } from "@/plugin/v2/types";
-  import { entriesBackendDataSource, EntryRecord } from "@/data/model/dataset/entries/record";
-  import { NoteFeedRecord, noteFeedsBackendDataSource } from "@/data/model/dataset/notes/feeds/record";
-  import { page } from "$app/state";
+  import { cn } from "@/utils";
   import { goto } from "$app/navigation";
   import { resolve } from "$app/paths";
+  import { page } from "$app/state";
+  import { entriesBackendDataSource, EntryRecord } from "@/data/model/dataset/entries/record";
+  import { NoteFeedRecord, noteFeedsBackendDataSource } from "@/data/model/dataset/notes/feeds/record";
   import { refetches } from "@/utils/refetch";
+  import writableWithLocal from "@/utils/writableWithLocal";
 
+  import type { IDropdownMenus } from "@/components/app/dropdown-menus/types";
   import type { EntryWorkflowStep } from "@/data/model/dataset/entries/constants";
-  import Text from "@/components/ui/text/Text.svelte";
+  import type { IIdahDriverV2 } from "@/plugin/v2/types";
 
   // Props
   interface Props {
@@ -275,6 +276,9 @@
     {/if}
     <div class="relative">
       <Button
+        class={cn({
+          "hover:bg-primary cursor-default": driver.entryStatus === "completed",
+        })}
         variant={currentMode === "review" || currentMode === "note" ? "default" : "ghost"}
         size="sm"
         onclick={() => driver.setMode("review")}

--- a/app/frontend/src/lib/plugin/layout/header/annotation-header-bar-actions.svelte
+++ b/app/frontend/src/lib/plugin/layout/header/annotation-header-bar-actions.svelte
@@ -29,15 +29,14 @@
 
   import Text from "@/components/ui/text/Text.svelte";
   import EntryStatsModal from "@/plugin/v2/components/entry-stats-modal.svelte";
+  import writableWithLocal from "@/utils/writableWithLocal";
 
-  import { cn } from "@/utils";
   import { goto } from "$app/navigation";
   import { resolve } from "$app/paths";
   import { page } from "$app/state";
   import { entriesBackendDataSource, EntryRecord } from "@/data/model/dataset/entries/record";
   import { NoteFeedRecord, noteFeedsBackendDataSource } from "@/data/model/dataset/notes/feeds/record";
   import { refetches } from "@/utils/refetch";
-  import writableWithLocal from "@/utils/writableWithLocal";
 
   import type { IDropdownMenus } from "@/components/app/dropdown-menus/types";
   import type { EntryWorkflowStep } from "@/data/model/dataset/entries/constants";
@@ -274,9 +273,6 @@
     </Button>
     <div class="relative">
       <Button
-        class={cn({
-          "hover:bg-primary cursor-default": driver.entryStatus === "completed",
-        })}
         variant={currentMode === "review" || currentMode === "note" ? "default" : "ghost"}
         size="sm"
         onclick={() => driver.setMode("review")}

--- a/app/frontend/src/lib/plugin/layout/header/annotation-header-bar-media-name.svelte
+++ b/app/frontend/src/lib/plugin/layout/header/annotation-header-bar-media-name.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import Button from "@/components/ui/button/button.svelte";
   import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
   import { truncate } from "@/utils/string";
 
@@ -13,11 +12,11 @@
 <TooltipProvider>
   <Tooltip>
     <TooltipTrigger class="max-w-full min-w-0 overflow-hidden">
-      <Button variant="ghost" size="sm" class="max-w-full overflow-hidden text-ellipsis whitespace-nowrap">
-        <span class="overflow-hidden text-ellipsis">
-          {truncate(name, 80)}
-        </span>
-      </Button>
+      <div
+        class="text-accent-foreground max-w-full overflow-hidden text-xs font-semibold text-ellipsis whitespace-nowrap hover:cursor-default"
+      >
+        {truncate(name, 80)}
+      </div>
     </TooltipTrigger>
 
     <TooltipContent>

--- a/app/frontend/src/lib/plugin/layout/header/annotation-header-bar-state-badge.svelte
+++ b/app/frontend/src/lib/plugin/layout/header/annotation-header-bar-state-badge.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import Badge from "@/components/ui/badge/badge.svelte";
 
+  import { capitalize } from "@/utils/string";
+
   import type { IdahDriverV2 } from "@/plugin/v2/driver";
 
   type Props = {
@@ -10,4 +12,4 @@
   let { driver }: Props = $props();
 </script>
 
-<Badge variant="info">{driver.workflowStep}</Badge>
+<Badge variant="info">{capitalize(driver.workflowStep)}</Badge>

--- a/app/frontend/src/lib/plugin/layout/header/annotation-header-bar-state-badge.svelte
+++ b/app/frontend/src/lib/plugin/layout/header/annotation-header-bar-state-badge.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import Badge from "@/components/ui/badge/badge.svelte";
+
+  import type { IdahDriverV2 } from "@/plugin/v2/driver";
+
+  type Props = {
+    driver: IdahDriverV2;
+  };
+
+  let { driver }: Props = $props();
+
+  $effect(() => {
+    console.log("driver", driver);
+  });
+</script>
+
+<Badge variant="info">{driver.workflowStep}</Badge>

--- a/app/frontend/src/lib/plugin/layout/header/annotation-header-bar-state-badge.svelte
+++ b/app/frontend/src/lib/plugin/layout/header/annotation-header-bar-state-badge.svelte
@@ -8,10 +8,6 @@
   };
 
   let { driver }: Props = $props();
-
-  $effect(() => {
-    console.log("driver", driver);
-  });
 </script>
 
 <Badge variant="info">{driver.workflowStep}</Badge>

--- a/app/frontend/src/lib/plugin/layout/header/annotation-header-bar.svelte
+++ b/app/frontend/src/lib/plugin/layout/header/annotation-header-bar.svelte
@@ -5,6 +5,7 @@
   import AnnotationHeaderBarActions from "./annotation-header-bar-actions.svelte";
   import AnnotationHeaderBarBackButton from "./annotation-header-bar-back-button.svelte";
   import AnnotationHeaderBarMediaName from "./annotation-header-bar-media-name.svelte";
+  import AnnotationHeaderBarStateBadge from "./annotation-header-bar-state-badge.svelte";
   import AnnotationHeaderBarTools from "./annotation-header-bar-tools.svelte";
 
   import type { WithElementRef } from "@/utils";
@@ -36,6 +37,8 @@
     <Separator orientation="vertical" />
     <!-- MEDIA NAME -->
     <AnnotationHeaderBarMediaName name={driver.media.filename} />
+
+    <AnnotationHeaderBarStateBadge {driver} />
   </div>
 
   <!-- CENTER::TOOLS -->


### PR DESCRIPTION
## Summary
Adds an entry workflow-stage badge to the annotation header bar, simplifies the media-name display, and makes the Review toggle read as non-interactive once an entry is completed.

## Why
When an entry is `completed`, the editor is locked to review mode, so the Review toggle is functionally dead but still looks clickable (pointer cursor + hover highlight) — misleading to users. Separately, the header lacked a visible indicator of the entry's workflow stage, and the media name was rendered as a `Button` despite not being actionable.

## Changes
- **State badge:** new `annotation-header-bar-state-badge.svelte` showing `driver.workflowStep`, wired into `annotation-header-bar.svelte`.
- **Media name:** render the filename as a plain `<div>` instead of a `Button`, since it isn't interactive (drops the unused Button import).
