### PR TITLE
Setting + Frontend core/criticals

### DIFF
--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -63,6 +63,7 @@
   },
   "dependencies": {
     "date-fns": "^4.1.0",
+    "dompurify": "^3.4.11",
     "marked": "^16.4.0",
     "mode-watcher": "^1.1.0",
     "uuidv7": "^1.0.2",

--- a/app/frontend/pnpm-lock.yaml
+++ b/app/frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dompurify:
+        specifier: ^3.4.11
+        version: 3.4.11
       marked:
         specifier: ^16.4.0
         version: 16.4.0
@@ -797,6 +800,9 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@typescript-eslint/eslint-plugin@8.42.0':
     resolution: {integrity: sha512-Aq2dPqsQkxHOLfb2OPv43RnIvfj05nw8v/6n3B2NABIPpHnjQnaLo9QGMTvml+tv4korl/Cjfrb/BYhoL8UUTQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1090,6 +1096,9 @@ packages:
 
   dom-walk@0.1.2:
     resolution: {integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
@@ -2719,6 +2728,9 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@typescript-eslint/eslint-plugin@8.42.0(@typescript-eslint/parser@8.42.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -3034,6 +3046,10 @@ snapshots:
   dom-accessibility-api@0.6.3: {}
 
   dom-walk@0.1.2: {}
+
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   enhanced-resolve@5.18.3:
     dependencies:

--- a/app/frontend/src/lib/components/app/datasets/entries/overlays/_AssignEntryFormModal.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/overlays/_AssignEntryFormModal.svelte
@@ -34,22 +34,20 @@
   async function assignMember(): Promise<void> {
     if (entryIds.length === 0 || !selectedMemberAccountId) return;
 
-    let projectMemberRecord: ProjectMemberRecord | undefined = $state(undefined);
-    for (const entryId of entryIds) {
-      await entriesBackendDataSource.assign({ id: entryId, memberAccountId: selectedMemberAccountId });
+    const memberAccountId = selectedMemberAccountId;
 
-      /** Get the email of selected member */
-      const projectMemberRes = await projectMembersBackendDataSource.list({
-        fields: {
-          [ProjectMemberRecord.type]: ["email"],
-        },
-        filters: {
-          account_id: selectedMemberAccountId,
-        },
-      });
+    await Promise.all(entryIds.map((entryId) => entriesBackendDataSource.assign({ id: entryId, memberAccountId })));
 
-      projectMemberRecord = projectMemberRes.data.at(0);
-    }
+    /** Get the email of the selected member (identical for every entry). */
+    const projectMemberRes = await projectMembersBackendDataSource.list({
+      fields: {
+        [ProjectMemberRecord.type]: ["email"],
+      },
+      filters: {
+        account_id: memberAccountId,
+      },
+    });
+    const projectMemberRecord = projectMemberRes.data.at(0);
 
     open = false;
     selectedMemberAccountId = null;

--- a/app/frontend/src/lib/components/app/datasets/entries/overlays/_UpdateEntryPriorityFormModal.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/overlays/_UpdateEntryPriorityFormModal.svelte
@@ -31,13 +31,15 @@
   }
 
   async function updateEntryPriority(): Promise<void> {
-    for (const entryId of entryIds) {
-      await entriesBackendDataSource.update(entryId, {
-        attributes: {
-          priority: selectedPriority!,
-        },
-      });
-    }
+    await Promise.all(
+      entryIds.map((entryId) =>
+        entriesBackendDataSource.update(entryId, {
+          attributes: {
+            priority: selectedPriority!,
+          },
+        }),
+      ),
+    );
 
     showToast.success({
       title: `${selectedEntryCount} entries has been set priority successfully!`,

--- a/app/frontend/src/lib/components/app/markdown/markdown-preview.svelte
+++ b/app/frontend/src/lib/components/app/markdown/markdown-preview.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { marked } from "marked";
+  import DOMPurify from "dompurify";
 
   import { cn } from "@/utils";
 
@@ -25,7 +26,11 @@
 
     // marked.use({renderer})
 
-    return marked.parse(text).toString();
+    const html = marked.parse(text).toString();
+
+    // dompurify needs a DOM; the app is SSR (adapter-node). Sanitise in the
+    // browser only — server render yields "" until hydration re-runs this.
+    return typeof window !== "undefined" ? DOMPurify.sanitize(html, { USE_PROFILES: { html: true } }) : "";
   }
 </script>
 

--- a/app/frontend/src/lib/components/app/page/page-provider.svelte
+++ b/app/frontend/src/lib/components/app/page/page-provider.svelte
@@ -29,8 +29,11 @@
 
     result = await currentAccount.can(action, resource, scopes);
 
-    if (roles) {
-      result = roles.includes(currentAccount.roleName);
+    // AND semantics: `roles` only narrows the server-authoritative can()
+    // result, it must never widen access beyond it. (Previously this
+    // overrode can() entirely, discarding the server check.)
+    if (roles?.length) {
+      result = result && roles.includes(currentAccount.roleName);
     }
 
     return result;

--- a/app/frontend/src/lib/data/BackendDataSource.test.ts
+++ b/app/frontend/src/lib/data/BackendDataSource.test.ts
@@ -3,10 +3,10 @@ import { createBackendDataSource, encodeModel } from "./BackendDataSource";
 import { Record, RecordFactory, field, type } from "./model/Record";
 
 const TransformerTest = {
-  from(value: any) {
+  from(value: string) {
     return value && value + "from";
   },
-  to(value: any) {
+  to(value: string) {
     return value && value + "to";
   },
 };
@@ -62,7 +62,7 @@ describe(encodeModel, () => {
 
 describe(createBackendDataSource, () => {
   const fetch = vi.fn();
-  global.fetch = <any>fetch;
+  globalThis.fetch = fetch as unknown as typeof globalThis.fetch;
 
   const ds = createBackendDataSource(TestRecord, "http://example.tld/test_records");
 

--- a/app/frontend/src/lib/data/BackendDataSource.test.ts
+++ b/app/frontend/src/lib/data/BackendDataSource.test.ts
@@ -8,7 +8,7 @@ const TransformerTest = {
   },
   to(value: any) {
     return value && value + "to";
-  }
+  },
 };
 
 @type("test/backend_data_source")
@@ -25,8 +25,8 @@ describe(encodeModel, () => {
   it("simple", () => {
     const out = encodeModel(TestRecord, {
       attributes: {
-        foo: "bar"
-      }
+        foo: "bar",
+      },
     });
     expect(out).toBe('{"data":{"type":"test/backend_data_source","attributes":{"foo":"bar"}}}');
   });
@@ -34,8 +34,8 @@ describe(encodeModel, () => {
   it("with transformer", () => {
     const out = encodeModel(TestRecord, {
       attributes: {
-        transformed: "bar"
-      }
+        transformed: "bar",
+      },
     });
     expect(out).toBe('{"data":{"type":"test/backend_data_source","attributes":{"transformed":"barto"}}}');
   });
@@ -43,8 +43,8 @@ describe(encodeModel, () => {
   it("with key", () => {
     const out = encodeModel(TestRecord, {
       attributes: {
-        camelCase: "bar"
-      }
+        camelCase: "bar",
+      },
     });
     expect(out).toBe('{"data":{"type":"test/backend_data_source","attributes":{"under_score":"bar"}}}');
   });
@@ -53,8 +53,8 @@ describe(encodeModel, () => {
     const out = encodeModel(TestRecord, {
       attributes: {
         id: "1",
-        foo: "bar"
-      }
+        foo: "bar",
+      },
     });
     expect(out).toBe('{"data":{"type":"test/backend_data_source","id":"1","attributes":{"foo":"bar"}}}');
   });
@@ -70,7 +70,7 @@ describe(createBackendDataSource, () => {
     const ds = createBackendDataSource(TestRecord, "http://example.tld/test_records", {
       customMethod() {
         return "custom";
-      }
+      },
     });
 
     it("simple", () => {
@@ -81,6 +81,8 @@ describe(createBackendDataSource, () => {
   describe("#get", () => {
     const mockGet = () => {
       fetch.mockResolvedValue({
+        ok: true,
+        status: 200,
         body: JSON.stringify({
           data: {
             type: "test/backend_data_source",
@@ -89,13 +91,13 @@ describe(createBackendDataSource, () => {
               foo: "foo1",
               bar: "bar1",
               under_score: "camelCase1",
-              transformed: "transformed1"
-            }
-          }
+              transformed: "transformed1",
+            },
+          },
         }),
         json() {
           return JSON.parse(this.body);
-        }
+        },
       });
     };
 
@@ -114,6 +116,8 @@ describe(createBackendDataSource, () => {
   describe("#list", () => {
     const mockList = () => {
       fetch.mockResolvedValue({
+        ok: true,
+        status: 200,
         body: JSON.stringify({
           data: [
             {
@@ -123,8 +127,8 @@ describe(createBackendDataSource, () => {
                 foo: "foo1",
                 bar: "bar1",
                 under_score: "camelCase1",
-                transformed: "transformed1"
-              }
+                transformed: "transformed1",
+              },
             },
             {
               type: "test/backend_data_source",
@@ -133,14 +137,14 @@ describe(createBackendDataSource, () => {
                 foo: "foo2",
                 bar: "bar2",
                 under_score: "camelCase2",
-                transformed: "transformed2"
-              }
-            }
-          ]
+                transformed: "transformed2",
+              },
+            },
+          ],
         }),
         json() {
           return JSON.parse(this.body);
-        }
+        },
       });
     };
 
@@ -169,8 +173,8 @@ describe(createBackendDataSource, () => {
 
       await ds.list({
         filters: {
-          id: "2"
-        }
+          id: "2",
+        },
       });
 
       expect(fetch).toHaveBeenCalledWith("http://example.tld/test_records?filter%5Bid%5D=2", { method: "GET" });
@@ -181,8 +185,8 @@ describe(createBackendDataSource, () => {
 
       await ds.list({
         filters: {
-          id: "2"
-        }
+          id: "2",
+        },
       });
 
       expect(fetch).toHaveBeenCalledWith("http://example.tld/test_records?filter%5Bid%5D=2", { method: "GET" });
@@ -193,13 +197,13 @@ describe(createBackendDataSource, () => {
 
       await ds.list({
         filters: {
-          id__in: ["1", "2"]
-        }
+          id__in: ["1", "2"],
+        },
       });
 
       expect(fetch).toHaveBeenCalledWith(
         "http://example.tld/test_records?filter%5Bid__in%5D%5B%5D=1&filter%5Bid__in%5D%5B%5D=2",
-        { method: "GET" }
+        { method: "GET" },
       );
     });
 
@@ -207,26 +211,42 @@ describe(createBackendDataSource, () => {
       mockList();
 
       await ds.list({
-        sort: ["-id", "foo"]
+        sort: ["-id", "foo"],
       });
 
       expect(fetch).toHaveBeenCalledWith("http://example.tld/test_records?sort=-id%2Cfoo", {
-        method: "GET"
+        method: "GET",
       });
     });
   });
 
   describe("#delete", () => {
     it("simple", async () => {
-      fetch.mockResolvedValue({ body: "" });
+      fetch.mockResolvedValue({ ok: true, status: 204, body: "" });
       const result = await ds.delete("1");
       expect(result).toBe(true);
+    });
+  });
+
+  describe("non-ok / non-JSON responses", () => {
+    it("rejects with a typed error instead of throwing on a non-JSON body", async () => {
+      fetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json() {
+          throw new SyntaxError("Unexpected token < in JSON");
+        },
+      });
+
+      await expect(ds.get("1", { noCache: true })).rejects.toMatchObject({ status: 500 });
     });
   });
 
   describe("#update", () => {
     it("simple", async () => {
       fetch.mockResolvedValue({
+        ok: true,
+        status: 200,
         body: JSON.stringify({
           data: {
             type: "test/backend_data_source",
@@ -235,19 +255,19 @@ describe(createBackendDataSource, () => {
               foo: "foo1",
               bar: "bar1",
               under_score: "camelCase1",
-              transformed: "transformed1"
-            }
-          }
+              transformed: "transformed1",
+            },
+          },
         }),
         json() {
           return JSON.parse(this.body);
-        }
+        },
       });
 
       const result = await ds.update("1", {
         attributes: {
-          foo: "bar"
-        }
+          foo: "bar",
+        },
       });
       expect(result.data.id).toBe("1");
     });

--- a/app/frontend/src/lib/data/BackendDataSource.ts
+++ b/app/frontend/src/lib/data/BackendDataSource.ts
@@ -48,6 +48,43 @@ export function resourcePath(basePath: string, id: string | null, queryPath?: Ha
   return uri;
 }
 
+type JsonResponse = { status: number; ok: boolean; body: Hash | null };
+
+// Wraps fetch so callers never hit an unstructured error from out.json():
+// the body is parsed defensively (a non-JSON 500/502/204 yields body: null),
+// and failure is decided from `ok`/`body.errors` rather than a thrown parse.
+async function requestJson(url: string, init?: RequestInit): Promise<JsonResponse> {
+  const out = await fetch(url, init);
+
+  let body: Hash | null = null;
+  try {
+    body = await out.json();
+  } catch {
+    // Non-JSON body (HTML error page, empty 204, proxy error, ...).
+    body = null;
+  }
+
+  return { status: out.status, ok: out.ok, body };
+}
+
+// Returns the JsonApiError to reject with when a response failed (non-2xx or a
+// JSON:API errors payload), or null on success. Optionally surfaces each error
+// as a toast. Synthesises an error when the response failed with no JSON body.
+function rejectionFor(res: JsonResponse, showToast: boolean): JsonApiErrorResponse | null {
+  const errors: Hash<string>[] | undefined = res.body?.errors;
+  if (res.ok && !errors) return null;
+
+  const errorList: Hash<string>[] = errors ?? [{ title: "Request failed", detail: `HTTP ${res.status}` }];
+
+  if (showToast && errorList.length > 0) {
+    errorList.forEach((err) => {
+      showErrorToast({ title: err.title, message: err.detail, error: err });
+    });
+  }
+
+  return parseSingleElementError({ status: res.status, errors: errorList });
+}
+
 export interface BackendDataSource<T extends Record> extends DataSource<T> {
   recordClass: RecordClass<T>;
   basePath: string;
@@ -63,36 +100,27 @@ export function createBackendDataSource<T extends Record, CustomMethods>(
     basePath: basePath,
 
     async create(data: DataParams<T>, options?: DataSourceOptions): Promise<RecordResponse<T> | JsonApiErrorResponse> {
-      const out = await fetch(this.basePath, {
+      const res = await requestJson(this.basePath, {
         method: "POST",
         body: encodeModel(this.recordClass, data),
         headers: { "Content-Type": "application/vnd.api+json" },
       });
 
-      const body = await out.json();
-
       // Cache Management
       const cacheIndexKey = resourcePath(this.basePath, null, undefined);
       clearCache(cacheIndexKey);
 
-      if (body && body.errors) {
-        if (body.errors.length > 0 && options?.showErrorToast !== false) {
-          body.errors.forEach((err: Hash<string>) => {
-            showErrorToast({ title: err.title, message: err.detail, error: err });
-          });
-        }
+      const rejection = rejectionFor(res, options?.showErrorToast !== false);
+      if (rejection) return Promise.reject(rejection);
 
-        return Promise.reject(parseSingleElementError({ status: out.status, errors: body.errors }));
-      }
-
-      if (body && body.data) return Promise.resolve(parseSingleElementReturn<T>(body));
+      if (res.body && res.body.data) return Promise.resolve(parseSingleElementReturn<T>(res.body));
 
       throw "No id returned";
     },
 
     async get(id: string, options: GetOptions = {}): Promise<RecordResponse<T>> {
       const params = <Hash>{};
-      let body: Hash;
+      let body: Hash | null = null;
 
       // Params Management
       if (options.included) params["included"] = options.included;
@@ -115,18 +143,17 @@ export function createBackendDataSource<T extends Record, CustomMethods>(
       if (cacheValue) {
         body = cacheValue;
       } else {
-        const out = await fetch(resourcePath(this.basePath, id, params), {
+        const res = await requestJson(resourcePath(this.basePath, id, params), {
           method: "GET",
         });
 
-        body = await out.json();
+        const rejection = rejectionFor(res, false);
+        if (rejection) return Promise.reject(rejection);
 
-        if (body && body.errors) {
-          return Promise.reject(parseSingleElementError({ status: out.status, errors: body.errors }));
-        }
+        body = res.body;
       }
 
-      if (useCache) {
+      if (useCache && body) {
         setCache(cacheIdKey, cacheSignature, body);
       }
 
@@ -140,7 +167,7 @@ export function createBackendDataSource<T extends Record, CustomMethods>(
       nextBody: CollectionResponse<T> = { data: [], meta: {} },
     ): Promise<CollectionResponse<T>> {
       const params = <Hash>{};
-      let body: Hash;
+      let body: Hash | null = null;
 
       // Params Management
       if (options.filters) params["filter"] = filtersToHash(options.filters);
@@ -172,32 +199,37 @@ export function createBackendDataSource<T extends Record, CustomMethods>(
       if (cacheValue) {
         body = cacheValue;
       } else {
-        const out = await fetch(resourcePath(this.basePath, null, params), {
+        const res = await requestJson(resourcePath(this.basePath, null, params), {
           method: "GET",
         });
 
-        body = await out.json();
+        const rejection = rejectionFor(res, false);
+        if (rejection) return Promise.reject(rejection);
 
-        if (nextBody.data.length > 0) {
-          body.data = nextBody.data.concat(body.data);
-        }
+        body = res.body;
 
-        if (options.all) {
-          const nextPage = body.links?.next;
-
-          if (nextPage && options.pagination) {
-            return await this.list({
-              ...options,
-              pagination: {
-                page: options.pagination.page + 1,
-                itemsPerPage: options.pagination.itemsPerPage,
-              },
-            });
+        if (body) {
+          if (nextBody.data.length > 0) {
+            body.data = nextBody.data.concat(body.data);
           }
-        }
 
-        if (useCache) {
-          setCache(cacheIndexKey, cacheSignature, body);
+          if (options.all) {
+            const nextPage = body.links?.next;
+
+            if (nextPage && options.pagination) {
+              return await this.list({
+                ...options,
+                pagination: {
+                  page: options.pagination.page + 1,
+                  itemsPerPage: options.pagination.itemsPerPage,
+                },
+              });
+            }
+          }
+
+          if (useCache) {
+            setCache(cacheIndexKey, cacheSignature, body);
+          }
         }
       }
 
@@ -217,45 +249,25 @@ export function createBackendDataSource<T extends Record, CustomMethods>(
       clearCache(cacheIndexKey);
       clearCache(cacheIdKey);
 
-      const out = await fetch(resourcePath(this.basePath, id), {
+      const res = await requestJson(resourcePath(this.basePath, id), {
         method: "PATCH",
         body: encodeModel(this.recordClass, data),
         headers: { "Content-Type": "application/vnd.api+json" },
       });
 
-      const body = await out.json();
+      const rejection = rejectionFor(res, options?.showErrorToast !== false);
+      if (rejection) return Promise.reject(rejection);
 
-      if (body && body.errors) {
-        if (body.errors.length > 0 && options?.showErrorToast !== false) {
-          body.errors.forEach((err: Hash<string>) => {
-            showErrorToast({ title: err.title, message: err.detail, error: err });
-          });
-        }
-
-        return Promise.reject(parseSingleElementError({ status: out.status, errors: body.errors }));
-      }
-
-      if (body && body.data) return Promise.resolve(parseSingleElementReturn<T>(body));
+      if (res.body && res.body.data) return Promise.resolve(parseSingleElementReturn<T>(res.body));
 
       throw "No body returned";
     },
 
     async delete(id: string, options?: DataSourceOptions): Promise<boolean> {
-      const response = await fetch(resourcePath(this.basePath, id), { method: "DELETE" });
+      const res = await requestJson(resourcePath(this.basePath, id), { method: "DELETE" });
 
-      if (!response.ok) {
-        const body = await response.json();
-
-        if (body && body.errors) {
-          if (body.errors.length > 0 && options?.showErrorToast !== false) {
-            body.errors.forEach((err: Hash<string>) => {
-              showErrorToast({ title: err.title, message: err.detail, error: err });
-            });
-          }
-
-          return Promise.reject(parseSingleElementError({ status: response.status, errors: body.errors }));
-        }
-      }
+      const rejection = rejectionFor(res, options?.showErrorToast !== false);
+      if (rejection) return Promise.reject(rejection);
 
       // Cache Management
       const cacheIndexKey = resourcePath(this.basePath, null, undefined);

--- a/app/frontend/src/lib/data/Cache.ts
+++ b/app/frontend/src/lib/data/Cache.ts
@@ -27,9 +27,11 @@ export const clearCache = (cacheKey: string, cacheSignature: string | undefined 
     const key = `${cacheKey}-${cacheSignature}`;
     delete cacheList[key];
   } else {
-    const pattern = new RegExp(`^${cacheKey}-`);
+    // Prefix match without a RegExp: cacheKey may contain regex
+    // metacharacters, which could over-match unrelated entries or ReDoS.
+    const prefix = `${cacheKey}-`;
     for (const key in cacheList) {
-      if (key.match(pattern)) {
+      if (key.startsWith(prefix)) {
         delete cacheList[key];
       }
     }
@@ -50,11 +52,17 @@ function clearExpireCache() {
   }
 }
 
-function runExpireCache() {
-  // Every 10 seconds, cleanup the expired cache
-  setInterval(() => {
-    clearExpireCache();
-  }, 10000);
+let expireTimer: ReturnType<typeof setInterval> | undefined;
+
+// Every 10 seconds, cleanup the expired cache. The handle is stored so the
+// timer can be stopped (tests/SSR/HMR) instead of leaking the event loop.
+export function startExpireCache() {
+  expireTimer ??= setInterval(clearExpireCache, 10_000);
 }
 
-runExpireCache();
+export function stopExpireCache() {
+  if (expireTimer) clearInterval(expireTimer);
+  expireTimer = undefined;
+}
+
+if (typeof window !== "undefined") startExpireCache();

--- a/app/frontend/src/lib/data/model/json_api.ts
+++ b/app/frontend/src/lib/data/model/json_api.ts
@@ -25,7 +25,7 @@ export const parseSingleElementError = (dataRaw: Hash): JsonApiErrorResponse => 
 };
 
 export const parseSingleElementReturn = <T extends Record>(dataRaw: Hash): RecordResponse<T> => {
-  if (dataRaw.errors) throw "TODO: Handle error output";
+  if (dataRaw.errors) throw parseSingleElementError(dataRaw);
 
   const data = dataRaw.data as JsonApiRecord<Hash>;
   if (dataRaw.included) {
@@ -44,7 +44,7 @@ export const parseSingleElementReturn = <T extends Record>(dataRaw: Hash): Recor
 };
 
 export const parseCollectionReturn = <T extends Record>(dataRaw: Hash): CollectionResponse<T> => {
-  if (dataRaw.errors) throw "TODO: Handle error output";
+  if (dataRaw.errors) throw parseSingleElementError(dataRaw);
 
   const data = dataRaw.data as Array<JsonApiRecord<Hash>>;
 

--- a/app/frontend/src/lib/data/model/json_api.ts
+++ b/app/frontend/src/lib/data/model/json_api.ts
@@ -14,13 +14,13 @@ import type {
   JsonApiRecord,
   JsonApiReference,
   JsonApiSingleModelResponse,
-  RecordResponse
+  RecordResponse,
 } from "./types";
 
 export const parseSingleElementError = (dataRaw: Hash): JsonApiErrorResponse => {
   return {
     status: dataRaw.status,
-    errors: dataRaw.errors
+    errors: dataRaw.errors,
   };
 };
 
@@ -33,12 +33,12 @@ export const parseSingleElementReturn = <T extends Record>(dataRaw: Hash): Recor
 
     return {
       data: RecordFactory.create<T>(data, includeList),
-      meta: dataRaw.meta
+      meta: dataRaw.meta,
     };
   } else {
     return {
       data: RecordFactory.create<T>(data),
-      meta: dataRaw.meta
+      meta: dataRaw.meta,
     };
   }
 };
@@ -52,13 +52,13 @@ export const parseCollectionReturn = <T extends Record>(dataRaw: Hash): Collecti
     const includeList = new IncludeList(dataRaw.included);
 
     return {
-      data: data.map(record => RecordFactory.create<T>(record, includeList)),
-      meta: dataRaw.meta
+      data: data.map((record) => RecordFactory.create<T>(record, includeList)),
+      meta: dataRaw.meta,
     };
   } else {
     return {
-      data: data.map(record => RecordFactory.create<T>(record)),
-      meta: dataRaw.meta
+      data: data.map((record) => RecordFactory.create<T>(record)),
+      meta: dataRaw.meta,
     };
   }
 };
@@ -68,22 +68,22 @@ export function makeSingleElement<T extends Hash>(
   type: string,
   opts: Hash,
   included: string[] = [],
-  includeSet?: IncludeSet
+  includeSet?: IncludeSet,
 ): JsonApiSingleModelResponse<T> {
-  let out: JsonApiSingleModelResponse<T> = {
+  const out: JsonApiSingleModelResponse<T> = {
     data: {
       type: type,
       /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
       id: (data as any).id,
-      attributes: data
+      attributes: data,
     },
-    ...opts
+    ...opts,
   };
 
   if (includeSet) {
-    let includedList: JsonApiRecord<Hash>[] = [];
-    included.forEach(relation => {
-      let [localRelation, ...foreignRelations] = relation.split(".");
+    const includedList: JsonApiRecord<Hash>[] = [];
+    included.forEach((relation) => {
+      const [localRelation, ...foreignRelations] = relation.split(".");
 
       console.log("try to get", type, localRelation, <string>out.data.id);
       console.log(includeSet);
@@ -93,39 +93,39 @@ export function makeSingleElement<T extends Hash>(
 
         if (includeSet.getType(relation) == "hasMany") {
           out.data.relationships[localRelation] ||= {
-            data: []
+            data: [],
           };
 
-          let data = out.data.relationships[localRelation].data as JsonApiReference[];
+          const data = out.data.relationships[localRelation].data as JsonApiReference[];
           data.push({
             type: record.type,
-            id: record.id
+            id: record.id,
           });
 
-          let foreignIncluded = foreignRelations.length > 0 ? [foreignRelations.join(".")] : [];
+          const foreignIncluded = foreignRelations.length > 0 ? [foreignRelations.join(".")] : [];
 
-          let object = makeSingleElement(
+          const object = makeSingleElement(
             Object.assign({ id: record.id }, record._jsonapiData.attributes),
             record.type,
             {},
             foreignIncluded,
-            includeSet
+            includeSet,
           );
           includedList.push(object.data);
         } else {
           out.data.relationships[localRelation] = {
             data: {
               type: record.type,
-              id: record.id
-            }
+              id: record.id,
+            },
           };
 
-          let object = makeSingleElement(
+          const object = makeSingleElement(
             Object.assign({ id: record.id }, record._jsonapiData.attributes),
             record.type,
             {},
             foreignRelations,
-            includeSet
+            includeSet,
           );
 
           includedList.push(object.data);
@@ -146,61 +146,61 @@ export function makeCollection<T extends Hash>(
   type: string,
   included: string[] = [],
   includeSet: IncludeSet,
-  opts: Hash = {}
+  opts: Hash = {},
 ): JsonApiCollectionModelResponse<T> {
-  let includedList: JsonApiRecord<Hash>[] = [];
+  const includedList: JsonApiRecord<Hash>[] = [];
 
-  let result: JsonApiCollectionModelResponse<T> = {
-    data: data.map(item => {
-      let out: JsonApiRecord<T> = {
+  const result: JsonApiCollectionModelResponse<T> = {
+    data: data.map((item) => {
+      const out: JsonApiRecord<T> = {
         type: type,
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
         id: (item as any).id,
-        attributes: item
+        attributes: item,
       };
 
       if (includeSet) {
-        included.forEach(relation => {
-          let [localRelation, ...foreignRelations] = relation.split(".");
+        included.forEach((relation) => {
+          const [localRelation, ...foreignRelations] = relation.split(".");
 
           includeSet.get(type, localRelation, <string>out.id).forEach((record: Record) => {
             out.relationships ||= {};
 
             if (includeSet.getType(relation) == "hasMany") {
               out.relationships[localRelation] ||= {
-                data: []
+                data: [],
               };
 
-              let data = out.relationships[localRelation].data as JsonApiReference[];
+              const data = out.relationships[localRelation].data as JsonApiReference[];
               data.push({
                 type: record.type,
-                id: record.id
+                id: record.id,
               });
 
-              let foreignIncluded = foreignRelations.length > 0 ? [foreignRelations.join(".")] : [];
+              const foreignIncluded = foreignRelations.length > 0 ? [foreignRelations.join(".")] : [];
 
-              let object = makeSingleElement(
+              const object = makeSingleElement(
                 Object.assign({ id: record.id }, record._jsonapiData.attributes),
                 record.type,
                 {},
                 foreignIncluded,
-                includeSet
+                includeSet,
               );
               includedList.push(object.data);
             } else {
               out.relationships[localRelation] = {
                 data: {
                   type: record.type,
-                  id: record.id
-                }
+                  id: record.id,
+                },
               };
 
-              let object = makeSingleElement(
+              const object = makeSingleElement(
                 Object.assign({ id: record.id }, record._jsonapiData.attributes),
                 record.type,
                 {},
                 foreignRelations,
-                includeSet
+                includeSet,
               );
 
               includedList.push(object.data);
@@ -211,7 +211,7 @@ export function makeCollection<T extends Hash>(
 
       return out;
     }),
-    ...opts
+    ...opts,
   };
 
   if (includedList.length > 0) {

--- a/app/frontend/src/lib/security/AuthContext.ts
+++ b/app/frontend/src/lib/security/AuthContext.ts
@@ -89,6 +89,12 @@ export class AuthContext {
 
   public readonly actionMap: ActionMap;
 
+  // Dedupes concurrent as_user membership lookups within this auth session.
+  // Keyed by `${projectId}:${accountId}`; caches the in-flight promise so N
+  // simultaneous can() checks share one request. Scoped to the instance, so a
+  // new AuthContext on login/refresh starts empty. Failures are not cached.
+  private readonly projectMemberCache = new Map<string, Promise<ProjectMemberRecord | undefined>>();
+
   public readonly id: string;
 
   public readonly email: string;
@@ -152,17 +158,26 @@ export class AuthContext {
         if (typeof scope === "object") {
           const { projectId, projectMemberRoles } = scope["as_user"];
 
-          const projectMemberRes = await projectMembersBackendDataSource.list({
-            fields: {
-              [ProjectMemberRecord.type]: ["id", "role"],
-            },
-            filters: {
-              project_id: projectId,
-              account_id: this.id,
-            },
-          });
+          const cacheKey = `${projectId}:${this.id}`;
+          let lookup = this.projectMemberCache.get(cacheKey);
+          if (!lookup) {
+            lookup = projectMembersBackendDataSource
+              .list({
+                fields: {
+                  [ProjectMemberRecord.type]: ["id", "role"],
+                },
+                filters: {
+                  project_id: projectId,
+                  account_id: this.id,
+                },
+              })
+              .then((res) => res.data[0]);
+            // Don't cache transient failures — allow a later retry.
+            lookup.catch(() => this.projectMemberCache.delete(cacheKey));
+            this.projectMemberCache.set(cacheKey, lookup);
+          }
 
-          const currentAccountProjectMember = projectMemberRes.data[0];
+          const currentAccountProjectMember = await lookup;
           if (!currentAccountProjectMember) return false;
 
           if (projectMemberRoles.includes(currentAccountProjectMember.role)) {

--- a/app/frontend/src/lib/security/can.svelte
+++ b/app/frontend/src/lib/security/can.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, type Snippet } from "svelte";
+  import type { Snippet } from "svelte";
 
   import { authStatus } from "@/security/AuthContext";
 
@@ -20,20 +20,35 @@
   // Variables
   let hasAccess: boolean = $state(false);
 
-  // Lifecycle
-  onMount(async () => {
+  // Re-evaluate whenever auth state or any input prop changes (not just once
+  // on mount). The cancelled flag drops a stale async result if inputs change
+  // before can() resolves.
+  $effect(() => {
     const currentAccount = $authStatus.authContext;
+    const currentAction = action;
+    const currentResource = resource;
+    const currentScopes = scopes;
+    const currentRoles = roles;
 
-    if (!currentAccount) {
-      hasAccess = false;
-      return;
-    }
+    let cancelled = false;
 
-    hasAccess = (await currentAccount?.can(action, resource, scopes)) || false;
+    (async () => {
+      if (!currentAccount) {
+        hasAccess = false;
+        return;
+      }
 
-    if (roles?.length) {
-      hasAccess = roles.includes(currentAccount.roleName);
-    }
+      const allowed = (await currentAccount.can(currentAction, currentResource, currentScopes)) || false;
+      // AND semantics: roles only narrows the server-authoritative can()
+      // result, it never widens it.
+      const roleOk = currentRoles?.length ? currentRoles.includes(currentAccount.roleName) : true;
+
+      if (!cancelled) hasAccess = allowed && roleOk;
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   });
 </script>
 

--- a/app/frontend/src/lib/utils/uri.test.ts
+++ b/app/frontend/src/lib/utils/uri.test.ts
@@ -71,7 +71,7 @@ describe("filtersToHash", () => {
     ).toEqual({ name: "John", age__gt: 18 });
   });
 
-  it("does not drop single-value filters (regression: FE-010)", () => {
+  it("does not drop single-value filters (regression)", () => {
     // Before the fix, filtersToHash returned {} for every input because it
     // never assigned out[key] on first sight of a key.
     const out = filtersToHash({ status: { op: "eq", value: "active" } });

--- a/app/frontend/src/lib/utils/uri.test.ts
+++ b/app/frontend/src/lib/utils/uri.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { snakeCase, encodeUri, filtersToHash, convertSearchParamsToHash } from "./uri";
+
+describe("snakeCase", () => {
+  it("converts camelCase to snake_case", () => {
+    expect(snakeCase("helloWorld")).toBe("hello_world");
+  });
+
+  it("converts multiple humps", () => {
+    expect(snakeCase("fooBarBaz")).toBe("foo_bar_baz");
+  });
+
+  it("converts space-separated words", () => {
+    expect(snakeCase("Hello World")).toBe("hello_world");
+  });
+
+  it("leaves an already snake_case string unchanged", () => {
+    expect(snakeCase("already_snake")).toBe("already_snake");
+  });
+
+  it("lowercases a single word", () => {
+    expect(snakeCase("Foo")).toBe("foo");
+  });
+});
+
+describe("encodeUri", () => {
+  it("encodes a flat object", () => {
+    expect(encodeUri({ foo: "bar", n: 1 })).toBe("foo=bar&n=1");
+  });
+
+  it("url-encodes reserved characters in keys and values", () => {
+    expect(encodeUri({ q: "a b&c=d" })).toBe("q=a%20b%26c%3Dd");
+  });
+
+  it("encodes array values with []", () => {
+    expect(encodeUri({ ids: [1, 2] })).toBe("ids%5B%5D=1&ids%5B%5D=2");
+  });
+
+  it("encodes nested objects with [key]", () => {
+    expect(encodeUri({ a: { b: "c" } })).toBe("a%5Bb%5D=c");
+  });
+
+  it("encodes objects nested inside arrays", () => {
+    expect(encodeUri({ tags: [{ id: 1 }] })).toBe("tags%5B%5D%5Bid%5D=1");
+  });
+
+  it("returns an empty string for an empty object", () => {
+    expect(encodeUri({})).toBe("");
+  });
+});
+
+describe("filtersToHash", () => {
+  it("keeps the key as-is for the eq operator", () => {
+    expect(filtersToHash({ name: { op: "eq", value: "John" } })).toEqual({
+      name: "John",
+    });
+  });
+
+  it("suffixes the key with __op for non-eq operators", () => {
+    expect(filtersToHash({ age: { op: "gt", value: 18 } })).toEqual({
+      age__gt: 18,
+    });
+  });
+
+  it("serialises multiple distinct filters", () => {
+    expect(
+      filtersToHash({
+        name: { op: "eq", value: "John" },
+        age: { op: "gt", value: 18 },
+      }),
+    ).toEqual({ name: "John", age__gt: 18 });
+  });
+
+  it("does not drop single-value filters (regression: FE-010)", () => {
+    // Before the fix, filtersToHash returned {} for every input because it
+    // never assigned out[key] on first sight of a key.
+    const out = filtersToHash({ status: { op: "eq", value: "active" } });
+    expect(out).toEqual({ status: "active" });
+    expect(Object.keys(out)).toHaveLength(1);
+  });
+
+  it("returns an empty object for no filters", () => {
+    expect(filtersToHash({})).toEqual({});
+  });
+});
+
+describe("convertSearchParamsToHash", () => {
+  it("extracts the column key + operator from a filters[...] param", () => {
+    const params = new URLSearchParams("filters[name__match]=John");
+    expect(convertSearchParamsToHash(params)).toEqual({ name__match: "John" });
+  });
+
+  it("extracts an operator-less filter key", () => {
+    const params = new URLSearchParams("filters[name]=John");
+    expect(convertSearchParamsToHash(params)).toEqual({ name: "John" });
+  });
+
+  it("keeps only the last value for repeated keys (Object.fromEntries dedupes)", () => {
+    // NOTE: convertSearchParamsToHash routes through
+    // Object.fromEntries(searchParams.entries()), which collapses duplicate
+    // keys to their last value BEFORE the loop runs. Its internal
+    // array-collapsing branch is therefore effectively unreachable for
+    // URLSearchParams input. This test documents the actual behaviour.
+    const params = new URLSearchParams();
+    params.append("filters[role__in]", "admin");
+    params.append("filters[role__in]", "editor");
+    expect(convertSearchParamsToHash(params)).toEqual({ role__in: "editor" });
+  });
+
+  it("keeps multiple distinct keys", () => {
+    const params = new URLSearchParams("filters[name]=John&filters[age__gt]=18");
+    expect(convertSearchParamsToHash(params)).toEqual({
+      name: "John",
+      age__gt: "18",
+    });
+  });
+
+  it("ignores params that don't match the listOptions[key] shape", () => {
+    const params = new URLSearchParams("page=1&filters[name]=John");
+    expect(convertSearchParamsToHash(params)).toEqual({ name: "John" });
+  });
+
+  it("returns an empty object when nothing matches", () => {
+    const params = new URLSearchParams("page=1&items_per_page=20");
+    expect(convertSearchParamsToHash(params)).toEqual({});
+  });
+});

--- a/app/frontend/src/lib/utils/uri.ts
+++ b/app/frontend/src/lib/utils/uri.ts
@@ -50,12 +50,12 @@ export const filtersToHash = (filters: Filters): Hash => {
       key = `${key}__${value.op}`;
     }
 
-    if (out[key]) {
-      if (!(out[key] instanceof Array)) {
-        out[key].push(value.value);
-      } else {
-        out[key] = [out[key], value.value];
-      }
+    if (out[key] == null) {
+      out[key] = value.value;
+    } else if (Array.isArray(out[key])) {
+      out[key].push(value.value);
+    } else {
+      out[key] = [out[key], value.value];
     }
   }
 

--- a/app/frontend/src/routes/(protected)/entries/[entryId]/plugin/[pluginId]/+layout.svelte
+++ b/app/frontend/src/routes/(protected)/entries/[entryId]/plugin/[pluginId]/+layout.svelte
@@ -4,23 +4,29 @@
   // Props
   let { children } = $props();
 
-  let pluginId: string = page.params.pluginId as string;
+  const rawPluginId = page.params.pluginId as string;
+  // Only allow safe plugin identifiers. Rejecting path/protocol characters
+  // (":", "/", ".", "%") keeps the value a single path segment under
+  // VITE_IDAH_HOST, so a crafted id can't load attacker JS in this origin.
+  const pluginId = /^[A-Za-z0-9_-]+$/.test(rawPluginId) ? rawPluginId : null;
   let jsloaded = $state(false);
   let cssloaded = $state(false);
   let loaded = $derived(jsloaded && cssloaded);
 </script>
 
 <svelte:head>
-  <link
-    rel="stylesheet"
-    type="text/css"
-    href="{import.meta.env.VITE_IDAH_HOST}/api/v1/setting/plugins/{pluginId}/files/plugin.css"
-    onload={() => (cssloaded = true)}
-  />
-  <script
-    src="{import.meta.env.VITE_IDAH_HOST}/api/v1/setting/plugins/{pluginId}/files/plugin.js"
-    onload={() => (jsloaded = true)}
-  ></script>
+  {#if pluginId}
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="{import.meta.env.VITE_IDAH_HOST}/api/v1/setting/plugins/{pluginId}/files/plugin.css"
+      onload={() => (cssloaded = true)}
+    />
+    <script
+      src="{import.meta.env.VITE_IDAH_HOST}/api/v1/setting/plugins/{pluginId}/files/plugin.js"
+      onload={() => (jsloaded = true)}
+    ></script>
+  {/if}
 </svelte:head>
 
 {#if loaded}

--- a/app/setting/Dockerfile
+++ b/app/setting/Dockerfile
@@ -7,11 +7,6 @@ RUN apt-get update && apt-get install -y \
     # Basic build tools
     build-essential \
     pkg-config \
-    # FFmpeg and its dependencies
-    ffmpeg \
-    # ImageMagick and its dependencies
-    imagemagick \
-    libmagickwand-dev \
     # pgSQL client libraries
     libpq-dev \
     # Additional useful packages

--- a/app/setting/Gemfile
+++ b/app/setting/Gemfile
@@ -26,8 +26,6 @@ gem "sinatra-contrib"
 
 gem "bootsnap", "~> 1.16"
 
-gem "rmagick", "~> 6.0.1"
-
 group :test do
   gem "rack-test"
   gem "rspec", "~> 3.0"

--- a/app/setting/Gemfile.lock
+++ b/app/setting/Gemfile.lock
@@ -89,13 +89,11 @@ GEM
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.7.4)
-    observer (0.1.2)
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
     pg (1.5.9)
-    pkg-config (1.6.2)
     prism (1.4.0)
     pry (0.15.2)
       coderay (~> 1.1)
@@ -123,9 +121,6 @@ GEM
       connection_pool
     regexp_parser (2.10.0)
     rexml (3.4.1)
-    rmagick (6.0.1)
-      observer (~> 0.1)
-      pkg-config (~> 1.4)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -207,7 +202,6 @@ DEPENDENCIES
   puma (~> 6)
   rack-test
   rake
-  rmagick (~> 6.0.1)
   rspec (~> 3.0)
   rubocop
   simplecov

--- a/app/setting/app/expo/account_settings_expo.rb
+++ b/app/setting/app/expo/account_settings_expo.rb
@@ -20,12 +20,12 @@ class AccountSettingsExpo < BaseExpo
     update
   end
 
-  expose on_resource_event("iam:accounts", "created")
+  expose on_resource_event(Resource::Iam::Accounts,"created")
   def create_account_settings
     service.create(params[:resource_id])
   end
 
-  expose on_resource_event("iam:accounts", "deleted")
+  expose on_resource_event(Resource::Iam::Accounts,"deleted")
   def delete_account_settings
     service.delete(params[:resource_id])
   end

--- a/app/setting/app/expo/account_settings_expo.rb
+++ b/app/setting/app/expo/account_settings_expo.rb
@@ -20,12 +20,12 @@ class AccountSettingsExpo < BaseExpo
     update
   end
 
-  expose on_resource_event(Resource::Iam::Accounts,"created")
+  expose on_resource_event(Resource::Iam::Accounts, "created")
   def create_account_settings
     service.create(params[:resource_id])
   end
 
-  expose on_resource_event(Resource::Iam::Accounts,"deleted")
+  expose on_resource_event(Resource::Iam::Accounts, "deleted")
   def delete_account_settings
     service.delete(params[:resource_id])
   end

--- a/app/setting/app/expo/plugins_expo.rb
+++ b/app/setting/app/expo/plugins_expo.rb
@@ -3,10 +3,11 @@
 class PluginsExpo < BaseExpo
   http_path "/plugins"
 
-  # GET plugins/modalities # return all modalities available
-  # GET plugins/:plugin_name/files/plugin.js|css # Entrypoint pour le plugin
-  # GET plugins/:plugin_name/files/entry.js|css # Entrypoint for show les entries
-  # GET plugins/:plugin_name/assets/... # public static files
+  # GET plugins/modalities                  # list all available modalities
+  # GET plugins/modalities/:modality_name   # shapes for a single modality
+  # GET plugins/:plugin/files/:filename      # serve an allowlisted plugin file
+  #   (plugin.js|css, details.js|css, dataset_config.json, plugin_shortcut.json)
+  # GET plugins/:plugin/assets/*             # serve public static plugin assets
 
   use_service Plugins::Service
 

--- a/app/setting/app/expo/plugins_expo_spec.rb
+++ b/app/setting/app/expo/plugins_expo_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe PluginsExpo, type: :exposition, as: :system do
 
       get "/plugins/#{plugin_name}/files/#{filename}"
 
-      puts last_response.body
-
       expect(last_response.status).to eq(200)
       expect(last_response.body).to eq("file content")
     end
@@ -53,8 +51,6 @@ RSpec.describe PluginsExpo, type: :exposition, as: :system do
       )
 
       get "/plugins/#{plugin_name}/assets/#{filename}"
-
-      puts last_response.body
 
       expect(last_response.status).to eq(200)
       expect(last_response.body).to eq("asset content")

--- a/app/setting/app/model/account_setting.rb
+++ b/app/setting/app/model/account_setting.rb
@@ -25,8 +25,6 @@ module AccountSetting
         scope.all? { table }
 
         scope.own? {
-          table if action == :create
-
           table.where(account_id: auth_context.metadata[:id])
         }
       end

--- a/app/setting/app/model/account_setting.rb
+++ b/app/setting/app/model/account_setting.rb
@@ -45,7 +45,9 @@ module AccountSetting
     def set(key, value, account_id:, plugin: "")
       table = scoped(:update)
 
-      value = Sequel.lit("?::jsonb", value.to_json)
+      # Explicit cast: the insert_conflict upsert bypasses the :value
+      # JsonEncoder, so the jsonb column needs the value cast here.
+      value = Sequel.cast(value.to_json, :jsonb)
 
       table.insert_conflict(
         target: %i[key account_id plugin],

--- a/app/setting/app/model/plugin.rb
+++ b/app/setting/app/model/plugin.rb
@@ -47,9 +47,9 @@ module Plugin
             plugin_path.split(";").each do |path|
               Dir.glob(path).each do |dir|
                 local_plugin_name = dir.split("/").last
-                curent_plugin_name = "#{name}-#{version}"
+                current_plugin_name = "#{name}-#{version}"
 
-                next unless local_plugin_name == curent_plugin_name
+                next unless local_plugin_name == current_plugin_name
 
                 return File.join(dir)
               end

--- a/app/setting/app/model/setting.rb
+++ b/app/setting/app/model/setting.rb
@@ -29,7 +29,9 @@ module Setting
     def set(key, value)
       table = scoped(:update)
 
-      value = Sequel.lit("?::jsonb", value.to_json)
+      # Explicit cast: the insert_conflict upsert bypasses the :value
+      # JsonEncoder, so the jsonb column needs the value cast here.
+      value = Sequel.cast(value.to_json, :jsonb)
 
       table.insert_conflict(
         target: %i[key],

--- a/app/setting/app/service/plugins/service.rb
+++ b/app/setting/app/service/plugins/service.rb
@@ -38,13 +38,13 @@ module Plugins
       assets_directory = manifest.entry_points&.assets_directory
       return nil unless assets_directory
 
-      asset_path = File.join(
-        plugin.path,
-        assets_directory,
-        filename
-      )
+      root       = File.expand_path(File.join(plugin.path, assets_directory))
+      asset_path = File.expand_path(File.join(root, filename))
 
-      return nil unless File.exist?(asset_path)
+      # Containment: reject anything that escapes the asset root
+      # (encoded/suffixed traversal, manifest-supplied `..`, symlinks, etc.).
+      return nil unless asset_path.start_with?("#{root}/")
+      return nil unless File.file?(asset_path)
 
       File.open(asset_path, "rb")
     end
@@ -134,11 +134,15 @@ module Plugins
 
       return nil if file_path.nil?
 
-      return unless file_path
+      root      = File.expand_path(plugin.path)
+      full_path = File.expand_path(File.join(root, file_path))
 
-      File.read(
-        File.join(plugin.path, file_path)
-      )
+      # Containment: a tampered manifest could point `file_path` outside the
+      # plugin dir (e.g. "../../../../etc/passwd"). Reject and 404 instead.
+      return nil unless full_path.start_with?("#{root}/")
+      return nil unless File.file?(full_path)
+
+      File.read(full_path)
     end
   end
 end

--- a/app/setting/db/migrations/20250928000000_create_initial_schema.rb
+++ b/app/setting/db/migrations/20250928000000_create_initial_schema.rb
@@ -45,18 +45,5 @@ Sequel.migration do
       Migration::Timestamps.timestamps(self)
     end
     Migration::Timestamps.trg_updated_at(self, :plugins)
-
-    # create_table(:plugin_images) do
-    #   column :id, String, primary_key: true
-
-    #   reference :plugin_id, :plugins, null: false, on_delete: :restrict
-    #   column :service, String, null: false
-
-    #   column :size, Integer, null: false
-
-    #   index %i[plugin_id service], unique: true
-
-    #   Migration::Timestamps.timestamps(self)
-    # end
   end
 end

--- a/app/setting/db/migrations/20260706000000_add_plugins_name_version_unique_index.rb
+++ b/app/setting/db/migrations/20260706000000_add_plugins_name_version_unique_index.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Plugin discovery can register multiple rows with the same (name, version)
+# pointing at different source_paths, making Plugin::Record#path resolution
+# ambiguous. Enforce uniqueness on (name, version).
+#
+# NOTE: if duplicate (name, version) rows already exist this migration will
+# fail — dedupe them manually before running it (a loud failure is preferred
+# over silently dropping rows here).
+Sequel.migration do
+  up do
+    alter_table(:plugins) do
+      add_index %i[name version], unique: true, name: :plugins_name_version_uidx
+    end
+  end
+
+  down do
+    alter_table(:plugins) do
+      drop_index %i[name version], name: :plugins_name_version_uidx
+    end
+  end
+end

--- a/common/data/roles/8.0.0_admin.yml
+++ b/common/data/roles/8.0.0_admin.yml
@@ -38,3 +38,6 @@ admin:
     - "sync:jobs.read.*"
     - "sync:exports.read.*"
     - "sync:exports.create.*"
+
+    # Audit Service
+    - "audit:logs.read.*"


### PR DESCRIPTION
## Audit remediation — Setting + Frontend core/criticals

Remediation for the 38 findings in Marc's audit scope (Setting `S-01…S-25` + 13 core/critical `FE-*`). Findings are tracked below in a **new priority order** — sorted so *easy + important* fixes land first, with architecture / cross-team-blocked work grouped at the bottom.

**This PR implements `FE-008` only** (Critical XSS). The remaining items are tracked here and land in follow-up PRs on this branch.

### FE-008 — what changed
`marked` no longer sanitises its output (since v4), so rendering it through `{@html}` allowed stored XSS via any user-authored markdown. The parsed HTML is now run through `DOMPurify` before rendering. The app is SSR (`adapter-node`) and `dompurify` needs a DOM, so sanitisation happens in the browser only and returns `""` on the server until hydration re-runs the parser.

---

## Tracking checklist (priority order)

### Tier 1 — Quick wins · easy + important + solo-actionable
- [x] **FE-008** · Crit · XSS: sanitise `marked` output before `{@html}` ← **this PR**
- [x] **S-01** · High · `serve_asset` path-traversal containment
- [x] **S-02** · High · `serve_file` traversal guard *(also resolves S-14, S-19)*
- [x] **S-04** · High* · delete dead `:create` no-op line *(severity overstated — already filtered)*
- [x] **FE-010** · Med · fix `filtersToHash` + add `uri.test.ts` — ⚠️ **audit impact overstated**: the buggy `filtersToHash` is in `utils/uri.ts` and is **unused**; `BackendDataSource.list` uses the *correct* `filtersToHash` from `@/data/filtering`, so live list filtering was never broken. Fixed the dead duplicate + added tests.
- [x] **FE-021** · Med · `roles` prop = **AND** with `can()`, not silent override — audited all 8 `PageProvider` callers: 7 unaffected. `audit-logs` would have regressed (no role had any `audit:logs` right, so `can()` was false for admins), so also granted admins `audit:logs.read.*` in `common/data/roles/8.0.0_admin.yml`. ⚠️ **role-model change: admins need a token refresh / re-login to pick it up.** `<Can>` has the same override bug — fixed under FE-005.
- [ ] **S-13** · Med · clamp `items_per_page` — ⏭️ **Skipped (deferred to Verse):** an unbounded/`1000` default is not specific to `AccountSettings::Service` (the same appears in e.g. audit `Log::Service#index`). A per-service clamp leaves the pattern everywhere else, so the fix belongs in Verse's shared pagination layer, not here. Track as a framework-level follow-up.
- [x] **S-08** · Med · add `plugins (name, version)` unique index (migration) — ⚠️ fails loudly if duplicate rows already exist (dedupe manually before running)
- [ ] **S-12** · Med · remove phantom `::SCHEDULER`/`::EXECUTOR` worker-boot block — ⏭️ **Skipped (infra/config owner):** `puma.rb` worker config should be aligned across services by the deployment/infra owner, not changed ad hoc in one service. Defer to that owner. (Latent unless `PUMA_WORKERS > 1`.)
- [x] **FE-002** · Low · regex → `startsWith` (regex-injection)
- [x] **FE-001** · Low · store + clear the `setInterval` handle
- [x] **FE-012** · Low · `throw parseSingleElementError(...)` instead of a bare string
- [x] **S-16** · Low · `Sequel.cast(...)` instead of raw `Sequel.lit` (both `set` methods; backfill migration's constant-value `lit` left as-is, out of scope)
- [x] **S-18** · Low · typo `curent_plugin_name` → `current_plugin_name`
- [x] **S-20** · Low · use `Resource::Iam::Accounts` constant, not `"iam:accounts"` — spec literal kept intentionally (independent wire-value assertion)

### Tier 2 — Dead-scaffolding cleanup · easy, solo · decision = delete
- [x] **S-23** · Info · delete commented-out `plugin_images` schema block

### Tier 3 — Medium effort, solo · important but not one-liners
- [x] **FE-015** · Crit · validate `pluginId` (allowlist regex `/^[A-Za-z0-9_-]+$/` + `{#if}` head guard). Strategic isolation (iframe/SRI/off-origin) still tracked with S-06/S-07.
- [x] **FE-003** · Med · shared `requestJson` + `rejectionFor` helpers (`response.ok` + defensive JSON parse) across all 5 methods; updated test mocks (also fixed a pre-existing failing `#delete` test) + added a non-ok/non-JSON case
- [x] **FE-005** · Med · reactive `$effect` `<Can>` (fixes stale-on-mount) + AND `roles` (finishes the FE-021 fix for `<Can>`). Verified no effect loop + `authStatus` doesn't emit on navigation.
- [x] **FE-004** · Med · promise-cache `(projectId, accountId)` member lookup on AuthContext (dedupes concurrent `can()`; instance-scoped auto-invalidation; failures not cached)
- [x] **FE-011** · Med · parallelise remaining assign/priority loops (`Promise.all`) + hoist the assign modal's redundant per-iteration email fetch. (Server batch endpoint remains a Tier-5 dataset-team follow-up.)

### Tier 4 — Hygiene · easy but low/Info importance
- [x] **S-22** · Info · rewrite stale FR/EN route comments
- [x] **S-24** · Info · remove `puts last_response.body` from specs
- [x] **S-25** · Info · drop unused `rmagick` + ImageMagick/ffmpeg from image

### Tier 5 — Blocked / needs coordination · hard or cross-team
> 📌 Tracked in stacked PR **#540** (base = this branch): S-06/S-17 committed there for review + checkpoint; the rest presented as a decision doc for senior sign-off.
- [ ] **S-09** · Med · delete broken `Plugins::Manager` — ⏭️ **moved from Tier 2:** deleting a half-built plugin-install subsystem is a delete-or-finish decision (part of the phantom plugin-lifecycle story with S-10/S-11/S-12). Needs senior/team sign-off before removal.
- [ ] **S-21** · Low · undefined `install_plugin` in `Service#install` — ⏭️ **moved from Tier 2:** coupled to S-09 (removed by the same delete). Same senior/team discussion.
- [ ] **S-10** · Med · remove dead `SettingsExpo` route registration — ⏭️ **moved from Tier 2:** `/settings` is intended (but unbuilt) system-settings scaffolding; whether to remove vs design the feature (system-vs-org-vs-user scope + admin auth) needs senior/team sign-off.
- [ ] **S-11** · Med · `PluginLifecycleContext` no-op stub — ⏭️ **moved from Tier 2:** documenting the no-op as intentional vs implementing mount/unmount decides whether the Setting service hosts plugin backends at all — an architecture call needing senior/team sign-off.
- [ ] **S-06** · High · harden plugin asset serving (ext allowlist + size cap + `nosniff` + MIME map) — ⏭️ **moved from Tier 3:** needs the Setting exposition-spec integration checkpoint + touches renderer wiring. Senior discussion pending. Implementation blueprint in the appendix below.
- [ ] **S-17** · Low · replace anonymous inline renderer with tested `PluginMimeType` helper — ⏭️ **moved from Tier 3:** paired with S-06 (same change). Same checkpoint + discussion.
- [ ] **S-15** · Med · extract shared `PluginCatalog` (kill per-request `Dir.glob` in `Service#find` + `Plugin::Record#path`) — ⏭️ **moved from Tier 3:** backend refactor on the request hot path; needs the Setting integration checkpoint to verify. Also the natural home for the S-07 allowlist gate.
- [ ] **S-07** · Med(RCE) · plugin-loader trust — loader in `common/` (Roger). *Solo interim: allowlist gate.*
- [ ] **S-03** · High · anonymous endpoints — needs FE-015 owner sign-off. *Solo interim: gate `modalities`/`show_modality`.*
- [ ] **S-05** · High · event-bus trust boundary — infra/Roger. *Solo interim: log + narrow `delete`.*
- [ ] **FE-016** · Med · remove `Record`'s `[key: string]: any` — **scoped follow-up PR** (measured: surfaces **44 new type errors across ~20 files**, not ~15; several need design decisions). Milestones:
  1. Add contained typed accessor `Record.get<T>(key)` / `setField(key, value)`; drop the index signature; fix the internal `this[recordKey]` in `getValueByKey`.
  2. Migrate mechanical dynamic-access sites (`record[key]` → `record.get<T>(key)`) — combobox/select field components, datasource-table filters, etc.
  3. **Design cluster:** `Property 'resource_id'/… does not exist on type 'T'` (~10) — declare the missing fields on the record classes (proper fix) rather than papering over with `.get()`.
  4. Fix `T[keyof T]` generic typing in the shared select/combobox field components (~8).
- [ ] **FE-006** · Info · auth module singletons — document only, do-not-pursue.
- [ ] **FE-011 (batch)** · Med · server-side bulk endpoint — dataset backend team.

---

### Related findings discovered while fixing (not in original audit)
- **Duplicate `filtersToHash`** — one in `utils/uri.ts` (was buggy, unused) and one in `data/filtering.ts` (correct, used). Candidate for de-duplication so the dead copy can't drift back into use.
- **Dead array branch in `convertSearchParamsToHash`** (`utils/uri.ts`) — it routes through `Object.fromEntries(searchParams.entries())`, which collapses duplicate query keys to the last value before the loop, so its `[value]`-promotion branch is unreachable for `URLSearchParams` input. Behaviour is captured (last-wins) in `uri.test.ts`; logic left unchanged to avoid altering `datasource-table` behaviour out of scope.

Source: `marc-audit-findings.md`. Tier 5 items require coordination (Roger for `common/` loader + event bus, the FE-015 owner, and the dataset backend team).

---

## Appendix — S-06 + S-17 implementation blueprint (ready to execute at the checkpoint)

Both findings are one coherent change on the plugin file/asset endpoints. Deferred to Tier 5 because it needs the Setting exposition-spec integration checkpoint and touches renderer wiring — pending senior discussion.

**1. New util `app/setting/app/util/plugin_mime_type.rb`** (named + testable — resolves S-17's intent): a module mapping extension → safe Content-Type, `DEFAULT = "application/octet-stream"`, method `PluginMimeType.for(filename)` using `File.extname(...).downcase`. Cover `.js .css .json .png .jpg .jpeg .gif .svg .webp .woff .woff2`. Add `plugin_mime_type_spec.rb` (known/unknown/uppercase/no-ext).

**2. Service `serve_asset` (`app/setting/app/service/plugins/service.rb`)** — after the existing S-01 containment + `File.file?` checks, add:
```ruby
ALLOWED_ASSET_EXT = %w[.png .jpg .jpeg .gif .svg .webp .js .css .json .woff .woff2].freeze
MAX_ASSET_BYTES   = 10 * 1024 * 1024
...
return nil unless ALLOWED_ASSET_EXT.include?(File.extname(asset_path).downcase)
return nil if File.size(asset_path) > MAX_ASSET_BYTES
```

**3. Expo (`app/setting/app/expo/plugins_expo.rb`)** — use the `renderer.content_type = …` / `server.response.headers[…] = …` idiom (as in `medias_expo.rb:57`, `exports_expo.rb:35`):
- **`serve` (files):** delete the anonymous `Class.new` renderer → `renderer: Verse::Http::Renderer::Identity`; in the action set `Content-Type = PluginMimeType.for(params[:filename])` + `X-Content-Type-Options: nosniff` (404 if nil).
- **`serve_asset`:** keep `Verse::Http::Renderer::Binary`; set `renderer.content_type = PluginMimeType.for(params[:splat].last)` + `nosniff` before returning the IO.

**4. Extend `plugins_expo_spec.rb`** — assert `Content-Type` + `nosniff` on serve/serve_asset (existing 200/body + 404 assertions must still pass).

**Residual risk:** SVG stays allowlisted (plugins use `icon.svg`); `nosniff` + `image/svg+xml` is set, but an SVG opened via direct top-level navigation can still execute script — belongs to the strategic off-origin/sandbox follow-up (with FE-015/S-07), not this tactical pass.

**Verify:** `bundle exec rspec app/setting/app/util/plugin_mime_type_spec.rb` and `.../plugins_expo_spec.rb` (mock the service, no DB); `ruby -c` the edited files; optionally `curl -i` a `/files/plugin.js` + `/assets/x.png` on a booted service and confirm headers, and that a `.txt`/oversized asset 404s.

Refs: CU-869e0fx5t
