### PR TITLE
Dataset and Media revision

### DIFF
--- a/app/dataset/app/expo/annotations_expo_spec.rb
+++ b/app/dataset/app/expo/annotations_expo_spec.rb
@@ -112,10 +112,6 @@ RSpec.describe AnnotationsExpo, type: :exposition, as: :system do
       }
     end
 
-    def rpc_batch_call(calls)
-      post "/annotations/rpc", calls, { "CONTENT_TYPE" => "application/json" }
-    end
-
     it "show" do
       expect(service).to receive(:show).with(uuid).and_return(annotation_record)
       rpc_call rpc_cmd("show", { id: uuid })

--- a/app/dataset/app/model/entry.rb
+++ b/app/dataset/app/model/entry.rb
@@ -238,15 +238,27 @@ module Entry
           entry = find!(id)
 
           if entry.status == "pending"
-            update!(
+            account_id = auth_context.metadata[:id]
+
+            # Narrowed scope makes the claim atomic: a concurrent claimer's
+            # UPDATE re-evaluates the condition after the winner commits,
+            # matches zero rows and loses deterministically instead of
+            # silently overwriting the first claim.
+            updated = update(
               id,
               {
-                assigned_to_id: auth_context.metadata[:id],
+                assigned_to_id: account_id,
                 assigned_to_email: auth_context.metadata[:email],
                 status: "in_progress"
               },
               scope: scoped(:read)
+                     .where(status: "pending")
+                     .where(Sequel.expr(assigned_to_id: nil) | Sequel.expr(assigned_to_id: account_id))
             )
+
+            unless updated
+              raise Verse::Error::Unauthorized, "Entry already claimed by another user"
+            end
           end
         end
       end

--- a/app/dataset/app/model/entry.rb
+++ b/app/dataset/app/model/entry.rb
@@ -323,7 +323,8 @@ module Entry
     end
 
     def mark_entries_status_as(job_id, status)
-      entry = find_by!({ job_id: job_id, status: "processing" })
+      entry = find_by({ job_id: job_id, status: "processing" })
+      return unless entry
 
       transaction do
         update!(entry.id, { status: })

--- a/app/dataset/app/model/entry_spec.rb
+++ b/app/dataset/app/model/entry_spec.rb
@@ -9,5 +9,85 @@ RSpec.describe Entry, database: true do
     it "can be instantiated" do
       expect(subject).to be_a(Entry::Repository)
     end
+
+    describe "#select" do
+      let(:user_a_context) do
+        Verse::Auth::Context.from_role("admin", metadata: { id: 100, email: "user_a@example.com" })
+      end
+
+      let(:user_b_context) do
+        Verse::Auth::Context.from_role("admin", metadata: { id: 200, email: "user_b@example.com" })
+      end
+
+      let(:repo_a) { described_class.new(user_a_context) }
+      let(:repo_b) { described_class.new(user_b_context) }
+
+      let!(:project_id) do
+        Project::Repository.new(user_a_context).create(
+          name: "Test Project",
+          description: "A test project",
+          created_by_email: "user_a@example.com",
+          organization_id: 1,
+        )
+      end
+
+      let!(:dataset_id) do
+        Dataset::Repository.new(user_a_context).create(
+          modality: "image_labeling",
+          labels: ["cat", "dog"],
+          labeling_configuration: { "width" => 100, "height" => 100 },
+          workflow_configuration: {},
+          project_id:
+        )
+      end
+
+      let(:entry_attributes) do
+        {
+          priority: 1,
+          wf_step: "start",
+          status: "pending",
+          project_id:,
+          dataset_id:
+        }
+      end
+
+      it "claims an unassigned pending entry" do
+        entry_id = repo_a.create(entry_attributes)
+
+        repo_b.select(entry_id)
+
+        entry = repo_b.find!(entry_id)
+        expect(entry.assigned_to_id).to eq(200)
+        expect(entry.assigned_to_email).to eq("user_b@example.com")
+        expect(entry.status).to eq("in_progress")
+      end
+
+      it "re-selects a pending entry already assigned to the caller" do
+        entry_id = repo_a.create(
+          entry_attributes.merge(assigned_to_id: 100, assigned_to_email: "user_a@example.com")
+        )
+
+        repo_a.select(entry_id)
+
+        entry = repo_a.find!(entry_id)
+        expect(entry.assigned_to_id).to eq(100)
+        expect(entry.status).to eq("in_progress")
+      end
+
+      it "does not steal a pending entry already claimed by another user" do
+        entry_id = repo_a.create(
+          entry_attributes.merge(assigned_to_id: 100, assigned_to_email: "user_a@example.com")
+        )
+
+        expect {
+          repo_b.select(entry_id)
+        }.to raise_error(Verse::Error::Unauthorized, /already claimed/)
+
+        entry = repo_a.find!(entry_id)
+        expect(entry.assigned_to_id).to eq(100)
+        expect(entry.assigned_to_email).to eq("user_a@example.com")
+        expect(entry.status).to eq("pending")
+      end
+    end
   end
 end

--- a/app/dataset/app/model/entry_spec.rb
+++ b/app/dataset/app/model/entry_spec.rb
@@ -89,5 +89,70 @@ RSpec.describe Entry, database: true do
         expect(entry.status).to eq("pending")
       end
     end
+
+    describe "#custom_filter :assigned" do
+      let(:system_auth_context) { Verse::Auth::Context[:system] }
+
+      subject { described_class.new(system_auth_context) }
+
+      let!(:project_id) do
+        Project::Repository.new(system_auth_context).create(
+          name: "Filter Project",
+          description: "A test project",
+          created_by_email: "admin@example.com",
+          organization_id: 1,
+        )
+      end
+
+      let!(:dataset_id) do
+        Dataset::Repository.new(system_auth_context).create(
+          modality: "image_labeling",
+          labels: ["cat", "dog"],
+          labeling_configuration: { "width" => 100, "height" => 100 },
+          workflow_configuration: {},
+          project_id:
+        )
+      end
+
+      let!(:assigned_entry_id) do
+        subject.create(
+          priority: 1,
+          wf_step: "start",
+          status: "in_progress",
+          assigned_to_id: 4,
+          assigned_to_email: "annotator@example.com",
+          project_id:,
+          dataset_id:
+        )
+      end
+
+      let!(:unassigned_entry_id) do
+        subject.create(
+          priority: 1,
+          wf_step: "start",
+          status: "pending",
+          project_id:,
+          dataset_id:
+        )
+      end
+
+      it "returns only assigned entries for the literal string \"true\" (case-insensitive)" do
+        ["true", "TRUE", true].each do |value|
+          result = subject.index({ assigned: value })
+
+          expect(result.map(&:id)).to eq([assigned_entry_id]),
+                                      "expected #{value.inspect} to select the assigned branch"
+        end
+      end
+
+      it "treats any value other than the literal string \"true\" as false" do
+        ["false", "1", "yes", "garbage"].each do |value|
+          result = subject.index({ assigned: value })
+
+          expect(result.map(&:id)).to eq([unassigned_entry_id]),
+                                      "expected #{value.inspect} to select the unassigned branch"
+        end
+      end
+    end
   end
 end

--- a/app/dataset/app/model/project_member_spec.rb
+++ b/app/dataset/app/model/project_member_spec.rb
@@ -226,6 +226,15 @@ RSpec.describe ProjectMember, database: true do
           expect(result[0].email).to eq("disabled@example.com")
           expect(result[0].disabled_at).not_to be_nil
         end
+
+        it "treats any value other than the literal string \"true\" as false" do
+          ["1", "yes", "garbage"].each do |value|
+            result = subject.index({ enabled: value })
+
+            expect(result.map { |r| r[:email] }).to eq(["disabled@example.com"]),
+                                                    "expected #{value.inspect} to select the disabled branch"
+          end
+        end
       end
     end
   end

--- a/app/dataset/app/model/workflow/simple_review_annotation_workflow.rb
+++ b/app/dataset/app/model/workflow/simple_review_annotation_workflow.rb
@@ -27,8 +27,11 @@ module Workflow
       end
     end
 
+    # Fraction of annotated entries routed to review, read from the dataset's
+    # workflow_configuration. Expected range 0..1; defaults to 1 when unset,
+    # so review is mandatory unless an operator explicitly lowers it. A value
+    # of 0 skips review entirely (annotate transitions straight to done).
     def sample_rate
-      # Get sample rate from dataset workflow configuration
       @entry.dataset.workflow_configuration[:sample_rate] || 1
     end
 

--- a/app/dataset/app/service/annotation/service.rb
+++ b/app/dataset/app/service/annotation/service.rb
@@ -51,6 +51,10 @@ module Annotation
       end
 
       # Assign attributes
+      # NOTE: overwriting project_id/dataset_id/entry_id from the scoped entry
+      # is load-bearing — the JSON:API create schema does not strip readonly
+      # fields, so client-supplied ids reach record.attributes and would
+      # otherwise allow cross-project writes.
       attributes = record.attributes
       attributes[:id] = record.id || UUIDv7.generate
       attributes[:project_id] = entry.project_id

--- a/app/dataset/app/service/annotation/service_spec.rb
+++ b/app/dataset/app/service/annotation/service_spec.rb
@@ -83,6 +83,58 @@ RSpec.describe Annotation::Service, database: true do
         expect(annotation.project_id).to eq(project_id)
       end
 
+      it "ignores client-supplied project/dataset/entry ids in favor of the entry's" do
+        other_project_id = project_repo.create(
+          name: "Other Project",
+          description: "Another test project",
+          created_by_email: "user@example.com",
+          organization_id: 1,
+        )
+
+        other_dataset_id = dataset_repo.create(
+          modality: "image_labeling",
+          labels: ["cat", "dog"],
+          labeling_configuration: { "width" => 100, "height" => 100 },
+          workflow_configuration: {},
+          project_id: other_project_id
+        )
+
+        other_entry_id = entry_repo.create(
+          priority: 1,
+          wf_step: "start",
+          status: "pending",
+          assigned_to_id: 1,
+          project_id: other_project_id,
+          dataset_id: other_dataset_id
+        )
+
+        record = deserialize(
+          {
+            data: {
+              type: "dataset:annotations",
+              attributes: attributes.merge(
+                project_id: other_project_id,
+                dataset_id: other_dataset_id,
+                entry_id: other_entry_id
+              ),
+              relationships: {
+                entry: {
+                  data: {
+                    type: "dataset:entries",
+                    id: entry_id
+                  }
+                }
+              }
+            }
+          }
+        )
+
+        annotation = subject.create(record)
+        expect(annotation.project_id).to eq(project_id)
+        expect(annotation.dataset_id).to eq(dataset_id)
+        expect(annotation.entry_id).to eq(entry_id)
+      end
+
       it "raises error when entry is completed" do
         completed_entry_id = entry_repo.create(
           priority: 1,

--- a/app/dataset/app/service/dataset/service.rb
+++ b/app/dataset/app/service/dataset/service.rb
@@ -36,7 +36,6 @@ module Dataset
       attributes = record.attributes
       attributes[:id] = record.id || UUIDv7.generate
       attributes[:project_id] = record.project.id
-      # attributes[:created_by_email] ||= auth_context.metadata[:email]
 
       datasets.transaction do
         id = datasets.create(attributes)

--- a/app/dataset/app/service/entry/permission_spec.rb
+++ b/app/dataset/app/service/entry/permission_spec.rb
@@ -225,8 +225,9 @@ RSpec.describe Entry::Service, database: true do
 
         expect(record.priority).to eq 2
         expect(record.resource).to eq "http://example.com/updated.mp4"
-        expect(record.wf_step).to eq "end"
-        expect(record.status).to eq "done"
+        # status/wf_step are protected fields (D22): PATCH cannot change them for non-system callers
+        expect(record.wf_step).to eq "start"
+        expect(record.status).to eq "pending"
         expect(record.assigned_to_id).to eq update_data[:data][:attributes][:assigned_to_id]
       end
 
@@ -312,8 +313,9 @@ RSpec.describe Entry::Service, database: true do
 
         expect(record.priority).to eq 2
         expect(record.resource).to eq "http://example.com/updated.mp4"
-        expect(record.wf_step).to eq "end"
-        expect(record.status).to eq "done"
+        # status/wf_step are protected fields (D22): PATCH cannot change them for non-system callers
+        expect(record.wf_step).to eq "start"
+        expect(record.status).to eq "pending"
         expect(record.assigned_to_id).to eq update_data[:data][:attributes][:assigned_to_id]
       end
 

--- a/app/dataset/app/service/entry/service.rb
+++ b/app/dataset/app/service/entry/service.rb
@@ -9,6 +9,8 @@ module Entry
         annotations: Annotation::Repository
     use_system system_datasets_repo: Dataset::Repository, system_entries_repo: Entry::Repository
 
+    PROTECTED_FIELDS = %i[status wf_step job_id].freeze
+
     def index(filter = {}, included: [], page: 1, items_per_page: 1000, sort: nil, query_count: false)
       entries.index(
         filter,
@@ -70,6 +72,10 @@ module Entry
       attributes[:project_id] = dataset.project_id
       attributes[:dataset_id] = dataset.id
 
+      unless auth_context.can?(:create, entries.class.resource) == :all
+        attributes = attributes.except(*PROTECTED_FIELDS)
+      end
+
       entries.transaction do
         id = entries.create(attributes)
         entries.find!(id)
@@ -92,7 +98,12 @@ module Entry
     end
 
     def update(record)
-      entries.update!(record.id, record.attributes)
+      attributes = record.attributes
+      unless auth_context.can?(:update, entries.class.resource) == :all
+        attributes = attributes.except(*PROTECTED_FIELDS)
+      end
+
+      entries.update!(record.id, attributes)
       entries.find!(record.id)
     end
 

--- a/app/dataset/app/service/entry/service.rb
+++ b/app/dataset/app/service/entry/service.rb
@@ -109,7 +109,13 @@ module Entry
       entries.transaction do
         entry = entries.find!(id)
         member = project_members.find_by({ account_id: assigned_to_id, project_id: entry.project_id })
-        entries.assign(id, assigned_to_id, member&.email)
+
+        if member.nil? || !member.disabled_at.nil?
+          raise Verse::Error::ValidationFailed,
+                "assignee is not an active member of this project"
+        end
+
+        entries.assign(id, assigned_to_id, member.email)
         system_datasets_repo.update_progress!(entry.dataset_id)
         entries.find!(id)
       end

--- a/app/dataset/app/service/entry/service.rb
+++ b/app/dataset/app/service/entry/service.rb
@@ -82,7 +82,9 @@ module Entry
 
     def complete_entry_processing(job_id)
       system_entries_repo.transaction do
-        entry = system_entries_repo.find_by!({ job_id:, status: "processing" }, included: [:dataset])
+        entry = system_entries_repo.find_by({ job_id:, status: "processing" }, included: [:dataset])
+        next unless entry
+
         entry_workflow = entry.dataset.entry_workflow.new(system_entries_repo, entry)
         entry_workflow.submit!
         system_datasets_repo.update_progress!(entry.dataset.id)

--- a/app/dataset/app/service/entry/service_spec.rb
+++ b/app/dataset/app/service/entry/service_spec.rb
@@ -208,6 +208,17 @@ RSpec.describe Entry::Service, database: true do
       entries = repo.index({ job_id: job_id })
       expect(entries.map(&:status)).to all(eq("pending"))
     end
+
+    it "tolerates a duplicate/late job event without raising" do
+      subject.complete_entry_processing(job_id)
+
+      expect {
+        subject.complete_entry_processing(job_id)
+      }.not_to raise_error
+
+      entries = repo.index({ job_id: job_id })
+      expect(entries.map(&:status)).to all(eq("pending"))
+    end
   end
 
   describe "#mark_entries_status_as" do
@@ -237,6 +248,17 @@ RSpec.describe Entry::Service, database: true do
 
       other_entry = repo.index({ job_id: other_job_id }).first
       expect(other_entry.status).to eq("done")
+    end
+
+    it "tolerates a duplicate/late job event without raising" do
+      subject.mark_entries_status_as(job_id, "errored")
+
+      expect {
+        subject.mark_entries_status_as(job_id, "errored")
+      }.not_to raise_error
+
+      entry = repo.index({ job_id: job_id }).first
+      expect(entry.status).to eq("errored")
     end
   end
 

--- a/app/dataset/app/service/entry/service_spec.rb
+++ b/app/dataset/app/service/entry/service_spec.rb
@@ -332,6 +332,15 @@ RSpec.describe Entry::Service, database: true do
   end
 
   describe "#assign_member" do
+    let(:project_member_repo) { ProjectMember::Repository.new(auth_context) }
+
+    before do
+      project_member_repo.create(
+        project_id:, account_id: 2, email: "annotator@example.com",
+        role: "annotator", invited_by_id: 1
+      )
+    end
+
     it "assigns a member to an entry and sets status to in_progress" do
       subject.assign_member(entry.id, 2)
 
@@ -345,10 +354,34 @@ RSpec.describe Entry::Service, database: true do
 
       expect(dataset_repo.find!(dataset_id).status).to eq("in_progress")
     end
+
+    it "rejects assigning a non-member of the project" do
+      expect {
+        subject.assign_member(entry.id, 999)
+      }.to raise_error(Verse::Error::ValidationFailed, /active member/)
+    end
+
+    it "rejects assigning a disabled member" do
+      disabled_id = project_member_repo.create(
+        project_id:, account_id: 3, email: "disabled@example.com",
+        role: "annotator", invited_by_id: 1
+      )
+      project_member_repo.update!(disabled_id, { disabled_at: Time.now })
+
+      expect {
+        subject.assign_member(entry.id, 3)
+      }.to raise_error(Verse::Error::ValidationFailed, /active member/)
+    end
   end
 
   describe "#unassign_member" do
+    let(:project_member_repo) { ProjectMember::Repository.new(auth_context) }
+
     before do
+      project_member_repo.create(
+        project_id:, account_id: 2, email: "annotator@example.com",
+        role: "annotator", invited_by_id: 1
+      )
       subject.assign_member(entry.id, 2)
     end
 
@@ -404,7 +437,9 @@ RSpec.describe Entry::Service, database: true do
         invited_by_id: 1
       )
 
-      subject.assign_member(entry.id, 99)
+      # D13 blocks assigning a cross-project member through the service, so set
+      # the assignment directly to exercise the relation-resolution guard.
+      repo.assign(entry.id, 99, "stray@example.com")
 
       result = repo.find!(entry.id, included: [:assigned_to])
       expect(result.assigned_to).to be_nil

--- a/app/dataset/app/service/entry/service_spec.rb
+++ b/app/dataset/app/service/entry/service_spec.rb
@@ -360,8 +360,11 @@ RSpec.describe Entry::Service, database: true do
 
     before do
       project_member_repo.create(
-        project_id:, account_id: 2, email: "annotator@example.com",
-        role: "annotator", invited_by_id: 1
+        project_id:,
+        account_id: 2,
+        email: "annotator@example.com",
+        role: "annotator",
+        invited_by_id: 1
       )
     end
 
@@ -387,8 +390,11 @@ RSpec.describe Entry::Service, database: true do
 
     it "rejects assigning a disabled member" do
       disabled_id = project_member_repo.create(
-        project_id:, account_id: 3, email: "disabled@example.com",
-        role: "annotator", invited_by_id: 1
+        project_id:,
+        account_id: 3,
+        email: "disabled@example.com",
+        role: "annotator",
+        invited_by_id: 1
       )
       project_member_repo.update!(disabled_id, { disabled_at: Time.now })
 
@@ -403,8 +409,11 @@ RSpec.describe Entry::Service, database: true do
 
     before do
       project_member_repo.create(
-        project_id:, account_id: 2, email: "annotator@example.com",
-        role: "annotator", invited_by_id: 1
+        project_id:,
+        account_id: 2,
+        email: "annotator@example.com",
+        role: "annotator",
+        invited_by_id: 1
       )
       subject.assign_member(entry.id, 2)
     end

--- a/app/dataset/app/service/entry/service_spec.rb
+++ b/app/dataset/app/service/entry/service_spec.rb
@@ -559,6 +559,20 @@ RSpec.describe Entry::Service, database: true do
       end
     end
 
+    context "when sample_rate is not configured" do
+      before do
+        repo.update!(test_entry, { wf_step: "annotate" })
+      end
+
+      it "defaults to always routing annotated entries to review" do
+        # dataset fixture uses workflow_configuration: {} so sample_rate falls
+        # back to 1; rand is always < 1, so review is deterministic here.
+        result = subject.submit(test_entry)
+
+        expect(result.wf_step).to eq("review")
+      end
+    end
+
     context "when transitioning from annotate to done" do
       before do
         repo.update!(test_entry, { wf_step: "annotate" })

--- a/app/dataset/app/service/entry/service_spec.rb
+++ b/app/dataset/app/service/entry/service_spec.rb
@@ -329,6 +329,30 @@ RSpec.describe Entry::Service, database: true do
       updated_entry = repo.find!(entry.id)
       expect(updated_entry.status).to eq("in_progress")
     end
+
+    it "still allows a system caller to write status/wf_step/job_id (media processor path)" do
+      job_uuid = UUIDv7.generate
+      record = deserialize(
+        {
+          data: {
+            type: "entries",
+            id: entry.id,
+            attributes: {
+              status: "processing",
+              wf_step: "annotate",
+              job_id: job_uuid,
+            }
+          }
+        }
+      )
+
+      subject.update(record)
+
+      updated_entry = repo.find!(entry.id)
+      expect(updated_entry.status).to eq("processing")
+      expect(updated_entry.wf_step).to eq("annotate")
+      expect(updated_entry.job_id).to eq(job_uuid)
+    end
   end
 
   describe "#assign_member" do

--- a/app/dataset/app/service/entry_stats/recompute.rb
+++ b/app/dataset/app/service/entry_stats/recompute.rb
@@ -61,7 +61,7 @@ module EntryStats
 
     # Deletes all existing stats for the entry and inserts the new set in one transaction.
     def self.persist(entry_id, stats)
-      repo = EntryStat::Repository.new(nil)
+      repo = EntryStat::Repository.new(Verse::Auth::Context[:system])
       repo.transaction do
         repo.delete_by_entry_id(entry_id)
         repo.bulk_insert(entry_id, stats)

--- a/app/dataset/app/service/entry_stats/recompute_spec.rb
+++ b/app/dataset/app/service/entry_stats/recompute_spec.rb
@@ -82,6 +82,14 @@ RSpec.describe EntryStats::Recompute, database: true do
     end
   end
 
+  describe ".persist" do
+    it "constructs the repository with a real auth context, not nil" do
+      expect(EntryStat::Repository).to receive(:new).with(an_instance_of(Verse::Auth::Context)).and_call_original
+
+      described_class.persist(entry_id, { "a" => "1" })
+    end
+  end
+
   describe ".collect_plugin_stats" do
     let(:modality) { "test-collect-modality" }
     let(:dataset)  { instance_double(Dataset::Record, modality: modality) }

--- a/app/dataset/app/service/note_feed/service.rb
+++ b/app/dataset/app/service/note_feed/service.rb
@@ -81,7 +81,12 @@ module NoteFeed
 
       if attributes[:annotation_id] && attributes[:anchor_type] == "annotation"
         annotation_id = attributes[:annotation_id]
-        annotations.find!(annotation_id)
+        annotation = annotations.find!(annotation_id)
+
+        unless annotation.entry_id == attributes[:entry_id]
+          raise Verse::Error::ValidationFailed,
+                "annotation does not belong to this entry"
+        end
       else
         attributes.delete(:annotation_id)
       end

--- a/app/dataset/app/service/note_feed/service_spec.rb
+++ b/app/dataset/app/service/note_feed/service_spec.rb
@@ -109,6 +109,37 @@ RSpec.describe NoteFeed::Service, database: true do
         end
       end
 
+      context "when annotation belongs to a different entry" do
+        it "raises a validation error" do
+          other_entry_id = entry_repo.create(
+            priority: 1,
+            resource: "http://example.com/other.mp4",
+            wf_step: "review",
+            status: "in_progress",
+            assigned_to_id: 1,
+            project_id:,
+            dataset_id:
+          )
+
+          other_annotation_id = annotation_repo.create(
+            project_id:,
+            dataset_id:,
+            entry_id: other_entry_id,
+            dimensions: { "x" => 0, "y" => 0, "width" => 10, "height" => 10 },
+            annotation: { "label" => "dog" },
+            created_by_email: "user@example.com"
+          )
+
+          params = note_feed_attributes.merge(
+            anchor_type: "annotation",
+            annotation_id: other_annotation_id
+          )
+
+          expect { subject.create_from_params(params) }
+            .to raise_error(Verse::Error::ValidationFailed, /annotation/)
+        end
+      end
+
       context "when entry is not provided" do
         it "raises a not found error" do
           note_feed_attributes.delete(:entry_id)

--- a/app/dataset/app/service/project_member/permission_spec.rb
+++ b/app/dataset/app/service/project_member/permission_spec.rb
@@ -51,6 +51,16 @@ RSpec.describe ProjectMember::Service, database: true do
       invited_by_id: 1
     )
   }
+  let(:other_owner_member_id) {
+    project_member_repo.create(
+      project_id: first_project_id,
+      account_id: 6,
+      role: "project_owner",
+      name: "Other Owner",
+      email: "other_owner@example.com",
+      invited_by_id: 1
+    )
+  }
 
   let(:update_data) do
     {
@@ -144,6 +154,15 @@ RSpec.describe ProjectMember::Service, database: true do
         member = project_member_repo.find(annotator_member_id)
         expect(member.disabled_at).not_to be_nil
       end
+
+      it "can demote a project_owner in an owned org" do
+        update_data[:data][:id] = other_owner_member_id
+        update_data[:data][:attributes][:role] = "annotator"
+
+        record = subject.update(deserialize(update_data))
+
+        expect(record.role).to eq "annotator"
+      end
     end
 
     describe "with projects not in owned organization scope" do
@@ -225,6 +244,17 @@ RSpec.describe ProjectMember::Service, database: true do
         expect(record.name).to eq "Jane Doe"
         expect(record.email).to eq "janedoe@example.com"
         expect(record.role).to eq "reviewer"
+      end
+
+      it "cannot demote another project_owner" do
+        update_data[:data][:id] = other_owner_member_id
+        update_data[:data][:attributes][:role] = "annotator"
+
+        expect {
+          subject.update(deserialize(update_data))
+        }.to raise_error(Verse::Error::Unauthorized)
+
+        expect(project_member_repo.find!(other_owner_member_id).role).to eq "project_owner"
       end
 
       it "can soft delete" do

--- a/app/dataset/app/service/project_member/service.rb
+++ b/app/dataset/app/service/project_member/service.rb
@@ -66,16 +66,26 @@ module ProjectMember
       end
     end
 
+    UPDATABLE_FIELDS = %i[role name email].freeze
+
     def update(record)
       access = auth_context.can?(:update, project_members.class.resource)
-      # "project_owner" can only be added by an org_owner of the project
-      if record.attributes[:role] == "project_owner"
+      member = project_members.find!(record.id)
+
+      attributes = record.attributes.slice(*UPDATABLE_FIELDS)
+
+      # Promoting to or demoting from "project_owner" can only be done by an org_owner of the project
+      owner_role_change =
+        attributes.key?(:role) &&
+        attributes[:role] != member.role &&
+        (attributes[:role] == "project_owner" || member.role == "project_owner")
+
+      if owner_role_change
         unless [:as_org_owner, :all].include?(access)
           raise Verse::Error::Unauthorized,
                 "You do not have permission to update a member for this project"
         end
 
-        member = project_members.find!(record.id)
         project = projects.find!(member.project_id) # this can raise Verse::Error::RecordNotFound if not in org scope
 
         # Check if org_owner has access to the project's organization
@@ -85,7 +95,7 @@ module ProjectMember
         end
       end
 
-      project_members.update!(record.id, record.attributes)
+      project_members.update!(record.id, attributes)
       project_members.find!(record.id)
     end
 

--- a/app/dataset/db/migrations/20260709000000_add_indexes_on_hot_filter_columns.rb
+++ b/app/dataset/db/migrations/20260709000000_add_indexes_on_hot_filter_columns.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    add_index :annotations, :updated_at
+    add_index :note_feeds, [:project_id, :status]
+    add_index :entries, :resource
+  end
+end

--- a/app/media/app/model/medias.rb
+++ b/app/media/app/model/medias.rb
@@ -59,8 +59,6 @@ module Medias
       end
     end
 
-    # TODO: background processors also trigger this event and causing error logs on audit as there's no actor id
-    # might need to review or suppress on that
     def create(attributes)
       with_metadata do
         add_event_metadata(

--- a/app/media/app/service/jobs/base.rb
+++ b/app/media/app/service/jobs/base.rb
@@ -28,6 +28,11 @@ module Jobs
     end
 
     def emit(event, **args)
+      unless @command
+        raise "Jobs::Base#emit called before run - a job must be run with a " \
+              "block before it can emit events"
+      end
+
       @command.call(
         event, **args
       )

--- a/app/media/app/service/jobs/base_spec.rb
+++ b/app/media/app/service/jobs/base_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Jobs::Base do
+  # Minimal concrete subclass that emits an event from its run body.
+  let(:job_class) do
+    Class.new(described_class) do
+      def run_impl
+        update_progress(50)
+      end
+    end
+  end
+
+  subject { job_class.new("job-1", {}) }
+
+  describe "#emit" do
+    it "raises a clear error when called before run instead of NoMethodError on nil" do
+      expect { subject.error("boom") }
+        .to raise_error(RuntimeError, /emit called before run/)
+    end
+  end
+
+  describe "#run" do
+    it "routes emitted events to the given block" do
+      events = []
+
+      subject.run { |event, **args| events << [event, args] }
+
+      expect(events).to eq([[:update_progress, { value: 50 }]])
+    end
+  end
+end

--- a/app/media/app/service/jobs/scheduler.rb
+++ b/app/media/app/service/jobs/scheduler.rb
@@ -98,7 +98,7 @@ module Jobs
               jobs.update_progress(job.id, opts[:value])
             when :reschedule
               reschedule_in = Time.now + opts.fetch(:after, 10) # Default to 10 seconds if not provided
-              jobs.reschedule(job.id, "pending", scheduled_at: reschedule_in)
+              jobs.reschedule(job.id, scheduled_at: reschedule_in)
               throw :stop # Stop processing this job, it will be retried
             when :error
               error = opts[:error]

--- a/app/media/app/service/jobs/scheduler.rb
+++ b/app/media/app/service/jobs/scheduler.rb
@@ -142,7 +142,7 @@ module Jobs
         end
       rescue StandardError => e
         jobs.error(job.id, error: [e.class.name, e.message].join(": "))
-        raise e
+        Verse.logger&.error { "Job #{job.id} failed:\n#{e.backtrace.join("\n")}" }
       end
     end
 

--- a/app/media/app/service/jobs/scheduler_spec.rb
+++ b/app/media/app/service/jobs/scheduler_spec.rb
@@ -196,10 +196,10 @@ RSpec.describe Jobs::Scheduler do
     end
 
     context "when a job uses `reschedule` command" do
-      it "reschedules the job" do
+      it "reschedules the job (M-14: correct reschedule call signature)" do
         expect(job_repository).to receive(:lock_available).and_return([reschedule_job])
         allow(job_repository).to receive(:next_scheduled_time).and_return(nil)
-        expect(job_repository).to receive(:reschedule).with(3, "pending", scheduled_at: be_within(1).of(Time.now + 60))
+        expect(job_repository).to receive(:reschedule).with(3, scheduled_at: be_within(1).of(Time.now + 60))
         # The job should not complete, so no update_progress to 1.0
         expect(job_repository).not_to receive(:update_progress).with(3, 1.0)
 

--- a/app/media/app/service/jobs/scheduler_spec.rb
+++ b/app/media/app/service/jobs/scheduler_spec.rb
@@ -54,6 +54,15 @@ module Spec
       raise "Job failed"
     end
   end
+
+  class UnconstructableJob < Jobs::Base
+    def initialize(job_id, arguments)
+      super
+      raise "boom during construction"
+    end
+
+    def run_impl; end
+  end
 end
 
 RSpec.describe Jobs::Scheduler do
@@ -125,6 +134,20 @@ RSpec.describe Jobs::Scheduler do
       scheduled_at: Time.now,
       retry_count: 0,
       class: Spec::RetryJob
+    )
+  }
+
+  let(:unconstructable_job) {
+    double(
+      "job",
+      id: 6,
+      job_class: "Spec::UnconstructableJob",
+      arguments: {},
+      priority: 0,
+      status: "pending",
+      scheduled_at: Time.now,
+      retry_count: 0,
+      class: Spec::UnconstructableJob
     )
   }
 
@@ -281,6 +304,19 @@ RSpec.describe Jobs::Scheduler do
         sleep 0.1
         scheduler_thread = subject.instance_variable_get(:@scheduler)
         expect(scheduler_thread).to be_alive
+      end
+    end
+  end
+
+  describe "#process" do
+    context "when an error occurs outside run_impl (e.g. job construction fails)" do
+      it "records the job as errored and does not raise past process (M-10)" do
+        subject.instance_variable_set(:@thread_pool, thread_pool)
+        allow(thread_pool).to receive(:run) { |&block| block.call }
+
+        expect(job_repository).to receive(:error).with(6, error: /boom during construction/)
+
+        expect { subject.process(unconstructable_job) }.not_to raise_error
       end
     end
   end

--- a/app/media/app/service/medias/service.rb
+++ b/app/media/app/service/medias/service.rb
@@ -6,7 +6,6 @@ require "rack/mime"
 module Medias
   class Service < Verse::Service::Base
     use medias: Medias::Repository
-    use_system video_service: Video::Service
 
     def index(filter = {}, included: [], page: 1, items_per_page: 1000, sort: nil, query_count: false)
       medias.index(

--- a/app/media/app/service/processor/context.rb
+++ b/app/media/app/service/processor/context.rb
@@ -101,7 +101,7 @@ module Processor
     end
 
     def reschedule!(after: 10)
-      job.reschedule!(after:)
+      job.reschedule(after:)
     end
 
     def error!(message)

--- a/app/media/app/service/processor/context.rb
+++ b/app/media/app/service/processor/context.rb
@@ -27,7 +27,7 @@ module Processor
         # Copy the file to a temporary location:
         tempfile = Tempfile.create("idah_media_#{media.id}_", binmode: true)
 
-        tempfile.write(file.read)
+        IO.copy_stream(file, tempfile)
         tempfile.close
 
         tempfile.path

--- a/app/media/app/service/processor/context_spec.rb
+++ b/app/media/app/service/processor/context_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Processor::Context, type: :repository, database: true do
       let(:resource) { "m12-streaming-resource-#{UUIDv7.generate}" }
 
       it "copies the full content without slurping it into a String first" do
-        media_id = media_repo.create(
+        media_repo.create(
           id: UUIDv7.generate,
           resource: resource,
           key: "",

--- a/app/media/app/service/processor/context_spec.rb
+++ b/app/media/app/service/processor/context_spec.rb
@@ -58,6 +58,37 @@ RSpec.describe Processor::Context, type: :repository, database: true do
         expect { context.download_original }.to raise_error("media not found")
       end
     end
+
+    context "when streaming the object to the tempfile (M-12)" do
+      let(:resource) { "m12-streaming-resource-#{UUIDv7.generate}" }
+
+      it "copies the full content without slurping it into a String first" do
+        media_id = media_repo.create(
+          id: UUIDv7.generate,
+          resource: resource,
+          key: "",
+          filename: "file.txt",
+          size: 1024,
+          mime_type: "text/plain",
+        )
+
+        fake_source = StringIO.new("A" * 1024)
+        fake_storage = instance_double(Verse::Shrine::Manager, open: fake_source)
+        fake_plugin = instance_double(Verse::Shrine::Plugin)
+        allow(fake_plugin).to receive(:with_storage).and_yield(fake_storage)
+        allow(Verse::Plugin).to receive(:[]).and_call_original
+        allow(Verse::Plugin).to receive(:[]).with(:shrine).and_return(fake_plugin)
+
+        # IO.copy_stream reads in chunks via #read/#readpartial, never .read(nil) that
+        # would slurp the whole object into one String - verify that's what's called.
+        expect(fake_source).to receive(:read).at_least(:once).and_call_original
+
+        temp_path = context.download_original
+
+        expect(File.size(temp_path)).to eq(1024)
+        expect(File.read(temp_path)).to eq("A" * 1024)
+      end
+    end
   end
 
   describe "#upload_media" do

--- a/app/media/app/service/processor/context_spec.rb
+++ b/app/media/app/service/processor/context_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Processor::Context, type: :repository, database: true do
     Verse::Auth::Context.new
   end
 
-  let(:job) { double("job", update_progress: nil, reschedule!: nil, error: nil) }
+  let(:job) { instance_double(Jobs::Base, update_progress: nil, reschedule: nil, error: nil) }
   let(:resource) { "some-resource" }
   let(:config) { {} }
 
@@ -122,8 +122,8 @@ RSpec.describe Processor::Context, type: :repository, database: true do
       context.progress = 50
     end
 
-    it "delegates reschedule to the job" do
-      expect(job).to receive(:reschedule!).with(after: 20)
+    it "delegates reschedule to the job's reschedule command (M-17)" do
+      expect(job).to receive(:reschedule).with(after: 20)
       context.reschedule!(after: 20)
     end
 

--- a/app/media/app/service/processor/service.rb
+++ b/app/media/app/service/processor/service.rb
@@ -31,6 +31,14 @@ module Processor
         return
       end
 
+      # The registry allows a modality to register multiple processors, so
+      # this creates one job per processor. Today every modality registers
+      # exactly one (idah-image, idah-video), so the entry is linked to that
+      # single job. If a modality ever registers more than one processor,
+      # only the last job_id survives on the entry - earlier jobs still run
+      # but are not linked back. Revisit the entry->job data model (array of
+      # ids, or a composite job) before relying on multiple processors per
+      # modality.
       processor_entries.each do |processor_entry|
         job_id = jobs.create(
           job_class: "Processor::Job",
@@ -45,8 +53,7 @@ module Processor
           priority: 1,
           scheduled_at: Time.now
         )
-        # TODO: what to do with multiple job ids?
-        # Update the entry with the job_id
+        # Link the entry to this processor's job.
         Api[:idah].dataset.entries.update(
           id: entry.id,
           status: "processing",

--- a/app/media/app/service/video/service.rb
+++ b/app/media/app/service/video/service.rb
@@ -6,8 +6,6 @@ module Video
     def process(arguments)
       job_service = Jobs::Service.new(auth_context)
 
-      puts "Arguments = #{arguments.inspect}"
-
       job_service.create(
         "Video::Job",
         arguments:,

--- a/app/media/config/keys/README.md
+++ b/app/media/config/keys/README.md
@@ -6,3 +6,19 @@ The existing key is an example and should not be used in production but
 only in development and test environments.
 
 PRODUCTION KEY MUST NOT BE STORED IN THE GIT REPOSITORY
+
+## SERVICE_JWT_KEY
+
+The signing key is read from the `SERVICE_JWT_KEY` environment variable
+(see `config/initializers/set_keys.rb`). It accepts one of two forms:
+
+- A raw PEM string (the key content itself), or
+- `file:/absolute/path/to/key.pem` — the `file:` prefix is required for
+  the value to be read from a file.
+
+A bare filesystem path **without** the `file:` prefix is treated as key
+content and fails at parse time with an opaque OpenSSL error. Always
+prefix a path with `file:`.
+
+The key may be public or private: a public key can validate tokens but
+cannot forge (sign) new ones.


### PR DESCRIPTION
# Dataset + Media Code Revision

Scope: the dataset (`D-xx`) and media (`M-xx`) findings from the assigned audit
docs (`audit/03-dataset-service.md`, `audit/04-media-service.md`,
`audit/00-ASSIGNMENTS.md`). Recheck fold-ins (`R-xx`) and issues found during
implementation (`FI-xx`) are listed separately at the end — they are not part of
the assigned audit set.

---

## What have been done

Issues addressed and committed, from the dataset/media audit docs.

### Obvious Findings

| Item | Description | Type | Approach |
|------|-------------|------|-------------|
| D03 | `note_feed/service.rb` copied the annotation without checking its `entry_id` matched the feed's — a client could anchor an annotation from a different entry (cross-entry IDOR). Spec covers a mismatched `entry_id` → rejected | fix + spec | Reject a note-feed annotation whose `entry_id` doesn't match the feed's entry |
| D04 | `entry.rb` / `entry/service.rb` used `find_by!`, so a duplicate or late Redis job event on an already-transitioned entry raised. Switched to `find_by` + early return. Spec covers a repeated event | fix + spec | Make `mark_entries_status_as` idempotent so duplicate/late job events are no-ops |
| D05 | `project_member/service.rb#update` had no field whitelist (any attribute writable) and its owner-role guard only checked promotion. Added `UPDATABLE_FIELDS` `.slice` + a bidirectional `project_owner` guard. Spec both directions | fix + spec | Whitelist member-update fields; fire the owner-role guard on either direction |
| D09 | New migration `20260709000000_...`; `annotations.updated_at`, `note_feeds[project_id, status]`, `entries.resource` were unindexed. Plain indexes (not unique — dataset duplication deliberately reuses `resource`) | migration | Add indexes on hot filter columns |
| D10 | `entry_stats/recompute.rb#persist` built the repo with `Repository.new(nil)`; replaced with `Verse::Auth::Context[:system]`. Regression spec constructs the repo the way persist does | fix + spec | Use the system auth context in EntryStats persist instead of `nil` |
| D13 | `entry/service.rb#assign_member` assigned to any account with a membership row, including soft-disabled ones. Added a `disabled_at`-nil check. Spec: disabled member → rejected | fix + spec | Require an active (non-disabled) project membership to assign an entry |
| D22 | `status`/`wf_step`/`job_id` were freely PATCHable via the API (`entry.rb` / `entry/service.rb`). Guard strips them unless the caller resolves to `:all`. Not `readonly` — media legitimately PATCHes them with a system token, which `readonly` would silently drop | fix + spec | Service-layer guard stripping `status`/`wf_step`/`job_id` from non-system writes |
| D26 | `annotations_expo_spec.rb` helper posted to a wrong route and was unused; the real `"batch"` path is already covered | deletion | Drop the dead `rpc_batch_call` spec helper |
| M-10 | `jobs/scheduler.rb#process` did `raise e` after `jobs.error(...)`, re-raising into a pool that already rescues+logs — pointless. Dropped it; added explicit backtrace logging where the error is handled | fix + spec | Stop re-raising into the already-logging thread pool |
| M-11 | Bypassed the logger and leaked resource ids to stdout; service is dead until `Video::Job` (M-01) exists, so deleted rather than converted | deletion | Remove debug `puts` in `Video::Service` |
| M-12 | `processor/context.rb#download_original` did `tempfile.write(file.read)`, loading the whole remote object into a String. Switched to `IO.copy_stream(file, tempfile)` | fix + spec | Stream media download instead of slurping into memory |
| M-14 | `jobs/scheduler.rb` called `jobs.reschedule(job.id, scheduled_at:)` with a stray positional → `ArgumentError`. Fixed the signature. Had to land before M-17 | fix + spec | Fix the `reschedule` call signature in the scheduler |
| M-17 | `processor/context.rb` delegated to `job.reschedule!`, which doesn't exist; fixed to `job.reschedule(after:)`. Spec uses `instance_double` so the nonexistent method is verified against the real class | fix + spec | Fix `Context#reschedule!` delegating to a missing bang method |

### Items worked on with considerations

| Item | Description | Type | Approach |
|------|-------------|------|-------------|
| D02 | `annotation/service.rb:54-58` overwrites `project_id`/`dataset_id`/`entry_id` from the scoped entry — the *only* barrier, since the JSON:API create schema doesn't strip readonly fields. No exploit today; risk is a refactor dropping the block. Spec + load-bearing comment. **Evidence:** mutation removing the block persisted the client-supplied id | spec + comment | Regression spec pinning the annotation-create id reassignment |
| D06 | `entry.rb#select` ran its claim UPDATE under the broad read scope after a separate `status == "pending"` check, so two racers both passed and the second overwrote the first. Narrowed the UPDATE scope to `status pending AND (assigned_to_id nil OR self)`; a 0-row update returns false → raise. **Evidence:** red steal-test raised nothing pre-fix, green after | fix + spec | Atomic entry claim; loser gets a clear "already claimed" error |
| D16 | `entry.rb#assigned` and `project_member.rb#enabled` coerce with `value.to_s.downcase == "true"`, so `"1"`/`"yes"` fall to the false branch. Behavior kept (FE sends `"true"`/`"false"`); specs assert exact result sets so any coercion change is deliberate | specs | Pin the `assigned`/`enabled` filter string-coercion contract |
| D18 | `simple_review_annotation_workflow.rb:30-35` `sample_rate \|\| 1`. The skip path (`annotate → done`) was already tested at rate 0 (`service_spec.rb:562`), but the `\|\| 1` default (key absent) was not. Added a default-fallback spec + doc comment. **Evidence:** mutation `\|\| 0` landed the entry in "done" | spec + doc | Cover the untested `sample_rate` default; document 0..1 semantics |
| D23 | `dataset/service.rb:39` commented-out assignment; `datasets` has no such column (initial schema has it on projects/annotations/note_feeds/note_comments only) and `Dataset::Record` declares no such field — so it couldn't be uncommented without a migration | deletion | Remove dead `created_by_email` comment on dataset create |
| M-09 | `medias/service.rb:9` injected `Video::Service` as `video_service`, never referenced (grep: only other mention is its own spec), falsely implying uploads trigger video processing. Class untouched | deletion | Remove dead `use_system video_service` injection |
| M-16 | `jobs/base.rb#emit` routes through `@command.call`, but `@command` is set only inside `run(&block)`; emitting earlier gave `NoMethodError: undefined method 'call' for nil`. Guarded with a self-explanatory message. New `base_spec.rb`. **Evidence:** mutation removing the guard reproduced the exact NoMethodError | guard + spec | Clear error when `emit` is called before `run` |
| M-20 | `set_keys.rb` accepts raw PEM or `file:/path`; a bare path is parsed as key content → opaque OpenSSL error. The initializer is **byte-identical across all 7 services** (same md5), so documented in `config/keys/README.md` rather than diverge one copy | doc | Document `SERVICE_JWT_KEY` `file:` convention |
| M-22 | `processor/service.rb:34-55` loops a modality's processors and overwrites `entry.job_id` each iteration, so with >1 only the last links. **Evidence:** only `idah-image` and `idah-video` register, one processor each → last-wins unreachable today. Replaced the TODO with the assumption + data-model pointer | comment | Document the single-processor-per-modality `job_id` assumption |
| M-23 | `medias.rb:62-63` warned that actor-less background-processor media events cause audit error logs. The audit guard `logs_expo.rb:156` (`return unless actor_account_id`) already skips them. **Evidence:** git timeline — the guard (2026-01-22) postdates the TODO (2026-01-15) by a week | deletion | Remove the stale actor-less-media-event TODO |

---

## What to be considered

Real items left open — deferred deliberately, worth doing later.

| Item | Description | Type | Why deferred / what's needed |
|------|-------------|------|------------------------------|
| D19 | `annotations_expo.rb:38-49` (`RpcCreateSchema`, `batch_limit: 50`): `dimensions`/`annotation`/`metadata` are open `jsonb` Hashes with no size/depth limit, ×50 per batch. In-app there is no cap today | hardening | Not needed now; needs a per-field byte cap + confirmation of the ingress body limit |
| M-13 | `medias.rb:103-115` and `jobs.rb:126-164` scoped queries call `dataset.projects/project_members.index_all` — 1–2 synchronous HTTP hops to Dataset per query. Amplifies latency and couples Media availability to Dataset (Dataset down ⇒ all Media reads error) | architecture | Intended for now; measure reads/sec + p95 before choosing cache vs. denormalization |
| M-15 | `jobs.rb:116-122` — `select(Sequel.lit("min(scheduled_at)")).first[:min]` relies on Postgres naming the aggregate column `min`; works but brittle to a Sequel/PG change | cleanup | Correct today; do the explicit alias only when next editing `jobs.rb` (e.g. for M-13) |
| M-21 | `jobs_expo.rb:3` extends `Verse::Exposition::Base` directly, not `BaseExpo`; works via its own `json_api` block but won't inherit future `BaseExpo` cross-cutting config | consistency | Align when next touching the file, verifying response parity |

---

## What have been skipped

Decided not to act on — settled design decision, not a real problem, falsified,
owned elsewhere, or accepted trade-off.

### Won't-fix (verified intended / falsified / owned elsewhere)

| Item | Description | Why not |
|------|-------------|---------|
| D01 | Audit flagged that an annotator can review their own submission | Intended for solo use; per-workflow `allow_self_review` flag only if team separation is ever needed |
| D07 | Audit flagged a note-feed `:resolve` scope mismatch | Code already matches intended resolve policy; flag came from a stale doc-comment (optional 1-line doc fix) |
| D08 / M-18 | Audit claimed `page[size]` was unbounded (large-page DoS vector) | **Falsified** — framework already caps `page[size]` at 1000 (`verse-jsonapi dsl/index.rb:80-83`) |
| D11 | `entry_stats/recompute.rb:15-27` — the `rescue StandardError` around plugin stats also swallows `StatKeyConflictError` (a plugin *registration* bug), with only a log line for visibility | Log-only is sufficient; no publish/event wanted (re-raising would also drop core stats) |
| D12 | Audit flagged EntryStats' system-context use as a naming/scoping smell | Legitimate system-context use; the real underlying bug is R-01 (tracked below) |
| D14 | Audit flagged a project_member issue already resolved in code | Already fixed at `project_member.rb:67` — verify post-merge only |
| D15 | Audit flagged a per-submit read as a potential N+1/perf concern | No bulk-submit path; single indexed read per submit is negligible |
| D17 | Audit flagged unused multi-workflow scaffolding | Dead multi-workflow scaffolding; roadmap call |
| D20 | `dataset/service.rb:61-82` — `notify_dataset_completed` loops project owners and publishes one notification each on the handler thread. Publish is already async (Redis); cost is N publishes + a member query | Negligible at single-digit owner counts; a real fix needs a new batched cross-service contract |
| D21 | `project_member/service.rb:47-63` — `after_commit` calls `accounts.show` (sync IAM) to gate the email; if IAM is down the member commits but the notification is lost, no retry | Straightforward and retriggerable; the proposed job-based fix doesn't fit (dataset has no job system) |
| D24 | Audit flagged org-owner note moderation as scoped to `own` rather than org-wide | **Policy call, not a bug** — `permission_spec.rb` doc-tables document org-owner note update/delete as `own`/`own` and code matches; needs explicit product decision |
| D25 | Audit flagged `updated_at` propagation causing extra writes | Accepted write-amplification trade-off |
| M-07 | Audit flagged `use_system` on a background-job service | Intended for system-triggered background jobs |
| M-08 | Audit flagged the unused `EXECUTOR` injection | Owned by Roger's Executor consolidation — verify his change lands |
| M-19 | `config/initializers/scheduler.rb:13` — unconditional `puts ENV["PUMA_WORKERS"]` on boot, bypassing the logger | Left as-is by decision |

---

## Appendix — Recheck fold-ins and issues found during implementation

Not part of the assigned dataset/media audit set. Surfaced during our own
verification pass (`R-xx`) or while implementing the
commits above (`FI-xx`). Deferred to a follow-up.

### Recheck fold-ins (self-discovered, not in the assigned 43)

| Item | Description | Type | Summary |
|------|-------------|------|---------|
| R-01 | `scoped_query/service.rb:10-18` gates create-authorization for annotations, note feeds, entries, datasets, and members by role membership but not `disabled_at IS NULL` — a soft-removed member keeps creating records. One-line SQL fix, matches every other scope | authz gap | `ScopedQuery::Service.with_project_access?` ignores `disabled_at` |
| R-02 | `note_feed.rb:158-207` — the `:resolve` branch's two `project_members` subqueries lack the `disabled_at` check that `:read` and `:update/:delete` have; a soft-removed owner/reviewer can still resolve. Same root cause as R-01 | authz gap | Note-feed `:resolve` scope omits `disabled_at` |
| R-03 | `jobs/scheduler.rb:79-86` — `constantize(job.job_class)` + subclass check run in the run-loop *before* the thread pool's rescue; a bad `job_class` raises straight into the loop, killing the scheduler thread. The job is stranded `running` and all media processing halts until restart | reliability | Unguarded `constantize` can kill the scheduler run-loop permanently |

### Found during implementation (not audit findings)

| Item | Description | Type | Summary |
|------|-------------|------|---------|
| FI-01 | `edited_at`/`disabled_at` come back as `+0700` instead of UTC across note_feed/note_comment/project_member specs — same wall-clock digits, a 7-hour instant shift. Systemic (3 services, 2 columns) → likely global Sequel/`TZ` config. Confirm test-only vs. real write discrepancy before fixing | test / config | `Time`-typed columns round-trip in the wrong timezone |
| FI-02 | Rows created by `media_repo.create` sometimes survive into the next example. **Update:** a leaked `test_resource/test_key` row is now persistently in `idah_media_test`, so the media suite fails *deterministically* until the DB is reset. Root cause (Verse/Sequel `rollback_on_exit` gap) still unidentified | test isolation | `medias` specs leak rows across examples despite the per-example transaction |
