### PR TITLE
Deleting the only keyframe of an annotation doesn't remove the annotation

### DIFF
--- a/plugins/idah-video/frontend/src/lib/commands/annotation/keyframe_delete.ts
+++ b/plugins/idah-video/frontend/src/lib/commands/annotation/keyframe_delete.ts
@@ -77,13 +77,26 @@ export function register(driver: IIdahDriverV2): void {
       if (idx === -1) return noopAction(command);
 
       const snapshot: AnnotationItem = { ...record, shape: { ...record.shape, frames: [...frames] } };
+      // Removing the last remaining keyframe must delete the whole annotation —
+      // an annotation with zero keyframes is invalid and must never persist.
+      const isLastKeyframe = frames.length === 1;
 
       return {
         command: { ...command },
         async do() {
+          if (isLastKeyframe) {
+            // Deselect first if this annotation is the current selection, then delete it.
+            if (selection.isAnnotationSelected(annotationId!)) {
+              selection.deselect();
+            }
+            await data.annotations!.delete(annotationId!);
+            viewport.video.currentFrame.value = frame;
+            return;
+          }
+
           const newFrames = frames.filter((f) => f.frame !== frame);
-          const min = newFrames.length > 0 ? newFrames.reduce((m, f) => Math.min(m, f.frame), Infinity) : 0;
-          const max = newFrames.length > 0 ? newFrames.reduce((m, f) => Math.max(m, f.frame), -Infinity) : 0;
+          const min = newFrames.reduce((m, f) => Math.min(m, f.frame), Infinity);
+          const max = newFrames.reduce((m, f) => Math.max(m, f.frame), -Infinity);
 
           await data.annotations!.update({
             ...snapshot,
@@ -93,7 +106,12 @@ export function register(driver: IIdahDriverV2): void {
         },
         async undo() {
           if (!data.annotations) return;
-          await data.annotations.update(snapshot);
+          if (isLastKeyframe) {
+            // Recreate the annotation that `do()` deleted (mirrors annotation.delete's undo).
+            await data.annotations.create({ ...snapshot, id: snapshot.id });
+          } else {
+            await data.annotations.update(snapshot);
+          }
           viewport.video.currentFrame.value = frame;
         },
         isCombinable() {

--- a/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackBlockContextMenu.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Timeline/annotations/_TrackBlockContextMenu.svelte
@@ -31,6 +31,9 @@
   let { trackId, startRange, endRange, rawData } = $derived(item);
   let frame = $derived(currentFrame ?? viewport.video.currentFrame.value);
   let isKeyframe = $derived(rawData.shape.frames.some((f: {frame: number, x?: number, y?: number}) => f.frame === frame));
+  // When this is the annotation's only keyframe, deleting it would empty the annotation.
+  // Hide the "Delete keyframe" action and steer the user to "Delete annotation" instead.
+  let isLastKeyframe = $derived(isKeyframe && rawData.shape.frames.length <= 1);
   let annotationIsLocked = $derived(annotation.isLocked(rawData));
 
   let menus = $derived<Menus>({
@@ -49,7 +52,9 @@
     },
     edit: {
       items: {
-        ...(isKeyframe
+        ...(isLastKeyframe
+          ? {}
+          : isKeyframe
           ? {
               deleteKeyframe: {
                 label: `Delete keyframe`,


### PR DESCRIPTION
## What
Deleting the only keyframe of a video annotation now removes the whole annotation instead of leaving an invalid zero-keyframe annotation in the timeline.

## Why
An annotation with zero keyframes is invalid and should not exist. Previously it lingered in the timeline, hurting data quality and downstream review/export.

## How
- `keyframe_delete` command: when the last keyframe is removed, it now deletes the whole annotation (undo recreates it), reusing the same primitives as `annotation.delete`, instead of writing back an empty shape.
- Timeline context menu (`_TrackBlockContextMenu.svelte`): hides the "Delete keyframe" action for single-keyframe annotations, steering users to "Delete annotation".

## Testing
- `npm run check` → 0 errors
- `npm test` → 277 passed
- Manual: single-keyframe delete via context menu and via Ctrl+Delete removes the whole annotation; undo restores it; deleting a non-last keyframe on a multi-keyframe annotation is unaffected.

---
Closes CU-869e8azzy
