### PR TITLE
Page freezes after deleting a configuration in label editor

### DIFF
--- a/app/frontend/src/lib/components/app/datasets/labels/label-config-editor.svelte
+++ b/app/frontend/src/lib/components/app/datasets/labels/label-config-editor.svelte
@@ -106,7 +106,6 @@
       shapeDrag.end();
     },
   };
-  let labelConfigIsEmpty: boolean = $derived(Object.keys(labelConfig).length === 0);
   let hasAtLeastOneCategory: boolean = $derived(selectedLabelConfig ? selectedLabelConfig.values.length > 0 : false);
   let hasAtLeastOneProperty: boolean = $derived(
     selectedLabelConfig ? selectedLabelConfig.properties.length > 0 : false,
@@ -203,8 +202,6 @@
   function removeLabelConfig(key: string) {
     if (controller.selectedConfigKey === key) {
       controller.selectedConfigKey = controller.getOrderedConfigKeys().find((k) => k !== key) || "";
-    } else {
-      controller.selectedConfigKey = "";
     }
 
     controller.removeLabelConfig(key);
@@ -389,7 +386,7 @@
       </CardHeader>
 
       <CardContent>
-        {#if !labelConfigIsEmpty}
+        {#if selectedLabelConfig}
           <CategoryTree
             values={selectedLabelConfig.values}
             onAddCategory={addCategory}
@@ -426,7 +423,7 @@
       </CardHeader>
 
       <CardContent class="flex flex-col gap-2">
-        {#if !labelConfigIsEmpty}
+        {#if selectedLabelConfig}
           {#each Object.values(selectedLabelConfig.properties) as property (property.id)}
             <PropertyCard {property} onSetProperty={setProperty} onRemoveProperty={removeProperty} />
           {:else}


### PR DESCRIPTION
…figuration

Deleting a non-selected label configuration incorrectly cleared the selected config key, causing a null dereference crash that froze the page. The fix only reassigns the selection when the deleted config was the one selected.

Removed the now-dead labelConfigIsEmpty derived check and hardened render guards to check the actual selectedLabelConfig instead of a whole-config-empty condition.

Refs: CU-869e5vc8p