### PR TITLE
IDAH - Audit Logs shows resource ID instead of file name

### DIFF
--- a/app/frontend/src/lib/data/model/audit/logs/utils.ts
+++ b/app/frontend/src/lib/data/model/audit/logs/utils.ts
@@ -135,7 +135,7 @@ export function getLogResourceDetails(
     case "entries": {
       const foundEntry = entries.find((entry) => entry.id == String(resource_id));
       resource.url = `/projects/${project_id}/datasets/${dataset_id}/entries`;
-      resource.name = foundEntry?.resource;
+      resource.name = foundEntry?.name;
 
       switch (action) {
         case "deleted": {
@@ -155,7 +155,7 @@ export function getLogResourceDetails(
        * we will use the api endpoint to show the files of medias instead.
        */
       resource.url = `${mediaBasePath}/files/${resource_id}`;
-      resource.name = medias.find((media) => media.id == String(resource_id))?.filename;
+      resource.name = medias.find((media) => media.resource == String(resource_id))?.filename;
       break;
     }
     default: {

--- a/app/frontend/src/lib/data/model/media/medias/medias-record.ts
+++ b/app/frontend/src/lib/data/model/media/medias/medias-record.ts
@@ -53,8 +53,9 @@ export const mediaBackendDataSource = createBackendDataSource(MediaRecord, media
   getInfo: async (param: {
     resource: string;
     key?: string;
+    showErrorToast?: boolean;
   }): Promise<RecordResponse<MediaRecord> | JsonApiErrorResponse> => {
-    const { resource, key } = param;
+    const { resource, key, showErrorToast: shouldShowErrorToast = true } = param;
     let mediaInfoUrl = `${mediaBasePath}/info/${resource}`;
 
     if (key) {
@@ -73,7 +74,7 @@ export const mediaBackendDataSource = createBackendDataSource(MediaRecord, media
       )
       .then((body) => {
         if (body && body.errors) {
-          if (body.errors.length > 0) {
+          if (body.errors.length > 0 && shouldShowErrorToast) {
             body.errors.forEach((err: Hash<string>) => {
               showErrorToast({ title: err.title, message: err.detail, error: err });
             });

--- a/app/frontend/src/routes/(protected)/(app)/audit-logs/+page.svelte
+++ b/app/frontend/src/routes/(protected)/(app)/audit-logs/+page.svelte
@@ -210,15 +210,20 @@
             break;
           }
           case "medias": {
-            const mediasRes = await mediaBackendDataSource.list({
-              fields: {
-                [MediaRecord.type]: ["resource", "filename"],
-              },
-              filters: {
-                resource: Array.from(new Set(_ids)),
-              },
+            /**
+             * A `resource` can have multiple rows (transcoded variants, thumbnails, ...)
+             * each with an artifact-derived filename. Only the `key: ""` row is the
+             * canonical upload with the real filename, so fetch each one individually
+             * via `info` rather than a bulk `.list()`, which would return every variant.
+             */
+            const mediaResults = await Promise.allSettled(
+              Array.from(new Set(_ids)).map((id) =>
+                mediaBackendDataSource.getInfo({ resource: String(id), showErrorToast: false }),
+              ),
+            );
+            mediaResults.forEach((result) => {
+              if (result.status === "fulfilled" && "data" in result.value) medias.push(result.value.data);
             });
-            medias.push(...mediasRes.data);
             break;
           }
           default: {

--- a/app/frontend/src/routes/(protected)/(app)/audit-logs/+page.svelte
+++ b/app/frontend/src/routes/(protected)/(app)/audit-logs/+page.svelte
@@ -12,7 +12,7 @@
   import { ProjectRecord, projectsBackendDataSource } from "@/data/model/dataset/projects/project-record";
   import { AccountRecord, accountsBackendDataSource } from "@/data/model/iam/accounts/record";
   import { OrganizationRecord, organizationsBackendDataSource } from "@/data/model/iam/organizations/record";
-  import { MediaRecord } from "@/data/model/media/medias/medias-record";
+  import { mediaBackendDataSource, MediaRecord } from "@/data/model/media/medias/medias-record";
   import { Record } from "@/data/model/Record";
   import { refetches } from "@/utils/refetch";
 
@@ -122,7 +122,7 @@
         if (_ids.length === 0) return;
 
         switch (resource) {
-          case "accounts_ids": {
+          case "account_ids": {
             const accountsRes = await accountsBackendDataSource.list({
               fields: {
                 [AccountRecord.type]: ["id", "email"],
@@ -200,13 +200,25 @@
           case "entries": {
             const entriesRes = await entriesBackendDataSource.list({
               fields: {
-                [EntryRecord.type]: ["id", "resource"],
+                [EntryRecord.type]: ["id", "resource", "name"],
               },
               filters: {
                 id: Array.from(new Set(_ids)),
               },
             });
             entries.push(...entriesRes.data);
+            break;
+          }
+          case "medias": {
+            const mediasRes = await mediaBackendDataSource.list({
+              fields: {
+                [MediaRecord.type]: ["resource", "filename"],
+              },
+              filters: {
+                resource: Array.from(new Set(_ids)),
+              },
+            });
+            medias.push(...mediasRes.data);
             break;
           }
           default: {


### PR DESCRIPTION
## What
Fixed the Audit Logs page to display human-readable file names instead of raw resource IDs for entries and medias resources, matching the Entries page convention.

## Why
The Audit Logs page was displaying resource IDs instead of human-readable file names, which was inconsistent with the Entries page. Users expect to see descriptive names for better UX and easier tracking.

## How
- Updated entries case to read entry.name instead of entry.resource
- Fixed medias case to match media.resource instead of media.id
- Added missing medias fetch branch to resolve media names
- Fixed account_ids field name (was accounts_ids typo)
- Added name field to entries fetch

## Testing
Type-checked with `pnpm run check` in app/frontend (confirmed zero new errors vs. base branch — pre-existing 185 errors unrelated to these files); manually verified in browser by the user.

---
Closes CU-869e3qxyd