### PR TITLE
Audit Logs page fails with 500 error

### DIFF
--- a/app/frontend/src/routes/(protected)/(app)/audit-logs/+page.svelte
+++ b/app/frontend/src/routes/(protected)/(app)/audit-logs/+page.svelte
@@ -41,7 +41,7 @@
         [AccountRecord.type]: ["name", "email", "pciture_url"],
       },
       filters: {
-        actor_account_id__in: actorAccountIds,
+        id__in: actorAccountIds,
       },
     });
     accounts.push(...accountsRes.data);
@@ -72,7 +72,6 @@
               break;
           }
 
-          ids["account_ids"].push(log.resource_id);
           break;
         }
         case "account_sessions":

--- a/app/iam/app/expo/accounts_expo.rb
+++ b/app/iam/app/expo/accounts_expo.rb
@@ -12,8 +12,10 @@ class AccountsExpo < BaseExpo
 
   json_api Account::Record do
     index do
-      allowed_filters :name__match,
+      allowed_filters :id__in,
+                      :name__match,
                       :email,
+                      :email__in,
                       :email__match,
                       :enabled,
                       :role_name__in,


### PR DESCRIPTION
## Summary
- Filter accounts by `id` instead of the nonexistent `actor_account_id` in the Audit Logs page's account lookup
- Allow `id__in` and `email__in` in AccountsExpo's allowed_filters
- Remove dead/buggy code that leaked a failed-login-attempt's email string into an `id__in` filter, causing a 500

Refs: CU-869e6nm00 (https://app.clickup.com/t/9003136936/869e6nm00)

## Test plan
- [ ] Load the Audit Logs page and confirm it no longer 500s
- [ ] Confirm failed login attempt log rows render correctly (actor resolved by email)
- [ ] Confirm normal account action log rows (created/updated/deleted) still resolve account names correctly