### PR TITLE
Audit remediation — Tier 5 (decisions + checkpoint-gated fixes)

### DIFF
--- a/app/setting/app/expo/plugins_expo.rb
+++ b/app/setting/app/expo/plugins_expo.rb
@@ -76,6 +76,10 @@ class PluginsExpo < BaseExpo
 
     return server.not_found unless io
 
+    # Explicit content type + no MIME sniffing on untrusted plugin assets.
+    renderer.content_type = PluginMimeType.for(params[:splat].last)
+    server.response.headers["X-Content-Type-Options"] = "nosniff"
+
     io
   end
 
@@ -83,19 +87,7 @@ class PluginsExpo < BaseExpo
     :get,
     ":plugin/files/:filename",
     auth: nil,
-    # renderer: Verse::Http::Renderer::Identity
-    renderer: Class.new do
-      def render(result, server)
-        case File.extname(server.request.env["verse.http.server"].params["filename"])
-        when ".js"
-          server.response["content-type"] = "text/javascript"
-        when ".css"
-          server.response["content-type"] = "text/css"
-        end
-
-        result
-      end
-    end
+    renderer: Verse::Http::Renderer::Identity
   ) do
     input do
       field :plugin, String
@@ -103,9 +95,18 @@ class PluginsExpo < BaseExpo
     end
   end
   def serve
-    service.serve_file(
+    content = service.serve_file(
       params[:plugin],
       params[:filename]
-    ) || server.not_found
+    )
+
+    return server.not_found unless content
+
+    # Content type is derived from the requested filename (not the on-disk
+    # manifest path), with sniffing disabled on untrusted plugin files.
+    server.response.headers["Content-Type"] = PluginMimeType.for(params[:filename])
+    server.response.headers["X-Content-Type-Options"] = "nosniff"
+
+    content
   end
 end

--- a/app/setting/app/expo/plugins_expo_spec.rb
+++ b/app/setting/app/expo/plugins_expo_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe PluginsExpo, type: :exposition, as: :system do
 
       expect(last_response.status).to eq(200)
       expect(last_response.body).to eq("file content")
+      expect(last_response.headers["Content-Type"]).to eq("text/javascript")
+      expect(last_response.headers["X-Content-Type-Options"]).to eq("nosniff")
     end
 
     it "returns 404 if the plugin file is not found" do
@@ -54,6 +56,8 @@ RSpec.describe PluginsExpo, type: :exposition, as: :system do
 
       expect(last_response.status).to eq(200)
       expect(last_response.body).to eq("asset content")
+      expect(last_response.headers["Content-Type"]).to eq("image/png")
+      expect(last_response.headers["X-Content-Type-Options"]).to eq("nosniff")
     end
 
     it "sanitize the path to prevent directory traversal" do

--- a/app/setting/app/service/plugins/service.rb
+++ b/app/setting/app/service/plugins/service.rb
@@ -4,6 +4,9 @@ module Plugins
   class Service < Verse::Service::Base
     use repo: Plugin::Repository
 
+    ALLOWED_ASSET_EXT = %w[.png .jpg .jpeg .gif .svg .webp .js .css .json .woff .woff2].freeze
+    MAX_ASSET_BYTES = 10 * 1024 * 1024
+
     def install(_plugin_name)
       Manager.run do
         install_plugin
@@ -45,6 +48,8 @@ module Plugins
       # (encoded/suffixed traversal, manifest-supplied `..`, symlinks, etc.).
       return nil unless asset_path.start_with?("#{root}/")
       return nil unless File.file?(asset_path)
+      return nil unless ALLOWED_ASSET_EXT.include?(File.extname(asset_path).downcase)
+      return nil if File.size(asset_path) > MAX_ASSET_BYTES
 
       File.open(asset_path, "rb")
     end

--- a/app/setting/app/util/plugin_mime_type.rb
+++ b/app/setting/app/util/plugin_mime_type.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Maps a plugin file/asset extension to a safe Content-Type. Used by the
+# plugins expo to set an explicit content type (instead of relying on MIME
+# sniffing) on both the file and asset responses.
+module PluginMimeType
+  TYPES = {
+    ".js" => "text/javascript",
+    ".css" => "text/css",
+    ".json" => "application/json",
+    ".png" => "image/png",
+    ".jpg" => "image/jpeg",
+    ".jpeg" => "image/jpeg",
+    ".gif" => "image/gif",
+    ".svg" => "image/svg+xml",
+    ".webp" => "image/webp",
+    ".woff" => "font/woff",
+    ".woff2" => "font/woff2"
+  }.freeze
+
+  DEFAULT = "application/octet-stream"
+
+  def self.for(filename)
+    TYPES.fetch(File.extname(filename.to_s).downcase, DEFAULT)
+  end
+end

--- a/app/setting/app/util/plugin_mime_type_spec.rb
+++ b/app/setting/app/util/plugin_mime_type_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe PluginMimeType do
+  describe ".for" do
+    it "maps known extensions to their content type" do
+      expect(described_class.for("plugin.js")).to eq("text/javascript")
+      expect(described_class.for("plugin.css")).to eq("text/css")
+      expect(described_class.for("config.json")).to eq("application/json")
+      expect(described_class.for("icon.svg")).to eq("image/svg+xml")
+      expect(described_class.for("logo.png")).to eq("image/png")
+      expect(described_class.for("font.woff2")).to eq("font/woff2")
+    end
+
+    it "is case-insensitive on the extension" do
+      expect(described_class.for("LOGO.PNG")).to eq("image/png")
+    end
+
+    it "falls back to octet-stream for unknown extensions" do
+      expect(described_class.for("archive.zip")).to eq("application/octet-stream")
+    end
+
+    it "falls back to octet-stream when there is no extension" do
+      expect(described_class.for("README")).to eq("application/octet-stream")
+    end
+
+    it "handles nil safely" do
+      expect(described_class.for(nil)).to eq("application/octet-stream")
+    end
+  end
+end


### PR DESCRIPTION
## Audit remediation — Tier 5 (decisions + checkpoint-gated fixes)

**Stacked on `features/CU-869e0fx5t/Setting-and-Frontend-corecriticals` (PR #519)** — base is that branch, so this diff shows only the Tier-5 work. Merge #519 first; if it squash-merges, this rebases onto `main`.

Tier 5 = the audit items that are **not** safe to land solo in #519: they either need a **decision** (architecture / cross-team policy) or a **runtime checkpoint** we can't run in the worktree. This PR splits them:

- **Part A — committed fixes** that only need review + the integration checkpoint.
- **Part B — decisions for you** (senior): each has options + a recommendation. Please rule "do it / don't / owner"; I'll implement the approved ones.

---

## Part A — Committed fixes (review + checkpoint)

### ✅ S-06 + S-17 — hardened plugin asset/file serving *(committed here)*
- New tested `PluginMimeType` helper (ext → safe Content-Type).
- `serve_asset`: extension allowlist + 10 MB cap; explicit Content-Type + `X-Content-Type-Options: nosniff`.
- `serve`: removed the untestable anonymous `Class.new` renderer → `Identity` + headers set in the action (S-17).
- ⚠️ **Checkpoint required:** the setting bundle isn't installed in the worktree, so the exposition-spec header assertions are **unrun**. Please run `bundle exec rspec app/setting/app/expo/plugins_expo_spec.rb app/setting/app/util/plugin_mime_type_spec.rb` and confirm the header wiring (`renderer.content_type=` for the Binary asset path; `server.response.headers[...]` for the Identity file path).
- Residual: SVG stays allowlisted (plugins use `icon.svg`); SVG-direct-navigation XSS belongs to the strategic off-origin item below.

### ⏸️ S-15 — shared `PluginCatalog` (not yet committed)
Extract the per-request `Dir.glob` (duplicated in `Plugins::Service#find` and `Plugin::Record#path`) into one memoised catalogue. Ready to implement, but it's a hot-path backend refactor that also wants the checkpoint — say the word and I'll add it to this PR.

---

## Part B — Decisions for you

| # | Item | The decision | Recommendation | Owner |
|---|------|--------------|----------------|-------|
| 1 | **S-09 + S-21** — broken `Plugins::Manager` / undefined `install_plugin` | Delete the dead half-built plugin-install subsystem, or finish it? | **Delete** (small, reversible; re-introduce as a designed feature if needed) | Setting |
| 2 | **S-10** — dead `SettingsExpo` `/settings` route | Remove the live-but-empty surface, or build the feature? | **Remove registration** now; design system-vs-org-vs-user scope + admin auth later | Setting |
| 3 | **S-11** — `PluginLifecycleContext` no-op | Does the Setting service host plugin backends at all? Document the no-op as intentional, or implement mount/unmount? | **Document as intentional** (Setting only serves files/catalogue) unless backends are planned | Setting + platform |
| 4 | **S-07** — plugin loader trusts on-disk manifest → RCE | Plugin trust model. Loader lives in `common/` (inherited by media/sync). | **Allowlist + read-only plugin dir** now (Setting can land an allowlist gate solo); signed manifests as strategic | Roger / `common` |
| 5 | **S-03** — plugin endpoints are `auth: nil` | Keep file/asset serving anonymous (public CDN-style) but gate `modalities`/`show_modality`? | **Gate the catalogue endpoints**; keep file/asset anonymous only if FE-015 owner confirms the `<script src>` load can't attach auth | Setting + FE |
| 6 | **S-05** — `create/delete` trust event-payload `account_id` | Does the event bus authenticate publishers? A forged `iam:accounts:deleted` wipes a user's settings. | Interim: **log + narrow the destructive handler** (solo); real fix = publisher verification at the bus | Roger / infra |
| 7 | **FE-016** — `Record` `[key:string]: any` | Remove the type-safety escape hatch. | **Milestoned follow-up PR** — measured at **44 new type errors / ~20 files**, incl. missing-field-declaration decisions (not a mechanical swap) | Frontend |
| 8 | **FE-006** — auth module singletons | Migrate to SvelteKit `locals`/session? | **Document as known constraint; don't rewrite** speculatively | Frontend |
| 9 | **FE-011 (batch)** — client `Promise.all` stopgap | Build a server bulk endpoint? | Track as backend follow-up; client parallelisation already shipped in #519 | Dataset backend |

### Notes
- Items 4/5 (S-07/S-05) and the `common/` loader are the cross-service ones — likely Roger's call.
- Item 3 (S-11) and item 4 interact: whether Setting hosts backends affects the plugin trust model.
- For any "do it" ruling, the interim/solo portion can land in this PR; the platform portions get their own tickets.

Source: `marc-audit-findings.md`. Full remediation history + the S-06/S-17 blueprint are in PR #519.

Refs: CU-869e0fx5t
