### PR TITLE
IDAH Update Delete Confirmation Dialogs

### DIFF
--- a/app/frontend/eslint.config.js
+++ b/app/frontend/eslint.config.js
@@ -38,6 +38,27 @@ export default defineConfig(
           ignoreLinks: true,
         },
       ],
+      // <ConfirmModal /> is rendered exactly once, from src/routes/+layout.svelte (see the
+      // override below). Everything else asks through the service.
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["**/overlays/modals/confirm-modal.svelte"],
+              message:
+                "Do not render <ConfirmModal /> yourself — it is mounted once in src/routes/+layout.svelte. Use showConfirmModal() from @/components/app/overlays/modals/confirm-modal.service.svelte instead.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // The single legitimate mount point, plus the component's own test.
+    files: ["src/routes/+layout.svelte", "**/confirm-modal.svelte.test.ts"],
+    rules: {
+      "no-restricted-imports": "off",
     },
   },
   {

--- a/app/frontend/src/lib/components/app/datasets/dropdowns/project-dataset-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/dropdowns/project-dataset-dropdown-menu.svelte
@@ -4,8 +4,8 @@
   import { CopyIcon, DownloadIcon, SquarePenIcon, Trash2Icon } from "@lucide/svelte";
   import { onMount } from "svelte";
 
-  import DatasetFormModal from "@/components/app/datasets/overlays/dataset-form-modal.svelte";
   import DatasetDuplicateModal from "@/components/app/datasets/overlays/dataset-duplicate-modal.svelte";
+  import DatasetFormModal from "@/components/app/datasets/overlays/dataset-form-modal.svelte";
   import DropdownMenus from "@/components/app/dropdown-menus/dropdown-menus.svelte";
   import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
   import ExportFormModal from "@/components/app/projects/exports/overlays/export-form-modal.svelte";
@@ -17,8 +17,8 @@
   import { refetches } from "@/utils/refetch";
 
   import type { DropdownMenuContentAlignment, IDropdownMenus } from "@/components/app/dropdown-menus/types";
-  import type { ProjectMemberScope } from "@/security/types";
   import { entriesBackendDataSource, EntryRecord } from "@/data/model/dataset/entries/record";
+  import type { ProjectMemberScope } from "@/security/types";
 
   // Props
   interface Props {
@@ -184,7 +184,7 @@
 
   <ConfirmModal
     title="Delete Dataset"
-    description="Are you sure you want to delete this dataset?"
+    description={`Are you sure you want to delete this "${datasetRecord?.name}" dataset? This action cannot be undone.`}
     onConfirm={deleteDataset}
     bind:open={openConfirmDeleteDatasetModal}
   />

--- a/app/frontend/src/lib/components/app/datasets/dropdowns/project-dataset-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/dropdowns/project-dataset-dropdown-menu.svelte
@@ -7,9 +7,10 @@
   import DatasetDuplicateModal from "@/components/app/datasets/overlays/dataset-duplicate-modal.svelte";
   import DatasetFormModal from "@/components/app/datasets/overlays/dataset-form-modal.svelte";
   import DropdownMenus from "@/components/app/dropdown-menus/dropdown-menus.svelte";
-  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
   import ExportFormModal from "@/components/app/projects/exports/overlays/export-form-modal.svelte";
 
+  import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+  import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { DatasetRecord, datasetsBackendDataSource } from "@/data/model/dataset/dataset-record";
   import { ProjectRecord } from "@/data/model/dataset/projects/project-record";
@@ -75,9 +76,7 @@
           icon: Trash2Icon,
           destructive: true,
           hidden: !canDeleteDataset,
-          action: () => {
-            openConfirmDeleteDatasetModal = true;
-          },
+          action: confirmDeleteDataset,
         },
       ],
     },
@@ -87,7 +86,6 @@
   let datasetEntryRecords: EntryRecord[] = $state([]);
   let openEditDatasetFormModal: boolean = $state(false);
   let openDuplicateDatasetFormModal: boolean = $state(false);
-  let openConfirmDeleteDatasetModal: boolean = $state(false);
   let openExportFormModal: boolean = $state(false);
 
   // Lifecycle
@@ -128,22 +126,32 @@
     });
   }
 
-  async function deleteDataset(): Promise<void> {
-    try {
-      await datasetsBackendDataSource.delete(datasetId, { showErrorToast: false });
-      openConfirmDeleteDatasetModal = false;
-      $refetches.datasets.list = new Date();
-      goto(resolve(`/projects/${projectId}/datasets`));
-      showToast.success({
-        title: "Dataset deleted",
-        description: `The dataset "${datasetRecord?.name}" has been deleted.`,
-      });
-    } catch (error) {
-      showToast.error({
-        title: "Unable to delete dataset",
-        description: error?.errors[0]?.detail || "The action could not be completed, please try again later.",
-      });
-    }
+  async function confirmDeleteDataset(): Promise<void> {
+    const choice = await showConfirmModal({
+      title: "Delete Dataset",
+      description: `Are you sure you want to delete this dataset "${datasetRecord?.name}"? This action cannot be undone.`,
+      onConfirm: async () => {
+        try {
+          await datasetsBackendDataSource.delete(datasetId, { showErrorToast: false });
+
+          $refetches.datasets.list = new Date();
+          showToast.success({
+            title: "Dataset deleted",
+            description: `The dataset "${datasetRecord?.name}" has been deleted.`,
+          });
+        } catch (error) {
+          showToast.error({
+            title: "Unable to delete dataset",
+            description: error?.errors[0]?.detail || "The action could not be completed, please try again later.",
+          });
+          return ConfirmModalResult.KeepOpen;
+        }
+      },
+    });
+    if (choice === ConfirmModalChoice.Cancel) return;
+
+    // Navigating inside `onConfirm` would run while the modal is still open.
+    goto(resolve(`/projects/${projectId}/datasets`));
   }
 
   async function fetchDatasetEntries() {
@@ -180,12 +188,5 @@
     action="create"
     datasetRecords={datasetRecord ? [datasetRecord] : []}
     bind:open={openExportFormModal}
-  />
-
-  <ConfirmModal
-    title="Delete Dataset"
-    description={`Are you sure you want to delete this dataset "${datasetRecord?.name}"? This action cannot be undone.`}
-    onConfirm={deleteDataset}
-    bind:open={openConfirmDeleteDatasetModal}
   />
 {/if}

--- a/app/frontend/src/lib/components/app/datasets/dropdowns/project-dataset-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/dropdowns/project-dataset-dropdown-menu.svelte
@@ -184,7 +184,7 @@
 
   <ConfirmModal
     title="Delete Dataset"
-    description={`Are you sure you want to delete this "${datasetRecord?.name}" dataset? This action cannot be undone.`}
+    description={`Are you sure you want to delete this project "${datasetRecord?.name}" dataset? This action cannot be undone.`}
     onConfirm={deleteDataset}
     bind:open={openConfirmDeleteDatasetModal}
   />

--- a/app/frontend/src/lib/components/app/datasets/dropdowns/project-dataset-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/dropdowns/project-dataset-dropdown-menu.svelte
@@ -184,7 +184,7 @@
 
   <ConfirmModal
     title="Delete Dataset"
-    description={`Are you sure you want to delete this dataset "${datasetRecord?.name}" dataset? This action cannot be undone.`}
+    description={`Are you sure you want to delete this dataset "${datasetRecord?.name}"? This action cannot be undone.`}
     onConfirm={deleteDataset}
     bind:open={openConfirmDeleteDatasetModal}
   />

--- a/app/frontend/src/lib/components/app/datasets/dropdowns/project-dataset-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/dropdowns/project-dataset-dropdown-menu.svelte
@@ -184,7 +184,7 @@
 
   <ConfirmModal
     title="Delete Dataset"
-    description={`Are you sure you want to delete this project "${datasetRecord?.name}" dataset? This action cannot be undone.`}
+    description={`Are you sure you want to delete this dataset "${datasetRecord?.name}" dataset? This action cannot be undone.`}
     onConfirm={deleteDataset}
     bind:open={openConfirmDeleteDatasetModal}
   />

--- a/app/frontend/src/lib/components/app/datasets/dropdowns/project-dataset-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/dropdowns/project-dataset-dropdown-menu.svelte
@@ -10,7 +10,7 @@
   import ExportFormModal from "@/components/app/projects/exports/overlays/export-form-modal.svelte";
 
   import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
-  import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+  import { ConfirmModalChoice, confirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { DatasetRecord, datasetsBackendDataSource } from "@/data/model/dataset/dataset-record";
   import { ProjectRecord } from "@/data/model/dataset/projects/project-record";
@@ -144,7 +144,7 @@
             title: "Unable to delete dataset",
             description: error?.errors[0]?.detail || "The action could not be completed, please try again later.",
           });
-          return ConfirmModalResult.KeepOpen;
+          return confirmModalResult.KeepOpen;
         }
       },
     });

--- a/app/frontend/src/lib/components/app/datasets/dropdowns/selected-datasets-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/dropdowns/selected-datasets-dropdown-menu.svelte
@@ -117,7 +117,9 @@
 
   <ConfirmModal
     title="Delete Datasets"
-    description="Are you sure you want to delete dataset {selectedDatasetsCount} dataset{selectedDatasetsCount > 1 ? 's' : ''}?"
+    description="Are you sure you want to delete dataset {selectedDatasetsCount} dataset{selectedDatasetsCount > 1
+      ? 's'
+      : ''}?"
     onConfirm={deleteDatasets}
     bind:open={openConfirmDeleteDatasetsModal}
   >

--- a/app/frontend/src/lib/components/app/datasets/dropdowns/selected-datasets-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/dropdowns/selected-datasets-dropdown-menu.svelte
@@ -11,7 +11,7 @@
 
   import { selectedDatasets } from "@/components/app/datasets/stores";
   import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
-  import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+  import { ConfirmModalChoice, confirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { datasetsBackendDataSource } from "@/data/model/dataset/dataset-record";
   import { authStatus } from "@/security/AuthContext";
@@ -94,7 +94,7 @@
           });
         } catch (error) {
           showActionFailedToast(error);
-          return ConfirmModalResult.KeepOpen;
+          return confirmModalResult.KeepOpen;
         }
       },
     });

--- a/app/frontend/src/lib/components/app/datasets/dropdowns/selected-datasets-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/dropdowns/selected-datasets-dropdown-menu.svelte
@@ -117,7 +117,7 @@
 
   <ConfirmModal
     title="Delete Datasets"
-    description="Are you sure you want to delete {selectedDatasetsCount} dataset{selectedDatasetsCount > 1 ? 's' : ''}?"
+    description="Are you sure you want to delete dataset {selectedDatasetsCount} dataset{selectedDatasetsCount > 1 ? 's' : ''}?"
     onConfirm={deleteDatasets}
     bind:open={openConfirmDeleteDatasetsModal}
   >

--- a/app/frontend/src/lib/components/app/datasets/dropdowns/selected-datasets-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/dropdowns/selected-datasets-dropdown-menu.svelte
@@ -6,16 +6,18 @@
   import { onMount } from "svelte";
 
   import DropdownMenus from "@/components/app/dropdown-menus/dropdown-menus.svelte";
-  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
   import ExportFormModal from "@/components/app/projects/exports/overlays/export-form-modal.svelte";
   import Button from "@/components/ui/button/button.svelte";
 
   import { selectedDatasets } from "@/components/app/datasets/stores";
+  import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+  import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { datasetsBackendDataSource } from "@/data/model/dataset/dataset-record";
   import { authStatus } from "@/security/AuthContext";
   import { showActionFailedToast } from "@/utils/error/error.toasts";
   import { refetches } from "@/utils/refetch";
+  import { pluralizeUnit } from "@/utils/unit";
 
   import type { IDropdownMenus } from "@/components/app/dropdown-menus/types";
   import type { ProjectMemberScope } from "@/security/types";
@@ -23,11 +25,9 @@
   // Variables
   let projectId = page.params.projectId as string;
   let selectedDatasetsCount = $derived($selectedDatasets.length);
-  let deleting = $state(false);
   let canExportDataset = $state(false);
   let canDeleteDataset = $state(false);
   let openExportFormModal = $state<boolean>(false);
-  let openConfirmDeleteDatasetsModal = $state<boolean>(false);
   let menus: IDropdownMenus = $derived({
     actions: {
       items: [
@@ -44,9 +44,7 @@
           icon: Trash2Icon,
           destructive: true,
           hidden: !canDeleteDataset,
-          action: () => {
-            openConfirmDeleteDatasetsModal = true;
-          },
+          action: confirmDeleteDatasets,
         },
       ],
     },
@@ -72,28 +70,38 @@
       (await $authStatus.authContext?.can("create", "sync:exports", ["as_org_owner", as_project_owner])) || false;
   }
 
-  async function deleteDatasets() {
-    deleting = true;
+  async function confirmDeleteDatasets(): Promise<void> {
+    // Captured before the mutation: clearing $selectedDatasets resets selectedDatasetsCount to 0.
+    const count = selectedDatasetsCount;
 
-    try {
-      await Promise.all(
-        $selectedDatasets.map(async (dataset) => {
-          await datasetsBackendDataSource.delete(dataset.id);
-        }),
-      );
+    const choice = await showConfirmModal({
+      title: "Delete Datasets",
+      description: `Are you sure you want to delete ${count} ${pluralizeUnit(count, "dataset")}? This action cannot be undone.`,
+      confirmLabel: "Yes, Delete",
+      onConfirm: async () => {
+        try {
+          await Promise.all(
+            $selectedDatasets.map(async (dataset) => {
+              await datasetsBackendDataSource.delete(dataset.id);
+            }),
+          );
 
-      $refetches.datasets.list = new Date();
-      openConfirmDeleteDatasetsModal = false;
-      $selectedDatasets = [];
-      goto(resolve(`/projects/${projectId}/datasets`));
-      showToast.success({
-        title: "Datasets deleted",
-        description: `The ${selectedDatasetsCount} dataset${selectedDatasetsCount > 1 ? "s" : ""} have been deleted.`,
-      });
-    } catch (error) {
-      showActionFailedToast(error);
-      deleting = false;
-    }
+          $refetches.datasets.list = new Date();
+          $selectedDatasets = [];
+          showToast.success({
+            title: "Datasets deleted",
+            description: `The ${count} ${pluralizeUnit(count, "dataset")} have been deleted.`,
+          });
+        } catch (error) {
+          showActionFailedToast(error);
+          return ConfirmModalResult.KeepOpen;
+        }
+      },
+    });
+    if (choice === ConfirmModalChoice.Cancel) return;
+
+    // Navigating inside `onConfirm` would run while the modal is still open.
+    goto(resolve(`/projects/${projectId}/datasets`));
   }
 </script>
 
@@ -114,17 +122,4 @@
     datasetRecords={$selectedDatasets}
     bind:open={openExportFormModal}
   />
-
-  <ConfirmModal
-    title="Delete Datasets"
-    description="Are you sure you want to delete dataset {selectedDatasetsCount} dataset{selectedDatasetsCount > 1
-      ? 's'
-      : ''}?"
-    onConfirm={deleteDatasets}
-    bind:open={openConfirmDeleteDatasetsModal}
-  >
-    {#snippet confirm()}
-      <Button variant="destructive" loading={deleting} onclick={deleteDatasets}>Yes, Delete</Button>
-    {/snippet}
-  </ConfirmModal>
 {/if}

--- a/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
@@ -7,11 +7,11 @@
   import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
   import Button from "@/components/ui/button/button.svelte";
   import {
-      DropdownMenu,
-      DropdownMenuContent,
-      DropdownMenuGroup,
-      DropdownMenuItem,
-      DropdownMenuTrigger,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuGroup,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
   } from "@/components/ui/dropdown-menu";
 
   import { getEntryDropdownMenuActions } from "@/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu";

--- a/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
@@ -177,7 +177,7 @@
   <!-- MODAL::CONFIRM DELETE -->
   <ConfirmModal
     title="Delete entry"
-    description={`Are you sure you want to delete this entry "${entry.name || entry.id}" entry? This action cannot be undone.`}
+    description={`Are you sure you want to delete this entry "${entry.name || entry.id}"? This action cannot be undone.`}
     onConfirm={deleteEntry}
     bind:open={openConfirmDeleteEntryModal}
   />

--- a/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
@@ -7,11 +7,11 @@
   import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
   import Button from "@/components/ui/button/button.svelte";
   import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuGroup,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
+      DropdownMenu,
+      DropdownMenuContent,
+      DropdownMenuGroup,
+      DropdownMenuItem,
+      DropdownMenuTrigger,
   } from "@/components/ui/dropdown-menu";
 
   import { getEntryDropdownMenuActions } from "@/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu";
@@ -177,7 +177,7 @@
   <!-- MODAL::CONFIRM DELETE -->
   <ConfirmModal
     title="Delete entry"
-    description={`Are you sure you want to delete this "${entry.name || entry.id}" entry? This action cannot be undone.`}
+    description={`Are you sure you want to delete this entry "${entry.name || entry.id}" entry? This action cannot be undone.`}
     onConfirm={deleteEntry}
     bind:open={openConfirmDeleteEntryModal}
   />

--- a/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
@@ -176,7 +176,7 @@
 
   <!-- MODAL::CONFIRM DELETE -->
   <ConfirmModal
-    title="Delete entry"
+    title="Delete Entry"
     description={`Are you sure you want to delete this entry "${entry.name || entry.id}"? This action cannot be undone.`}
     onConfirm={deleteEntry}
     bind:open={openConfirmDeleteEntryModal}

--- a/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
@@ -15,7 +15,7 @@
 
   import { getEntryDropdownMenuActions } from "@/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu";
   import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
-  import { ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+  import { confirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { entriesBackendDataSource, EntryRecord } from "@/data/model/dataset/entries/record";
   import { authStatus } from "@/security/AuthContext";
@@ -97,7 +97,7 @@
             title: "Unable to unassign entry",
             description: error?.errors[0]?.detail || "The action could not be completed, please try again later.",
           });
-          return ConfirmModalResult.KeepOpen;
+          return confirmModalResult.KeepOpen;
         }
       },
     });
@@ -121,7 +121,7 @@
             title: "Unable to delete entry",
             description: error?.errors[0]?.detail || "The action could not be completed, please try again later.",
           });
-          return ConfirmModalResult.KeepOpen;
+          return confirmModalResult.KeepOpen;
         }
       },
     });

--- a/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
@@ -7,11 +7,11 @@
   import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
   import Button from "@/components/ui/button/button.svelte";
   import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuGroup,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
+      DropdownMenu,
+      DropdownMenuContent,
+      DropdownMenuGroup,
+      DropdownMenuItem,
+      DropdownMenuTrigger,
   } from "@/components/ui/dropdown-menu";
 
   import { getEntryDropdownMenuActions } from "@/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu";
@@ -177,7 +177,7 @@
   <!-- MODAL::CONFIRM DELETE -->
   <ConfirmModal
     title="Delete entry"
-    description="Are you sure you want to delete this entry? This action cannot be undone."
+    description={`Are you sure you want to delete this "${entry.name || entry.id}" entry? This action cannot be undone.`}
     onConfirm={deleteEntry}
     bind:open={openConfirmDeleteEntryModal}
   />

--- a/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu.svelte
@@ -4,7 +4,6 @@
   import { onMount } from "svelte";
 
   import AssignEntryFormModal from "@/components/app/datasets/entries/overlays/_AssignEntryFormModal.svelte";
-  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
   import Button from "@/components/ui/button/button.svelte";
   import {
     DropdownMenu,
@@ -15,6 +14,8 @@
   } from "@/components/ui/dropdown-menu";
 
   import { getEntryDropdownMenuActions } from "@/components/app/datasets/entries/dropdown-menus/entry-dropdown-menu";
+  import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+  import { ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { entriesBackendDataSource, EntryRecord } from "@/data/model/dataset/entries/record";
   import { authStatus } from "@/security/AuthContext";
@@ -38,13 +39,9 @@
   let menus = $derived(
     getEntryDropdownMenuActions({
       onAssign: openAssignEntryModal,
-      onUnassign: () => {
-        openConfirmUnassignEntryModal = true;
-      },
+      onUnassign: confirmUnAssignEntry,
       onSetPriority: () => {},
-      onDelete: () => {
-        openConfirmDeleteEntryModal = true;
-      },
+      onDelete: confirmDeleteEntry,
       isAssigned: !!entry.assigned_to_id,
       isAssignDisabled: entry.wf_step === "done",
       isUnassignDisabled: entry.wf_step === "done",
@@ -55,8 +52,6 @@
   let canUpdateEntry = $state(false);
   let canDeleteEntry = $state(false);
   let openAssignEntryFormModal: boolean = $state(false);
-  let openConfirmUnassignEntryModal: boolean = $state(false);
-  let openConfirmDeleteEntryModal: boolean = $state(false);
 
   // Lifecycle
   onMount(async () => {
@@ -83,41 +78,53 @@
     openAssignEntryFormModal = true;
   }
 
-  async function unAssignEntry(): Promise<void> {
-    try {
-      const entryRes = await entriesBackendDataSource.unassign(entry.id);
+  async function confirmUnAssignEntry(): Promise<void> {
+    await showConfirmModal({
+      title: "Unassign entry",
+      description: "Are you sure you want to unassign this entry?",
+      onConfirm: async () => {
+        try {
+          const entryRes = await entriesBackendDataSource.unassign(entry.id);
 
-      onUnAssigned?.(entryRes.data);
+          onUnAssigned?.(entryRes.data);
 
-      openConfirmUnassignEntryModal = false;
-      showToast.success({
-        title: "Entry unassigned",
-        description: `The entry "${entry.name || entry.id}" has been unassigned.`,
-      });
-    } catch (error) {
-      showToast.error({
-        title: "Unable to unassign entry",
-        description: error?.errors[0]?.detail || "The action could not be completed, please try again later.",
-      });
-    }
+          showToast.success({
+            title: "Entry unassigned",
+            description: `The entry "${entry.name || entry.id}" has been unassigned.`,
+          });
+        } catch (error) {
+          showToast.error({
+            title: "Unable to unassign entry",
+            description: error?.errors[0]?.detail || "The action could not be completed, please try again later.",
+          });
+          return ConfirmModalResult.KeepOpen;
+        }
+      },
+    });
   }
 
-  async function deleteEntry(): Promise<void> {
-    try {
-      await entriesBackendDataSource.delete(entry.id, { showErrorToast: false });
+  async function confirmDeleteEntry(): Promise<void> {
+    await showConfirmModal({
+      title: "Delete Entry",
+      description: `Are you sure you want to delete this entry "${entry.name || entry.id}"? This action cannot be undone.`,
+      onConfirm: async () => {
+        try {
+          await entriesBackendDataSource.delete(entry.id, { showErrorToast: false });
 
-      openConfirmDeleteEntryModal = false;
-      $refetches.entries.list = new Date();
-      showToast.success({
-        title: "Entry deleted",
-        description: `The entry "${entry.name || entry.id}" has been deleted.`,
-      });
-    } catch (error) {
-      showToast.error({
-        title: "Unable to delete entry",
-        description: error?.errors[0]?.detail || "The action could not be completed, please try again later.",
-      });
-    }
+          $refetches.entries.list = new Date();
+          showToast.success({
+            title: "Entry deleted",
+            description: `The entry "${entry.name || entry.id}" has been deleted.`,
+          });
+        } catch (error) {
+          showToast.error({
+            title: "Unable to delete entry",
+            description: error?.errors[0]?.detail || "The action could not be completed, please try again later.",
+          });
+          return ConfirmModalResult.KeepOpen;
+        }
+      },
+    });
   }
 
   async function onEntryAssigned(): Promise<void> {
@@ -164,21 +171,5 @@
     onAssigned={onEntryAssigned}
     entryIds={[entry.id]}
     bind:open={openAssignEntryFormModal}
-  />
-
-  <!-- MODAL::CONFIRM UNASSIGN -->
-  <ConfirmModal
-    title="Unassign entry"
-    description="Are you sure you want to unassign this entry?"
-    onConfirm={unAssignEntry}
-    bind:open={openConfirmUnassignEntryModal}
-  />
-
-  <!-- MODAL::CONFIRM DELETE -->
-  <ConfirmModal
-    title="Delete Entry"
-    description={`Are you sure you want to delete this entry "${entry.name || entry.id}"? This action cannot be undone.`}
-    onConfirm={deleteEntry}
-    bind:open={openConfirmDeleteEntryModal}
   />
 {/if}

--- a/app/frontend/src/lib/components/app/datasets/entries/toolbar/_EntryFilterToolbar.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/toolbar/_EntryFilterToolbar.svelte
@@ -12,21 +12,20 @@
     DropdownMenuTrigger,
   } from "@/components/ui/dropdown-menu";
   import { cn } from "@/utils";
-
   // Inlined entry modals + actions (mirrors entry-dropdown-menu.svelte)
   import UploadEntryButton from "@/components/app/datasets/entries/button/_UploadEntryButton.svelte";
   import AssignEntryFormModal from "@/components/app/datasets/entries/overlays/_AssignEntryFormModal.svelte";
   import UpdateEntryPriorityFormModal from "@/components/app/datasets/entries/overlays/_UpdateEntryPriorityFormModal.svelte";
   import { deleteEntries, unAssignEntries } from "@/components/app/datasets/entries/util/entry-actions";
   import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
-  import { ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+  import { confirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { pluralizeUnit } from "@/utils/unit";
 
   import { ArrowDownAZIcon, ArrowDownZAIcon, ArrowUpDownIcon, ChevronsUpDownIcon, FunnelIcon } from "@lucide/svelte";
 
   import type { ListViewController } from "@/components/app/data-view/list-view-controller.svelte";
-  import type { ColumnSettings } from "@/components/app/datasource-table/types";
   import type { EntrySelection } from "@/components/app/datasets/entries/util/entry-selection.svelte";
+  import type { ColumnSettings } from "@/components/app/datasource-table/types";
   import type { EntryRecord } from "@/data/model/dataset/entries/record";
 
   let {
@@ -71,7 +70,7 @@
       description: `Are you sure you want to unassign ${count} ${pluralizeUnit(count, "entry", "entries")}?`,
       onConfirm: async () => {
         const updated = await unAssignEntries(sel.unAssignableEntryIds, (id) => sel.getEntryName(id));
-        if (!updated) return ConfirmModalResult.KeepOpen;
+        if (!updated) return confirmModalResult.KeepOpen;
 
         controller.patchRecords(updated);
         controller.clearSelection();
@@ -89,7 +88,7 @@
       description: `Are you sure you want to delete ${count} ${pluralizeUnit(count, "entry", "entries")}? This action cannot be undone.`,
       onConfirm: async () => {
         const ok = await deleteEntries(controller.selectedIds, (id) => sel.getEntryName(id));
-        if (!ok) return ConfirmModalResult.KeepOpen;
+        if (!ok) return confirmModalResult.KeepOpen;
 
         controller.clearSelection();
         await controller.fetch();

--- a/app/frontend/src/lib/components/app/datasets/entries/toolbar/_EntryFilterToolbar.svelte
+++ b/app/frontend/src/lib/components/app/datasets/entries/toolbar/_EntryFilterToolbar.svelte
@@ -17,8 +17,9 @@
   import UploadEntryButton from "@/components/app/datasets/entries/button/_UploadEntryButton.svelte";
   import AssignEntryFormModal from "@/components/app/datasets/entries/overlays/_AssignEntryFormModal.svelte";
   import UpdateEntryPriorityFormModal from "@/components/app/datasets/entries/overlays/_UpdateEntryPriorityFormModal.svelte";
-  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
   import { deleteEntries, unAssignEntries } from "@/components/app/datasets/entries/util/entry-actions";
+  import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+  import { ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { pluralizeUnit } from "@/utils/unit";
 
   import { ArrowDownAZIcon, ArrowDownZAIcon, ArrowUpDownIcon, ChevronsUpDownIcon, FunnelIcon } from "@lucide/svelte";
@@ -45,47 +46,55 @@
   // Modal visibility - owned here
   let openAssignEntry = $state(false);
   let openSetPriority = $state(false);
-  let openConfirmUnassign = $state(false);
-  let openConfirmDelete = $state(false);
 
   const bulkActions = $derived(
     getEntryDropdownMenuActions({
       onAssign: () => {
         openAssignEntry = true;
       },
-      onUnassign: () => {
-        openConfirmUnassign = true;
-      },
+      onUnassign: confirmUnassign,
       onSetPriority: () => {
         openSetPriority = true;
       },
-      onDelete: () => {
-        openConfirmDelete = true;
-      },
+      onDelete: confirmDelete,
       isAssigned: sel.checkAnyAssigned(controller.selectedIds),
       isAssignDisabled: sel.assignableEntryIds.length === 0,
       isUnassignDisabled: sel.unAssignableEntryIds.length === 0,
     }),
   );
 
-  async function handleUnassign(): Promise<void> {
-    const updated = await unAssignEntries(sel.unAssignableEntryIds, (id) => sel.getEntryName(id));
-    if (updated) {
-      controller.patchRecords(updated);
-      controller.clearSelection();
-      openConfirmUnassign = false;
-      // Refetch so server-authoritative state is reflected (e.g. wf_step changes)
-      await controller.fetch();
-    }
+  async function confirmUnassign(): Promise<void> {
+    const count = sel.unAssignableEntryIds.length;
+
+    await showConfirmModal({
+      title: "Unassign entry",
+      description: `Are you sure you want to unassign ${count} ${pluralizeUnit(count, "entry", "entries")}?`,
+      onConfirm: async () => {
+        const updated = await unAssignEntries(sel.unAssignableEntryIds, (id) => sel.getEntryName(id));
+        if (!updated) return ConfirmModalResult.KeepOpen;
+
+        controller.patchRecords(updated);
+        controller.clearSelection();
+        // Refetch so server-authoritative state is reflected (e.g. wf_step changes)
+        await controller.fetch();
+      },
+    });
   }
 
-  async function handleDelete(): Promise<void> {
-    const ok = await deleteEntries(controller.selectedIds, (id) => sel.getEntryName(id));
-    if (ok) {
-      controller.clearSelection();
-      openConfirmDelete = false;
-      await controller.fetch();
-    }
+  async function confirmDelete(): Promise<void> {
+    const count = controller.selectedRowsCount;
+
+    await showConfirmModal({
+      title: "Delete entry",
+      description: `Are you sure you want to delete ${count} ${pluralizeUnit(count, "entry", "entries")}? This action cannot be undone.`,
+      onConfirm: async () => {
+        const ok = await deleteEntries(controller.selectedIds, (id) => sel.getEntryName(id));
+        if (!ok) return ConfirmModalResult.KeepOpen;
+
+        controller.clearSelection();
+        await controller.fetch();
+      },
+    });
   }
 </script>
 
@@ -193,17 +202,3 @@
 />
 
 <UpdateEntryPriorityFormModal action="update" entryIds={controller.selectedIds} bind:open={openSetPriority} />
-
-<ConfirmModal
-  title="Unassign entry"
-  description={`Are you sure you want to unassign ${sel.unAssignableEntryIds.length} ${pluralizeUnit(sel.unAssignableEntryIds.length, "entry", "entries")}?`}
-  onConfirm={handleUnassign}
-  bind:open={openConfirmUnassign}
-/>
-
-<ConfirmModal
-  title="Delete entry"
-  description={`Are you sure you want to delete ${controller.selectedRowsCount} ${pluralizeUnit(controller.selectedRowsCount, "entry", "entries")}? This action cannot be undone.`}
-  onConfirm={handleDelete}
-  bind:open={openConfirmDelete}
-/>

--- a/app/frontend/src/lib/components/app/datasets/labels/dropdown-menus/LabelConfigTemplateDropdownMenu.svelte
+++ b/app/frontend/src/lib/components/app/datasets/labels/dropdown-menus/LabelConfigTemplateDropdownMenu.svelte
@@ -1,23 +1,24 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import { ArrowDownIcon, ChevronsUpDownIcon, FileIcon, FilePlusIcon, SaveIcon } from "@lucide/svelte";
+  import { onMount } from "svelte";
 
-  import Button from "@/components/ui/button/button.svelte";
-  import Can from "@/security/can.svelte";
-  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
-  import DropdownMenus from "@/components/app/dropdown-menus/dropdown-menus.svelte";
   import LabelConfigTemplateSaveModal from "$lib/components/app/datasets/labels/overlays/LabelConfigTemplateSaveModal.svelte";
   import LabelConfigTemplateManagementSheet from "@/components/app/datasets/labels/overlays/LabelConfigTemplateManagementSheet.svelte";
+  import DropdownMenus from "@/components/app/dropdown-menus/dropdown-menus.svelte";
+  import Button from "@/components/ui/button/button.svelte";
+  import Can from "@/security/can.svelte";
 
+  import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+  import { ConfirmModalChoice } from "@/components/app/overlays/modals/confirm-modal.types";
+  import { showToast } from "@/components/ui/toast/index.svelte";
   import {
     LabelConfigTemplateRecord,
     labelConfigTemplateDataSource,
   } from "@/data/model/dataset/label-config-template/record";
-  import { showToast } from "@/components/ui/toast/index.svelte";
   import { showActionFailedToast } from "@/utils/error/error.toasts";
   import { refetches } from "@/utils/refetch";
 
-  import type { IDropdownMenus, IDropdownMenuItem } from "@/components/app/dropdown-menus/types";
+  import type { IDropdownMenuItem, IDropdownMenus } from "@/components/app/dropdown-menus/types";
   import type { IConfig } from "@/plugin/v2/types";
 
   interface Props {
@@ -32,8 +33,6 @@
   let labelConfigTemplateManagementDialogOpen = $state(false);
   let labelConfigTemplateSaveModalOpen = $state(false);
   let templates = $state<LabelConfigTemplateRecord[]>([]);
-  let pendingReplaceTemplate = $state<LabelConfigTemplateRecord | null>(null);
-  let openConfirmReplaceModal = $state(false);
 
   async function loadTemplates() {
     try {
@@ -73,11 +72,15 @@
     }
   }
 
-  function confirmReplaceTemplate() {
-    if (!pendingReplaceTemplate) return;
-    replaceTemplate(pendingReplaceTemplate);
-    pendingReplaceTemplate = null;
-    openConfirmReplaceModal = false;
+  async function confirmReplaceTemplate(template: LabelConfigTemplateRecord): Promise<void> {
+    const choice = await showConfirmModal({
+      title: "Overwrite template",
+      description: `Are you sure you want to overwrite this template "${template.name}"? This action cannot be undone.`,
+      confirmLabel: "Yes, Overwrite",
+    });
+    if (choice === ConfirmModalChoice.Cancel) return;
+
+    replaceTemplate(template);
   }
 
   const replaceItems = $derived<IDropdownMenuItem[]>(
@@ -86,10 +89,7 @@
       : templates.map((template) => ({
           label: template.name,
           icon: FileIcon,
-          action: () => {
-            pendingReplaceTemplate = template;
-            openConfirmReplaceModal = true;
-          },
+          action: () => confirmReplaceTemplate(template),
         })),
   );
 
@@ -159,15 +159,4 @@
   {organizationId}
   onSaved={handleSaved}
   bind:open={labelConfigTemplateSaveModalOpen}
-/>
-
-<ConfirmModal
-  title="Overwrite template"
-  description={`Are you sure you want to overwrite this template "${pendingReplaceTemplate?.name}"? This action cannot be undone.`}
-  confirmLabel="Yes, Overwrite"
-  onCancel={() => {
-    pendingReplaceTemplate = null;
-  }}
-  onConfirm={confirmReplaceTemplate}
-  bind:open={openConfirmReplaceModal}
 />

--- a/app/frontend/src/lib/components/app/datasets/labels/overlays/LabelConfigTemplateManagementSheet.svelte
+++ b/app/frontend/src/lib/components/app/datasets/labels/overlays/LabelConfigTemplateManagementSheet.svelte
@@ -3,22 +3,23 @@
 
   import * as Sheet from "$lib/components/ui/sheet";
   import ResponseBlock from "@/components/app/blocks/response-block.svelte";
-  import LabelConfigEditor from "@/components/app/datasets/labels/label-config-editor.svelte";
   import DatasetModalityBadge from "@/components/app/datasets/badges/DatasetModalityBadge.svelte";
+  import LabelConfigEditor from "@/components/app/datasets/labels/label-config-editor.svelte";
   import EditableTextField from "@/components/app/forms/fields/editable-text/EditableTextField.svelte";
   import SingleSelectDatasourceField from "@/components/app/forms/fields/select/single/single-select-datasource-field.svelte";
-  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
   import Button from "@/components/ui/button/button.svelte";
 
   import { LabelConfigController } from "@/components/app/datasets/labels/label-config-controller.svelte";
+  import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+  import { ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+  import { showToast } from "@/components/ui/toast/index.svelte";
   import {
     labelConfigTemplateDataSource,
     LabelConfigTemplateRecord,
   } from "@/data/model/dataset/label-config-template/record";
   import { pluginsBackendDataSource } from "@/data/model/setting/plugin/record";
-  import { refetches } from "@/utils/refetch";
-  import { showToast } from "@/components/ui/toast/index.svelte";
   import { showActionFailedToast } from "@/utils/error/error.toasts";
+  import { refetches } from "@/utils/refetch";
 
   import type { ModalityShapes } from "@/data/model/setting/plugin/types";
   import type { IConfig } from "@/plugin/v2/types";
@@ -47,7 +48,6 @@
   let saving = $state(false);
   let loaded = $state(false);
   let templates = $state<LabelConfigTemplateRecord[]>([]);
-  let openConfirmDeleteModal = $state(false);
 
   const isSelected = $derived(selectedTemplateId !== null);
   const templatesIsEmpty = $derived(templates.length === 0);
@@ -131,18 +131,27 @@
     }
   }
 
-  async function deleteTemplate() {
-    if (!selectedTemplateId) return;
-    try {
-      await labelConfigTemplateDataSource.delete(selectedTemplateId);
-      selectedTemplateId = null;
-      loaded = false;
-      openConfirmDeleteModal = false;
-      $refetches.labelConfigTemplates.list = new Date();
-      showToast.success({ title: "Template deleted", description: "The template has been deleted." });
-    } catch (error) {
-      showActionFailedToast(error);
-    }
+  async function confirmDeleteTemplate(): Promise<void> {
+    const templateId = selectedTemplateId;
+    if (!templateId) return;
+
+    await showConfirmModal({
+      title: "Delete Template",
+      description: `Are you sure you want to delete this template "${selectedTemplateName}"? This action cannot be undone.`,
+      confirmLabel: "Yes, Delete",
+      onConfirm: async () => {
+        try {
+          await labelConfigTemplateDataSource.delete(templateId);
+          selectedTemplateId = null;
+          loaded = false;
+          $refetches.labelConfigTemplates.list = new Date();
+          showToast.success({ title: "Template deleted", description: "The template has been deleted." });
+        } catch (error) {
+          showActionFailedToast(error);
+          return ConfirmModalResult.KeepOpen;
+        }
+      },
+    });
   }
 
   async function applyTemplate() {
@@ -197,11 +206,7 @@
               />
 
               <div class="ml-auto flex items-center gap-4">
-                <Button
-                  variant="destructive-outline"
-                  disabled={!loaded}
-                  onclick={() => (openConfirmDeleteModal = true)}
-                >
+                <Button variant="destructive-outline" disabled={!loaded} onclick={confirmDeleteTemplate}>
                   <Trash2Icon />
                   Delete
                 </Button>
@@ -253,11 +258,3 @@
     {/key}
   </Sheet.Content>
 </Sheet.Root>
-
-<ConfirmModal
-  title="Delete Template"
-  description={`Are you sure you want to delete this template "${selectedTemplateName}"? This action cannot be undone.`}
-  confirmLabel="Yes, Delete"
-  onConfirm={deleteTemplate}
-  bind:open={openConfirmDeleteModal}
-/>

--- a/app/frontend/src/lib/components/app/datasets/labels/overlays/LabelConfigTemplateManagementSheet.svelte
+++ b/app/frontend/src/lib/components/app/datasets/labels/overlays/LabelConfigTemplateManagementSheet.svelte
@@ -11,7 +11,7 @@
 
   import { LabelConfigController } from "@/components/app/datasets/labels/label-config-controller.svelte";
   import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
-  import { ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+  import { confirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import {
     labelConfigTemplateDataSource,
@@ -148,7 +148,7 @@
           showToast.success({ title: "Template deleted", description: "The template has been deleted." });
         } catch (error) {
           showActionFailedToast(error);
-          return ConfirmModalResult.KeepOpen;
+          return confirmModalResult.KeepOpen;
         }
       },
     });

--- a/app/frontend/src/lib/components/app/iam/accounts/data-tables/account-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/iam/accounts/data-tables/account-row-action-cell.svelte
@@ -4,8 +4,9 @@
 
   import DropdownMenus from "@/components/app/dropdown-menus/dropdown-menus.svelte";
   import AccountFormModal from "@/components/app/iam/accounts/overlays/account-form-modal.svelte";
-  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
 
+  import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+  import { ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { resourcePath } from "@/data/BackendDataSource";
   import { clearCache } from "@/data/Cache";
@@ -50,16 +51,13 @@
           label: "Cancel Invitation",
           icon: UserXIcon,
           hidden: canCancelInvitation,
-          action: () => {
-            openConfirmCancelInvitationModal = true;
-          },
+          action: confirmRemoveAccount,
         },
       ],
     },
   });
   let accountRecord: AccountRecord | undefined = $state(undefined);
   let openEditAccountFormModal: boolean = $state(false);
-  let openConfirmCancelInvitationModal: boolean = $state(false);
 
   // Lifecycle
   onMount(async () => {
@@ -93,22 +91,28 @@
     }
   }
 
-  async function removeAccount(): Promise<void> {
-    try {
-      await accountsBackendDataSource.delete(account.id, { showErrorToast: false });
+  async function confirmRemoveAccount(): Promise<void> {
+    await showConfirmModal({
+      title: "Cancel Invitation",
+      description: `Are you sure you want to cancel invitation for "${account.email}"?`,
+      onConfirm: async () => {
+        try {
+          await accountsBackendDataSource.delete(account.id, { showErrorToast: false });
 
-      // Delete project member cache to force refetch
-      clearCache(resourcePath(projectMembersBasePath, null, undefined));
+          // Delete project member cache to force refetch
+          clearCache(resourcePath(projectMembersBasePath, null, undefined));
 
-      openConfirmCancelInvitationModal = false;
-      $refetches.accounts.list = new Date();
-      showToast.success({
-        title: "Invitation cancelled",
-        description: `The account invitation for "${account.email}" has been cancelled.`,
-      });
-    } catch (error) {
-      showActionFailedToast(error);
-    }
+          $refetches.accounts.list = new Date();
+          showToast.success({
+            title: "Invitation cancelled",
+            description: `The account invitation for "${account.email}" has been cancelled.`,
+          });
+        } catch (error) {
+          showActionFailedToast(error);
+          return ConfirmModalResult.KeepOpen;
+        }
+      },
+    });
   }
 </script>
 
@@ -116,11 +120,4 @@
   <DropdownMenus {menus} align="center" />
 
   <AccountFormModal title="Account" action="update" {accountRecord} bind:open={openEditAccountFormModal} />
-
-  <ConfirmModal
-    title="Cancel Invitation"
-    description={`Are you sure you want to cancel invitation for "${account.email}"?`}
-    onConfirm={removeAccount}
-    bind:open={openConfirmCancelInvitationModal}
-  />
 {/if}

--- a/app/frontend/src/lib/components/app/iam/accounts/data-tables/account-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/iam/accounts/data-tables/account-row-action-cell.svelte
@@ -6,7 +6,7 @@
   import AccountFormModal from "@/components/app/iam/accounts/overlays/account-form-modal.svelte";
 
   import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
-  import { ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+  import { confirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { resourcePath } from "@/data/BackendDataSource";
   import { clearCache } from "@/data/Cache";
@@ -109,7 +109,7 @@
           });
         } catch (error) {
           showActionFailedToast(error);
-          return ConfirmModalResult.KeepOpen;
+          return confirmModalResult.KeepOpen;
         }
       },
     });

--- a/app/frontend/src/lib/components/app/iam/api-keys/data-tables/api-key-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/iam/api-keys/data-tables/api-key-row-action-cell.svelte
@@ -6,7 +6,7 @@
   import ApiKeyFormModal from "@/components/app/iam/api-keys/overlays/api-key-form-modal.svelte";
 
   import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
-  import { ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+  import { confirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { ApiKeyRecord, apiKeysBackendDataSource } from "@/data/model/iam/api-keys/record";
   import { authStatus } from "@/security/AuthContext";
@@ -94,7 +94,7 @@
           });
         } catch (error) {
           showActionFailedToast(error);
-          return ConfirmModalResult.KeepOpen;
+          return confirmModalResult.KeepOpen;
         }
       },
     });
@@ -116,7 +116,7 @@
           });
         } catch (error) {
           showActionFailedToast(error);
-          return ConfirmModalResult.KeepOpen;
+          return confirmModalResult.KeepOpen;
         }
       },
     });

--- a/app/frontend/src/lib/components/app/iam/api-keys/data-tables/api-key-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/iam/api-keys/data-tables/api-key-row-action-cell.svelte
@@ -4,8 +4,9 @@
 
   import DropdownMenus from "@/components/app/dropdown-menus/dropdown-menus.svelte";
   import ApiKeyFormModal from "@/components/app/iam/api-keys/overlays/api-key-form-modal.svelte";
-  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
 
+  import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+  import { ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { ApiKeyRecord, apiKeysBackendDataSource } from "@/data/model/iam/api-keys/record";
   import { authStatus } from "@/security/AuthContext";
@@ -41,25 +42,19 @@
           label: "Revoke",
           icon: CircleSlashIcon,
           hidden: !canUpdateAPIKey || alreadyRevoked,
-          action: () => {
-            openConfirmRevokeAPIKeyModal = true;
-          },
+          action: confirmRevokeAPIKey,
         },
         {
           label: "Delete",
           icon: Trash2Icon,
           hidden: !canDeleteAPIKey,
-          action: () => {
-            openConfirmDeleteAPIKeyModal = true;
-          },
+          action: confirmRemoveAPIKey,
         },
       ],
     },
   });
   let apiKeyRecord: ApiKeyRecord | undefined = $state(undefined);
   let openEditAPIKeyFormModal: boolean = $state(false);
-  let openConfirmDeleteAPIKeyModal: boolean = $state(false);
-  let openConfirmRevokeAPIKeyModal: boolean = $state(false);
 
   // Lifecycle
   onMount(async () => {
@@ -83,34 +78,49 @@
     });
   }
 
-  async function removeAPIKey(): Promise<void> {
-    try {
-      await apiKeysBackendDataSource.delete(apiKey.id, { showErrorToast: false });
+  async function confirmRemoveAPIKey(): Promise<void> {
+    await showConfirmModal({
+      title: "Delete API Key",
+      confirmLabel: "Delete API Key",
+      description: `Are you sure you want to delete this API key "${apiKey.name}"? This action cannot be undone.`,
+      onConfirm: async () => {
+        try {
+          await apiKeysBackendDataSource.delete(apiKey.id, { showErrorToast: false });
 
-      openConfirmDeleteAPIKeyModal = false;
-      $refetches.apiKeys.list = new Date();
-      showToast.success({
-        title: "API Key deleted",
-        description: `The API key "${apiKey.name}" has been deleted.`,
-      });
-    } catch (error) {
-      showActionFailedToast(error);
-    }
+          $refetches.apiKeys.list = new Date();
+          showToast.success({
+            title: "API Key deleted",
+            description: `The API key "${apiKey.name}" has been deleted.`,
+          });
+        } catch (error) {
+          showActionFailedToast(error);
+          return ConfirmModalResult.KeepOpen;
+        }
+      },
+    });
   }
 
-  async function revokeAPIKey(): Promise<void> {
-    try {
-      await apiKeysBackendDataSource.revoke({ id: apiKey.id });
+  async function confirmRevokeAPIKey(): Promise<void> {
+    await showConfirmModal({
+      title: "Revoke API Key",
+      confirmLabel: "Revoke API Key",
+      description: `Are you sure you want to revoke this API key "${apiKey.name}"?
+Revoking this key will immediately block all requests that use it. Any applications, integrations, or services relying on this key will stop working.`,
+      onConfirm: async () => {
+        try {
+          await apiKeysBackendDataSource.revoke({ id: apiKey.id });
 
-      openConfirmRevokeAPIKeyModal = false;
-      $refetches.apiKeys.list = new Date();
-      showToast.success({
-        title: "API Key revoked",
-        description: `The API key "${apiKey.name}" has been revoked.`,
-      });
-    } catch (error) {
-      showActionFailedToast(error);
-    }
+          $refetches.apiKeys.list = new Date();
+          showToast.success({
+            title: "API Key revoked",
+            description: `The API key "${apiKey.name}" has been revoked.`,
+          });
+        } catch (error) {
+          showActionFailedToast(error);
+          return ConfirmModalResult.KeepOpen;
+        }
+      },
+    });
   }
 </script>
 
@@ -118,21 +128,4 @@
   <DropdownMenus {menus} align="center" />
 
   <ApiKeyFormModal title="API Key" action="update" {apiKeyRecord} bind:open={openEditAPIKeyFormModal} />
-
-  <ConfirmModal
-    title="Delete API Key"
-    confirmLabel="Delete API Key"
-    description={`Are you sure you want to delete this API key "${apiKey.name}"? This action cannot be undone.`}
-    onConfirm={removeAPIKey}
-    bind:open={openConfirmDeleteAPIKeyModal}
-  />
-
-  <ConfirmModal
-    title="Revoke API Key"
-    confirmLabel="Revoke API Key"
-    description={`Are you sure you want to revoke this API key "${apiKey.name}"?
-Revoking this key will immediately block all requests that use it. Any applications, integrations, or services relying on this key will stop working.`}
-    onConfirm={revokeAPIKey}
-    bind:open={openConfirmRevokeAPIKeyModal}
-  />
 {/if}

--- a/app/frontend/src/lib/components/app/iam/api-keys/data-tables/api-key-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/iam/api-keys/data-tables/api-key-row-action-cell.svelte
@@ -104,8 +104,7 @@
     await showConfirmModal({
       title: "Revoke API Key",
       confirmLabel: "Revoke API Key",
-      description: `Are you sure you want to revoke this API key "${apiKey.name}"?
-Revoking this key will immediately block all requests that use it. Any applications, integrations, or services relying on this key will stop working.`,
+      description: `Are you sure you want to revoke this API key "${apiKey.name}"?\nRevoking this key will immediately block all requests that use it. Any applications, integrations, or services relying on this key will stop working.`,
       onConfirm: async () => {
         try {
           await apiKeysBackendDataSource.revoke({ id: apiKey.id });

--- a/app/frontend/src/lib/components/app/iam/api-keys/data-tables/api-key-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/iam/api-keys/data-tables/api-key-row-action-cell.svelte
@@ -122,7 +122,7 @@
   <ConfirmModal
     title="Delete API Key"
     confirmLabel="Delete API Key"
-    description={`Are you sure you want to delete the API key "${apiKey.name}"? This action cannot be undone.`}
+    description={`Are you sure you want to delete this API key "${apiKey.name}"? This action cannot be undone.`}
     onConfirm={removeAPIKey}
     bind:open={openConfirmDeleteAPIKeyModal}
   />

--- a/app/frontend/src/lib/components/app/organizations/data-tables/organization-owner-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/organizations/data-tables/organization-owner-row-action-cell.svelte
@@ -7,7 +7,7 @@
   import Can from "@/security/can.svelte";
 
   import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
-  import { ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+  import { confirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { AccountRecord, accountsBackendDataSource } from "@/data/model/iam/accounts/record";
   import { refetches } from "@/utils/refetch";
@@ -70,7 +70,7 @@
     } catch (error) {
       console.error(error);
       showToast.error({ title: "Failed to remove organization owner." });
-      return ConfirmModalResult.KeepOpen;
+      return confirmModalResult.KeepOpen;
     }
   }
 </script>

--- a/app/frontend/src/lib/components/app/organizations/data-tables/organization-owner-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/organizations/data-tables/organization-owner-row-action-cell.svelte
@@ -2,11 +2,12 @@
   import { page } from "$app/state";
   import { UserRoundXIcon } from "@lucide/svelte";
 
-  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
   import Tooltips from "@/components/app/tooltips/tooltips.svelte";
   import Button from "@/components/ui/button/button.svelte";
   import Can from "@/security/can.svelte";
 
+  import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+  import { ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { AccountRecord, accountsBackendDataSource } from "@/data/model/iam/accounts/record";
   import { refetches } from "@/utils/refetch";
@@ -18,10 +19,17 @@
 
   // Variables
   let organizationId = page.params.organizationId as string;
-  let openConfirmRemoveOrgOwnerModal: boolean = $state(false);
   let { id: accountId, email } = $derived(accountRecord);
 
   // Functions
+  async function confirmRemoveOrgOwner(): Promise<void> {
+    await showConfirmModal({
+      title: "Remove Organization Owner",
+      description: `Are you sure you want to remove ${email} from the organization owner? This action cannot be undone.`,
+      onConfirm: removeOrgOwner,
+    });
+  }
+
   async function removeOrgOwner() {
     try {
       const { data: account } = await accountsBackendDataSource.get(accountId, {
@@ -62,6 +70,7 @@
     } catch (error) {
       console.error(error);
       showToast.error({ title: "Failed to remove organization owner." });
+      return ConfirmModalResult.KeepOpen;
     }
   }
 </script>
@@ -69,7 +78,7 @@
 <Can action="delete" resource="iam:organizations" scopes={["as_org_owner"]}>
   <Tooltips align="center">
     {#snippet trigger()}
-      <Button variant="ghost" size="icon-sm" onclick={() => (openConfirmRemoveOrgOwnerModal = true)}>
+      <Button variant="ghost" size="icon-sm" onclick={confirmRemoveOrgOwner}>
         <UserRoundXIcon />
       </Button>
     {/snippet}
@@ -79,11 +88,4 @@
       from organization owner
     {/snippet}
   </Tooltips>
-
-  <ConfirmModal
-    title="Remove Organization Owner"
-    description="Are you sure you want to remove {email} from the organization owner? This action cannot be undone."
-    onConfirm={removeOrgOwner}
-    bind:open={openConfirmRemoveOrgOwnerModal}
-  />
 </Can>

--- a/app/frontend/src/lib/components/app/organizations/dropdowns/organization-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/organizations/dropdowns/organization-dropdown-menu.svelte
@@ -125,7 +125,7 @@
 
   <ConfirmModal
     title="Delete Organization"
-    description="Are you sure you want to delete this organization? This action cannot be undone."
+    description={`Are you sure you want to delete the organization "${organizationRecord?.name}"? This action cannot be undone.`}
     onConfirm={deleteOrganization}
     bind:open={openConfirmDeleteOrganizationModal}
   />

--- a/app/frontend/src/lib/components/app/organizations/dropdowns/organization-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/organizations/dropdowns/organization-dropdown-menu.svelte
@@ -8,7 +8,7 @@
   import { SquarePenIcon, Trash2Icon } from "@lucide/svelte";
 
   import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
-  import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+  import { ConfirmModalChoice, confirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { ProjectRecord, projectsBackendDataSource } from "@/data/model/dataset/projects/project-record";
   import { OrganizationRecord, organizationsBackendDataSource } from "@/data/model/iam/organizations/record";
@@ -109,7 +109,7 @@
           });
         } catch (error) {
           showActionFailedToast(error);
-          return ConfirmModalResult.KeepOpen;
+          return confirmModalResult.KeepOpen;
         }
       },
     });

--- a/app/frontend/src/lib/components/app/organizations/dropdowns/organization-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/organizations/dropdowns/organization-dropdown-menu.svelte
@@ -5,9 +5,10 @@
 
   import DropdownMenus from "@/components/app/dropdown-menus/dropdown-menus.svelte";
   import OrganizationFormModal from "@/components/app/organizations/overlays/organization-form-modal.svelte";
-  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
   import { SquarePenIcon, Trash2Icon } from "@lucide/svelte";
 
+  import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+  import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { ProjectRecord, projectsBackendDataSource } from "@/data/model/dataset/projects/project-record";
   import { OrganizationRecord, organizationsBackendDataSource } from "@/data/model/iam/organizations/record";
@@ -36,7 +37,6 @@
   let organizationRecord: OrganizationRecord | undefined = $state(undefined);
   let relatedProjectRecords: ProjectRecord[] = $state([]);
   let openEditOrganizationFormModal: boolean = $state(false);
-  let openConfirmDeleteOrganizationModal: boolean = $state(false);
   let menus: IDropdownMenus = $derived({
     actions: {
       items: [
@@ -57,9 +57,7 @@
           description:
             relatedProjectRecords.length > 0 ? "Cannot delete organization when projects are associated." : undefined,
           disabled: relatedProjectRecords.length > 0,
-          action: () => {
-            openConfirmDeleteOrganizationModal = true;
-          },
+          action: confirmDeleteOrganization,
         },
       ],
     },
@@ -95,21 +93,30 @@
     return projectsRes.data;
   }
 
-  async function deleteOrganization() {
-    try {
-      await organizationsBackendDataSource.delete(organizationId, { showErrorToast: false });
-      openConfirmDeleteOrganizationModal = false;
-      $refetches.organizations.list = new Date();
-      goto(resolve("/organizations"));
-      showToast.success({
-        title: "Organization deleted",
-        description: organizationRecord
-          ? `The organization "${organizationRecord?.name}" has been deleted.`
-          : "The organization has been deleted.",
-      });
-    } catch (error) {
-      showActionFailedToast(error);
-    }
+  async function confirmDeleteOrganization(): Promise<void> {
+    const choice = await showConfirmModal({
+      title: "Delete Organization",
+      description: `Are you sure you want to delete this organization "${organizationRecord?.name}"? This action cannot be undone.`,
+      onConfirm: async () => {
+        try {
+          await organizationsBackendDataSource.delete(organizationId, { showErrorToast: false });
+          $refetches.organizations.list = new Date();
+          showToast.success({
+            title: "Organization deleted",
+            description: organizationRecord
+              ? `The organization "${organizationRecord?.name}" has been deleted.`
+              : "The organization has been deleted.",
+          });
+        } catch (error) {
+          showActionFailedToast(error);
+          return ConfirmModalResult.KeepOpen;
+        }
+      },
+    });
+    if (choice === ConfirmModalChoice.Cancel) return;
+
+    // Navigating inside `onConfirm` would run while the modal is still open.
+    goto(resolve("/organizations"));
   }
 </script>
 
@@ -121,12 +128,5 @@
     action="update"
     {organizationRecord}
     bind:open={openEditOrganizationFormModal}
-  />
-
-  <ConfirmModal
-    title="Delete Organization"
-    description={`Are you sure you want to delete this organization "${organizationRecord?.name}"? This action cannot be undone.`}
-    onConfirm={deleteOrganization}
-    bind:open={openConfirmDeleteOrganizationModal}
   />
 {/if}

--- a/app/frontend/src/lib/components/app/organizations/dropdowns/organization-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/organizations/dropdowns/organization-dropdown-menu.svelte
@@ -125,7 +125,7 @@
 
   <ConfirmModal
     title="Delete Organization"
-    description={`Are you sure you want to delete the organization "${organizationRecord?.name}"? This action cannot be undone.`}
+    description={`Are you sure you want to delete this organization "${organizationRecord?.name}"? This action cannot be undone.`}
     onConfirm={deleteOrganization}
     bind:open={openConfirmDeleteOrganizationModal}
   />

--- a/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.service.svelte.test.ts
+++ b/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.service.svelte.test.ts
@@ -1,0 +1,347 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  cancelConfirmModal,
+  confirmModalStore,
+  isConfirmModalActive,
+  selectConfirmModalAction,
+  settleConfirmModal,
+  showConfirmModal,
+} from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+
+/**
+ * The store is a module singleton, so every test must leave it idle. `cancelConfirmModal`
+ * settles a dangling promise; `settleConfirmModal(false)` clears the request the way
+ * `onOpenChangeComplete` does in the host.
+ */
+afterEach(() => {
+  cancelConfirmModal();
+  settleConfirmModal(false);
+});
+
+/** Lets a pending microtask chain (an awaited `run`) finish before asserting. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("showConfirmModal", () => {
+  it("opens with a default confirm action", () => {
+    void showConfirmModal({ title: "Delete Dataset", description: "Are you sure?" });
+
+    expect(confirmModalStore.open).toBe(true);
+    expect(confirmModalStore.request?.title).toBe("Delete Dataset");
+    expect(confirmModalStore.request?.actions).toHaveLength(1);
+    expect(confirmModalStore.request?.actions[0].id).toBe(ConfirmModalChoice.Confirm);
+    expect(confirmModalStore.pendingActionId).toBeNull();
+  });
+
+  it("throws when a modal is already active", () => {
+    void showConfirmModal({ title: "First" });
+
+    expect(() => showConfirmModal({ title: "Second" })).toThrow(/while "First" is still active/);
+  });
+
+  /**
+   * Deliberately does NOT call settleConfirmModal() between the two: in the app that only
+   * runs from the host's onOpenChangeComplete, i.e. after the exit animation. Calling it by
+   * hand here would hide the very lifecycle window this asserts.
+   */
+  it("allows a second modal as soon as the first resolves, mid exit animation", async () => {
+    const first = showConfirmModal({ title: "First" });
+    const firstId = confirmModalStore.request?.id;
+
+    void selectConfirmModalAction(ConfirmModalChoice.Confirm);
+    await expect(first).resolves.toBe(ConfirmModalChoice.Confirm);
+
+    // Closing, but still mounted for the animation — the previous request lingers.
+    expect(confirmModalStore.open).toBe(false);
+    expect(confirmModalStore.request).not.toBeNull();
+
+    const second = showConfirmModal({ title: "Second" });
+    expect(confirmModalStore.request?.id).not.toBe(firstId);
+    expect(confirmModalStore.open).toBe(true);
+
+    void selectConfirmModalAction(ConfirmModalChoice.Confirm);
+    await expect(second).resolves.toBe(ConfirmModalChoice.Confirm);
+  });
+
+  it("ignores a late settle from the request a new one replaced", async () => {
+    const first = showConfirmModal({ title: "First" });
+    void selectConfirmModalAction(ConfirmModalChoice.Confirm);
+    await first;
+
+    const second = showConfirmModal({ title: "Second" });
+
+    // The first modal's close transition completes after the second has taken over.
+    settleConfirmModal(false);
+
+    expect(confirmModalStore.request?.title).toBe("Second");
+    expect(confirmModalStore.open).toBe(true);
+
+    void selectConfirmModalAction(ConfirmModalChoice.Confirm);
+    await expect(second).resolves.toBe(ConfirmModalChoice.Confirm);
+  });
+});
+
+describe("sync mode", () => {
+  it("closes and resolves the action id on confirm", async () => {
+    const choice = showConfirmModal({ title: "Delete Dataset" });
+
+    void selectConfirmModalAction(ConfirmModalChoice.Confirm);
+
+    await expect(choice).resolves.toBe(ConfirmModalChoice.Confirm);
+    expect(confirmModalStore.open).toBe(false);
+  });
+
+  it("closes and resolves cancel", async () => {
+    const choice = showConfirmModal({ title: "Delete Dataset" });
+
+    cancelConfirmModal();
+
+    await expect(choice).resolves.toBe(ConfirmModalChoice.Cancel);
+    expect(confirmModalStore.open).toBe(false);
+  });
+
+  it("resolves the id of the chosen action in a multi-action modal", async () => {
+    const choice = showConfirmModal({
+      title: "Unsaved changes",
+      actions: [
+        { id: "discard", label: "Don't Save", variant: "outline" },
+        { id: "save", label: "Save" },
+      ],
+    });
+
+    void selectConfirmModalAction("save");
+
+    await expect(choice).resolves.toBe("save");
+    expect(confirmModalStore.open).toBe(false);
+  });
+});
+
+describe("async mode", () => {
+  it("closes and resolves when run succeeds", async () => {
+    const run = vi.fn().mockResolvedValue(undefined);
+    const choice = showConfirmModal({ title: "Delete Dataset", onConfirm: run });
+
+    void selectConfirmModalAction(ConfirmModalChoice.Confirm);
+
+    await expect(choice).resolves.toBe(ConfirmModalChoice.Confirm);
+    expect(run).toHaveBeenCalledOnce();
+    expect(confirmModalStore.open).toBe(false);
+  });
+
+  it("keeps the modal open when run returns KeepOpen", async () => {
+    const settled = vi.fn();
+    const choice = showConfirmModal({
+      title: "Delete Dataset",
+      onConfirm: async () => ConfirmModalResult.KeepOpen,
+    });
+    void choice.then(settled);
+
+    await selectConfirmModalAction(ConfirmModalChoice.Confirm);
+    await flush();
+
+    expect(confirmModalStore.open).toBe(true);
+    expect(confirmModalStore.request?.title).toBe("Delete Dataset");
+    expect(confirmModalStore.pendingActionId).toBeNull();
+    expect(settled).not.toHaveBeenCalled();
+  });
+
+  it("keeps the modal open when run throws, and logs it", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const settled = vi.fn();
+    const choice = showConfirmModal({
+      title: "Delete Dataset",
+      onConfirm: async () => {
+        throw new Error("network down");
+      },
+    });
+    void choice.then(settled);
+
+    await selectConfirmModalAction(ConfirmModalChoice.Confirm);
+    await flush();
+
+    expect(confirmModalStore.open).toBe(true);
+    expect(confirmModalStore.pendingActionId).toBeNull();
+    expect(settled).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledOnce();
+
+    consoleError.mockRestore();
+  });
+
+  it("marks the action pending while run is in flight", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+
+    const choice = showConfirmModal({ title: "Delete Dataset", onConfirm: () => gate });
+    const dispatched = selectConfirmModalAction(ConfirmModalChoice.Confirm);
+
+    expect(confirmModalStore.pendingActionId).toBe(ConfirmModalChoice.Confirm);
+    expect(confirmModalStore.open).toBe(true);
+
+    release();
+    await dispatched;
+
+    await expect(choice).resolves.toBe(ConfirmModalChoice.Confirm);
+    expect(confirmModalStore.pendingActionId).toBeNull();
+  });
+
+  it("ignores a second action while one is pending", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const second = vi.fn();
+
+    void showConfirmModal({
+      title: "Unsaved changes",
+      actions: [
+        { id: "save", label: "Save", run: () => gate },
+        { id: "discard", label: "Don't Save", run: second },
+      ],
+    });
+
+    const dispatched = selectConfirmModalAction("save");
+    void selectConfirmModalAction("discard");
+
+    expect(second).not.toHaveBeenCalled();
+
+    release();
+    await dispatched;
+  });
+
+  /**
+   * The Cancel button and Escape are both disabled while an action runs, so the only caller
+   * left is the host's afterNavigate. A route change must still settle the promise, and the
+   * mutation's late result must not resolve it a second time.
+   */
+  it("survives a route-change cancel mid-action, ignoring the late result", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+
+    const choice = showConfirmModal({ title: "Delete Dataset", onConfirm: () => gate });
+    const dispatched = selectConfirmModalAction(ConfirmModalChoice.Confirm);
+
+    cancelConfirmModal();
+    await expect(choice).resolves.toBe(ConfirmModalChoice.Cancel);
+
+    // The mutation keeps running and settles afterwards; it must not resolve again.
+    release();
+    await dispatched;
+    await flush();
+
+    expect(confirmModalStore.open).toBe(false);
+  });
+
+  it("runs only the chosen action in a mixed sync/async modal", async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    const choice = showConfirmModal({
+      title: "Unsaved changes",
+      actions: [
+        { id: "discard", label: "Don't Save", variant: "outline" },
+        { id: "save", label: "Save", run: save },
+      ],
+    });
+
+    void selectConfirmModalAction("discard");
+
+    await expect(choice).resolves.toBe("discard");
+    expect(save).not.toHaveBeenCalled();
+    expect(confirmModalStore.open).toBe(false);
+  });
+});
+
+describe("isConfirmModalActive", () => {
+  /**
+   * Regression guard for the labels-page navigation guard: the overlay blocks clicks but not
+   * the browser's Back button, so `beforeNavigate` can re-enter while its own modal is open.
+   * Before this predicate existed it called showConfirmModal() again, which throws.
+   */
+  it("is false when idle", () => {
+    expect(isConfirmModalActive()).toBe(false);
+  });
+
+  it("is true while a modal is open", () => {
+    void showConfirmModal({ title: "Unsaved changes" });
+
+    expect(isConfirmModalActive()).toBe(true);
+  });
+
+  it("is true while an action is pending", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+
+    void showConfirmModal({ title: "Unsaved changes", onConfirm: () => gate });
+    const dispatched = selectConfirmModalAction(ConfirmModalChoice.Confirm);
+
+    expect(isConfirmModalActive()).toBe(true);
+
+    release();
+    await dispatched;
+  });
+
+  it("stays true through the close transition, until settle", async () => {
+    const choice = showConfirmModal({ title: "Unsaved changes" });
+
+    void selectConfirmModalAction(ConfirmModalChoice.Confirm);
+    await choice;
+
+    // Closing but still mounted for the exit animation: a re-entrant guard must still bail.
+    expect(isConfirmModalActive()).toBe(true);
+
+    settleConfirmModal(false);
+    expect(isConfirmModalActive()).toBe(false);
+  });
+
+  it("lets a re-entrant caller bail instead of throwing", async () => {
+    // What the labels-page beforeNavigate guard now does on browser Back.
+    const first = showConfirmModal({ title: "Unsaved changes" });
+
+    const reentrantGuard = () => {
+      if (isConfirmModalActive()) return "bailed";
+      return showConfirmModal({ title: "Unsaved changes" });
+    };
+
+    expect(reentrantGuard()).toBe("bailed");
+    expect(confirmModalStore.request?.title).toBe("Unsaved changes");
+
+    cancelConfirmModal();
+    await expect(first).resolves.toBe(ConfirmModalChoice.Cancel);
+  });
+});
+
+describe("settleConfirmModal", () => {
+  it("clears the request only once the close transition has completed", async () => {
+    const choice = showConfirmModal({ title: "Delete Dataset" });
+
+    void selectConfirmModalAction(ConfirmModalChoice.Confirm);
+    await choice;
+
+    // Still mounted so the exit animation has something to render.
+    expect(confirmModalStore.request).not.toBeNull();
+
+    settleConfirmModal(false);
+    expect(confirmModalStore.request).toBeNull();
+  });
+
+  it("is a no-op while the modal is opening", () => {
+    void showConfirmModal({ title: "Delete Dataset" });
+
+    settleConfirmModal(true);
+
+    expect(confirmModalStore.request).not.toBeNull();
+  });
+});
+
+describe("cancelConfirmModal", () => {
+  it("is idempotent once a request has settled", async () => {
+    const choice = showConfirmModal({ title: "Delete Dataset" });
+
+    void selectConfirmModalAction(ConfirmModalChoice.Confirm);
+    await expect(choice).resolves.toBe(ConfirmModalChoice.Confirm);
+
+    expect(() => cancelConfirmModal()).not.toThrow();
+  });
+
+  it("is a no-op when nothing is active", () => {
+    expect(() => cancelConfirmModal()).not.toThrow();
+    expect(confirmModalStore.open).toBe(false);
+  });
+});

--- a/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.service.svelte.test.ts
+++ b/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.service.svelte.test.ts
@@ -8,7 +8,7 @@ import {
   settleConfirmModal,
   showConfirmModal,
 } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
-import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+import { ConfirmModalChoice, confirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
 
 /**
  * The store is a module singleton, so every test must leave it idle. `cancelConfirmModal`
@@ -133,7 +133,7 @@ describe("async mode", () => {
     const settled = vi.fn();
     const choice = showConfirmModal({
       title: "Delete Dataset",
-      onConfirm: async () => ConfirmModalResult.KeepOpen,
+      onConfirm: async () => confirmModalResult.KeepOpen,
     });
     void choice.then(settled);
 

--- a/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.service.svelte.ts
+++ b/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.service.svelte.ts
@@ -2,10 +2,11 @@ import { browser } from "$app/environment";
 
 import {
   ConfirmModalChoice,
-  ConfirmModalResult,
+  confirmModalResult,
   type ConfirmModalChoiceOf,
   type ConfirmModalOptions,
   type ConfirmModalRequest,
+  type ConfirmModalResult,
   type ResolvedConfirmModalAction,
 } from "@/components/app/overlays/modals/confirm-modal.types";
 
@@ -18,7 +19,7 @@ import {
  * Lifecycle is hybrid and chosen per action by the presence of `run`:
  * - no `run`  → the modal closes as soon as the action is clicked
  * - has `run` → the modal stays open in a pending state and closes only when `run` resolves
- *   without returning `ConfirmModalResult.KeepOpen`
+ *   without returning `confirmModalResult.KeepOpen`
  */
 class ConfirmModalStore {
   /** The active request, or null when idle. Cleared after the exit animation completes. */
@@ -128,7 +129,7 @@ export function showConfirmModal<Id extends string = never>(
  * Run an action on behalf of the host.
  *
  * Sync actions settle immediately. Async actions hold the modal open in a pending state
- * while `run` executes, then close unless `run` returned `ConfirmModalResult.KeepOpen`.
+ * while `run` executes, then close unless `run` returned `confirmModalResult.KeepOpen`.
  */
 export async function selectConfirmModalAction(actionId: string): Promise<void> {
   const request = confirmModalStore.request;
@@ -150,10 +151,10 @@ export async function selectConfirmModalAction(actionId: string): Promise<void> 
   } catch (error) {
     console.error(
       `showConfirmModal: action "${action.id}" of "${request.title}" threw instead of returning ` +
-        `ConfirmModalResult.KeepOpen. Keeping the modal open.`,
+        `confirmModalResult.KeepOpen. Keeping the modal open.`,
       error,
     );
-    result = ConfirmModalResult.KeepOpen;
+    result = confirmModalResult.KeepOpen;
   }
 
   /**
@@ -168,7 +169,7 @@ export async function selectConfirmModalAction(actionId: string): Promise<void> 
   if (!activeResolve || confirmModalStore.request?.id !== request.id) return;
 
   confirmModalStore.pendingActionId = null;
-  if (result === ConfirmModalResult.KeepOpen) return;
+  if (result === confirmModalResult.KeepOpen) return;
 
   finish(action.id);
 }

--- a/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.service.svelte.ts
+++ b/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.service.svelte.ts
@@ -1,0 +1,211 @@
+import { browser } from "$app/environment";
+
+import {
+  ConfirmModalChoice,
+  ConfirmModalResult,
+  type ConfirmModalChoiceOf,
+  type ConfirmModalOptions,
+  type ConfirmModalRequest,
+  type ResolvedConfirmModalAction,
+} from "@/components/app/overlays/modals/confirm-modal.types";
+
+/**
+ * Global confirm-modal service.
+ *
+ * One `<ConfirmModal />` renders from the root layout; callers ask for a confirmation
+ * through {@link showConfirmModal} and never hold modal state themselves.
+ *
+ * Lifecycle is hybrid and chosen per action by the presence of `run`:
+ * - no `run`  → the modal closes as soon as the action is clicked
+ * - has `run` → the modal stays open in a pending state and closes only when `run` resolves
+ *   without returning `ConfirmModalResult.KeepOpen`
+ */
+class ConfirmModalStore {
+  /** The active request, or null when idle. Cleared after the exit animation completes. */
+  request: ConfirmModalRequest | null = $state(null);
+
+  /** Drives the underlying `AlertDialog`. Goes false before `request` is cleared. */
+  open: boolean = $state(false);
+
+  /** Id of the action whose `run` is in flight, or null. */
+  pendingActionId: string | null = $state(null);
+}
+
+export const confirmModalStore = new ConfirmModalStore();
+
+/**
+ * Resolver of the promise handed to the current caller. Deliberately NOT reactive — it is
+ * control state, not render state. Nulled the moment a request settles, which is also what
+ * makes {@link cancelConfirmModal} and late `run` results idempotent.
+ */
+let activeResolve: ((choice: string) => void) | null = null;
+
+let nextRequestId = 0;
+
+function resolveActions(options: ConfirmModalOptions<string>): ResolvedConfirmModalAction[] {
+  if (options.actions?.length) {
+    return options.actions.map((action) => ({
+      id: action.id,
+      label: action.label,
+      variant: action.variant ?? "default",
+      pendingLabel: action.pendingLabel ?? action.label,
+      run: action.run,
+    }));
+  }
+
+  const label = options.confirmLabel ?? "Confirm";
+
+  return [
+    {
+      id: ConfirmModalChoice.Confirm,
+      label,
+      variant: options.destructive === false ? "default" : "destructive",
+      pendingLabel: options.pendingLabel ?? label,
+      run: options.onConfirm,
+    },
+  ];
+}
+
+/** Settles the active request and starts the close transition. No-op when already settled. */
+function finish(choice: string): void {
+  const resolve = activeResolve;
+  if (!resolve) return;
+
+  activeResolve = null;
+  confirmModalStore.pendingActionId = null;
+  confirmModalStore.open = false;
+  resolve(choice);
+}
+
+/**
+ * Ask the user to confirm something.
+ *
+ * @returns the chosen action's id, or `ConfirmModalChoice.Cancel` if the user cancelled,
+ * pressed Escape, or navigated away.
+ * @throws if another confirm modal is already active — confirmations are strictly
+ * sequential, and a silently dropped one would be indistinguishable from a cancel.
+ */
+export function showConfirmModal<Id extends string = never>(
+  options: ConfirmModalOptions<Id>,
+): Promise<ConfirmModalChoiceOf<Id>> {
+  if (!browser) {
+    if (import.meta.env.DEV) {
+      console.error(`showConfirmModal: "${options.title}" called during SSR; resolving as cancelled.`);
+    }
+    return Promise.resolve(ConfirmModalChoice.Cancel as ConfirmModalChoiceOf<Id>);
+  }
+
+  /**
+   * Gate on "is someone awaiting a decision?", not "is a modal on screen?".
+   *
+   * `request` deliberately outlives the promise: it stays set through the exit animation so
+   * the closing modal has something to render. Gating on it would reject the perfectly legal
+   * `await showConfirmModal(A); showConfirmModal(B);` for as long as that animation runs.
+   */
+  if (activeResolve) {
+    throw new Error(
+      `showConfirmModal: "${options.title}" was called while "${confirmModalStore.request?.title}" is still active.`,
+    );
+  }
+
+  confirmModalStore.request = {
+    id: ++nextRequestId,
+    title: options.title,
+    description: options.description,
+    content: options.content,
+    actions: resolveActions(options as ConfirmModalOptions<string>),
+    cancelLabel: options.cancelLabel ?? "Cancel",
+  };
+  confirmModalStore.pendingActionId = null;
+  confirmModalStore.open = true;
+
+  return new Promise<ConfirmModalChoiceOf<Id>>((resolve) => {
+    activeResolve = resolve as (choice: string) => void;
+  });
+}
+
+/**
+ * Run an action on behalf of the host.
+ *
+ * Sync actions settle immediately. Async actions hold the modal open in a pending state
+ * while `run` executes, then close unless `run` returned `ConfirmModalResult.KeepOpen`.
+ */
+export async function selectConfirmModalAction(actionId: string): Promise<void> {
+  const request = confirmModalStore.request;
+  if (!request || confirmModalStore.pendingActionId) return;
+
+  const action = request.actions.find((candidate) => candidate.id === actionId);
+  if (!action) return;
+
+  if (!action.run) {
+    finish(action.id);
+    return;
+  }
+
+  confirmModalStore.pendingActionId = action.id;
+
+  let result: ConfirmModalResult | void;
+  try {
+    result = await action.run();
+  } catch (error) {
+    console.error(
+      `showConfirmModal: action "${action.id}" of "${request.title}" threw instead of returning ` +
+        `ConfirmModalResult.KeepOpen. Keeping the modal open.`,
+      error,
+    );
+    result = ConfirmModalResult.KeepOpen;
+  }
+
+  /**
+   * The request may have settled while `run` was in flight — the user can still cancel
+   * during pending, because a hung request would otherwise trap them (BackendDataSource has
+   * no timeout). A late result must not resolve or close anything.
+   */
+  if (!activeResolve || confirmModalStore.request?.id !== request.id) return;
+
+  confirmModalStore.pendingActionId = null;
+  if (result === ConfirmModalResult.KeepOpen) return;
+
+  finish(action.id);
+}
+
+/**
+ * Whether a confirm modal is currently asking the user something.
+ *
+ * For re-entrant callers that can fire again while their own modal is open — a
+ * `beforeNavigate` guard is the real case, since the overlay blocks clicks but not the
+ * browser's Back button. Those must bail out rather than call {@link showConfirmModal}
+ * again, which throws by design.
+ */
+export function isConfirmModalActive(): boolean {
+  return confirmModalStore.request !== null;
+}
+
+/**
+ * Cancel the active request. Backs the Cancel button, Escape, and route changes.
+ *
+ * While an action is pending the Cancel button and Escape are both disabled, so the only
+ * caller left is a route change. That path still abandons the modal rather than the in-flight
+ * mutation, which keeps running and reports through its own toasts — hence the staleness
+ * guard in {@link selectConfirmModalAction}.
+ */
+export function cancelConfirmModal(): void {
+  finish(ConfirmModalChoice.Cancel);
+}
+
+/**
+ * Clear the request once the close transition has finished.
+ *
+ * Must not run earlier: bits-ui keeps the content mounted through the exit animation, so
+ * clearing on close would blank the modal mid-fade.
+ *
+ * Fires after the open transition too, hence the `open` guard. The `activeResolve` guard
+ * covers the other direction: a new request may have opened during the exit animation, and
+ * a late completion from the request it replaced must not clear it.
+ */
+export function settleConfirmModal(open: boolean): void {
+  if (open || activeResolve) return;
+
+  confirmModalStore.request = null;
+  confirmModalStore.pendingActionId = null;
+}

--- a/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.service.svelte.ts
+++ b/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.service.svelte.ts
@@ -157,9 +157,13 @@ export async function selectConfirmModalAction(actionId: string): Promise<void> 
   }
 
   /**
-   * The request may have settled while `run` was in flight — the user can still cancel
-   * during pending, because a hung request would otherwise trap them (BackendDataSource has
-   * no timeout). A late result must not resolve or close anything.
+   * The request may have settled while `run` was in flight: Cancel and Escape are both
+   * disabled during pending, but a route change still cancels. A late result must not
+   * resolve or close anything.
+   *
+   * Both clauses are load-bearing. A cancelled request frees `activeResolve`, so a new
+   * request can already be active by the time this runs — the id check is what identifies
+   * the result as stale.
    */
   if (!activeResolve || confirmModalStore.request?.id !== request.id) return;
 

--- a/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.svelte
+++ b/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { afterNavigate } from "$app/navigation";
+
   import {
     AlertDialog,
     AlertDialogCancel,
@@ -10,49 +12,85 @@
   } from "@/components/ui/alert-dialog";
   import Button from "@/components/ui/button/button.svelte";
 
-  import type { ConfirmModalBaseProps } from "@/components/app/overlays/modals/confirm-modal.types";
+  import {
+    cancelConfirmModal,
+    confirmModalStore,
+    selectConfirmModalAction,
+    settleConfirmModal,
+  } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
 
-  // Props
-  let {
-    title,
-    description,
-    open = $bindable(),
-    modalTitle,
-    modalDescription,
-    children,
-    confirm,
-    confirmLabel = "Confirm",
-    onCancel,
-    onConfirm,
-  }: ConfirmModalBaseProps = $props();
+  // Variables
+  let pending = $derived(confirmModalStore.pendingActionId !== null);
+
+  // Lifecycle
+  /** Never leave a modal orphaned over a page it was not opened from. */
+  afterNavigate(() => cancelConfirmModal());
 </script>
 
-<AlertDialog bind:open>
-  <AlertDialogContent>
-    <AlertDialogHeader>
-      {#if modalTitle}
-        {@render modalTitle()}
-      {:else}
-        <AlertDialogTitle>{title}</AlertDialogTitle>
+<AlertDialog
+  bind:open={confirmModalStore.open}
+  onOpenChange={(open) => {
+    /* Covers the Cancel button and Escape; a programmatic close has already settled. */
+    if (!open) cancelConfirmModal();
+  }}
+  onOpenChangeComplete={settleConfirmModal}
+>
+  {#if confirmModalStore.request}
+    {@const request = confirmModalStore.request}
+
+    <AlertDialogContent
+      onEscapeKeydown={(event) => {
+        /* An action is mid-flight: Cancel remains available, Escape does not. */
+        if (pending) event.preventDefault();
+      }}
+    >
+      <AlertDialogHeader>
+        <AlertDialogTitle>{request.title}</AlertDialogTitle>
+      </AlertDialogHeader>
+
+      {#if request.description}
+        <AlertDialogDescription>{request.description}</AlertDialogDescription>
       {/if}
-    </AlertDialogHeader>
 
-    {#if modalDescription}
-      {@render modalDescription()}
-    {:else}
-      <AlertDialogDescription>{description}</AlertDialogDescription>
-    {/if}
-
-    {@render children?.()}
-
-    <AlertDialogFooter>
-      <AlertDialogCancel onclick={onCancel}>Cancel</AlertDialogCancel>
-
-      {#if confirm}
-        {@render confirm()}
-      {:else}
-        <Button variant="destructive" onclick={onConfirm}>{confirmLabel}</Button>
+      {#if request.content}
+        {@const Content = request.content.component}
+        <!--
+          Keyed on the request, not just guarded by {#if}: a new request can replace this one
+          without `request` passing through null, because it stays set through the exit
+          animation. Without the key, Svelte would reuse the previous content instance —
+          along with any state or in-flight fetch it owns.
+        -->
+        {#key request.id}
+          <Content {...request.content.props ?? {}} />
+        {/key}
       {/if}
-    </AlertDialogFooter>
-  </AlertDialogContent>
+
+      <AlertDialogFooter>
+        <!--
+          Disabled while an action runs: cancelling would only hide the dialog, not abort the
+          mutation, leaving the caller unable to tell whether its work completed.
+
+          Both props are needed. bits-ui consumes `disabled` internally to block its own
+          click/keydown handlers but never forwards it to the element, so `aria-disabled`
+          is what actually reaches the DOM — and `buttonVariants` already styles it
+          (`aria-disabled:pointer-events-none aria-disabled:opacity-50`).
+        -->
+        <AlertDialogCancel disabled={pending} aria-disabled={pending || undefined}>
+          {request.cancelLabel}
+        </AlertDialogCancel>
+
+        {#each request.actions as action (action.id)}
+          <Button
+            variant={action.variant}
+            loading={confirmModalStore.pendingActionId === action.id}
+            loadingLabel={action.pendingLabel}
+            disabled={pending && confirmModalStore.pendingActionId !== action.id}
+            onclick={() => selectConfirmModalAction(action.id)}
+          >
+            {action.label}
+          </Button>
+        {/each}
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  {/if}
 </AlertDialog>

--- a/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.svelte.test.ts
+++ b/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.svelte.test.ts
@@ -1,0 +1,166 @@
+import { render, screen } from "@testing-library/svelte";
+import { tick } from "svelte";
+import { afterEach, describe, expect, it } from "vitest";
+
+import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
+import {
+  cancelConfirmModal,
+  selectConfirmModalAction,
+  settleConfirmModal,
+  showConfirmModal,
+} from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+
+afterEach(() => {
+  cancelConfirmModal();
+  settleConfirmModal(false);
+});
+
+describe("ConfirmModal", () => {
+  it("mounts outside a router without throwing", () => {
+    expect(() => render(ConfirmModal)).not.toThrow();
+  });
+
+  it("renders nothing while idle", () => {
+    render(ConfirmModal);
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  it("renders the active request and resolves on confirm", async () => {
+    render(ConfirmModal);
+
+    const choice = showConfirmModal({
+      title: "Delete Dataset",
+      description: 'Are you sure you want to delete the dataset "Ants"?',
+      confirmLabel: "Delete",
+    });
+
+    expect(await screen.findByRole("alertdialog")).toBeTruthy();
+    expect(screen.getByText("Delete Dataset")).toBeTruthy();
+    expect(screen.getByText('Are you sure you want to delete the dataset "Ants"?')).toBeTruthy();
+
+    await screen.findByRole("button", { name: "Delete" });
+    void selectConfirmModalAction(ConfirmModalChoice.Confirm);
+
+    await expect(choice).resolves.toBe(ConfirmModalChoice.Confirm);
+  });
+
+  it("renders one button per action, plus cancel", async () => {
+    render(ConfirmModal);
+
+    void showConfirmModal({
+      title: "Unsaved changes",
+      actions: [
+        { id: "discard", label: "Don't Save", variant: "outline" },
+        { id: "save", label: "Save" },
+      ],
+    });
+
+    await screen.findByRole("alertdialog");
+
+    expect(screen.getByRole("button", { name: "Don't Save" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+  });
+
+  it("keeps the dialog mounted when run returns KeepOpen", async () => {
+    render(ConfirmModal);
+
+    void showConfirmModal({
+      title: "Delete Dataset",
+      onConfirm: async () => ConfirmModalResult.KeepOpen,
+    });
+
+    await screen.findByRole("alertdialog");
+    await selectConfirmModalAction(ConfirmModalChoice.Confirm);
+
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+  });
+
+  describe("while an action is pending", () => {
+    /** Opens a modal whose action hangs until the returned `release` is called. */
+    async function openWithPendingAction() {
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => (release = resolve));
+
+      const choice = showConfirmModal({
+        title: "Delete Dataset",
+        confirmLabel: "Delete",
+        cancelLabel: "Cancel",
+        onConfirm: () => gate,
+      });
+
+      await screen.findByRole("alertdialog");
+      const dispatched = selectConfirmModalAction(ConfirmModalChoice.Confirm);
+      await tick(); // let the pending state reach the DOM
+
+      return { choice, release, dispatched };
+    }
+
+    it("disables Cancel, so the dialog cannot be dismissed mid-mutation", async () => {
+      render(ConfirmModal);
+      const { release, dispatched } = await openWithPendingAction();
+
+      // bits-ui keeps `disabled` internal (it guards its own handlers) and never forwards it
+      // to the element, so aria-disabled is what carries the state to the DOM and to AT.
+      expect(screen.getByRole("button", { name: "Cancel" })).toHaveAttribute("aria-disabled", "true");
+
+      release();
+      await dispatched;
+    });
+
+    it("re-enables Cancel once the action settles with KeepOpen", async () => {
+      render(ConfirmModal);
+
+      void showConfirmModal({
+        title: "Delete Dataset",
+        cancelLabel: "Cancel",
+        onConfirm: async () => ConfirmModalResult.KeepOpen,
+      });
+
+      await screen.findByRole("alertdialog");
+      expect(screen.getByRole("button", { name: "Cancel" })).not.toHaveAttribute("aria-disabled");
+
+      await selectConfirmModalAction(ConfirmModalChoice.Confirm);
+      await tick();
+
+      expect(screen.getByRole("button", { name: "Cancel" })).not.toHaveAttribute("aria-disabled");
+    });
+
+    it("disables every action button and shows the pending spinner", async () => {
+      render(ConfirmModal);
+
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => (release = resolve));
+
+      const choice = showConfirmModal({
+        title: "Unsaved changes",
+        actions: [
+          { id: "discard", label: "Don't Save", variant: "outline" },
+          { id: "save", label: "Save", run: () => gate },
+        ],
+      });
+
+      await screen.findByRole("alertdialog");
+      const dispatched = selectConfirmModalAction("save");
+      await tick(); // let the pending state reach the DOM
+
+      /**
+       * Queried by slot rather than by name: the running button renders Spinner, whose
+       * `role="status" aria-label="Loading"` makes its accessible name "Loading Save".
+       * Siblings are disabled by the host; the running one disables itself via Button's
+       * `loading` prop, which also blocks a double submit.
+       */
+      const actions = screen.getAllByRole("button").filter((b) => b.dataset.slot === "button");
+      expect(actions).toHaveLength(2);
+      for (const action of actions) expect(action).toBeDisabled();
+
+      expect(screen.getByRole("status", { name: "Loading" })).toBeTruthy();
+
+      release();
+      await dispatched;
+      await expect(choice).resolves.toBe("save");
+    });
+  });
+});

--- a/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.svelte.test.ts
+++ b/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.svelte.test.ts
@@ -2,14 +2,14 @@ import { render, screen } from "@testing-library/svelte";
 import { tick } from "svelte";
 import { afterEach, describe, expect, it } from "vitest";
 
-import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
 import {
   cancelConfirmModal,
   selectConfirmModalAction,
   settleConfirmModal,
   showConfirmModal,
 } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
-import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
+import { ConfirmModalChoice, confirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
 
 afterEach(() => {
   cancelConfirmModal();
@@ -69,7 +69,7 @@ describe("ConfirmModal", () => {
 
     void showConfirmModal({
       title: "Delete Dataset",
-      onConfirm: async () => ConfirmModalResult.KeepOpen,
+      onConfirm: async () => confirmModalResult.KeepOpen,
     });
 
     await screen.findByRole("alertdialog");
@@ -116,7 +116,7 @@ describe("ConfirmModal", () => {
       void showConfirmModal({
         title: "Delete Dataset",
         cancelLabel: "Cancel",
-        onConfirm: async () => ConfirmModalResult.KeepOpen,
+        onConfirm: async () => confirmModalResult.KeepOpen,
       });
 
       await screen.findByRole("alertdialog");

--- a/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.types.ts
+++ b/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.types.ts
@@ -1,12 +1,100 @@
-import type { Snippet } from "svelte";
+import type { Component } from "svelte";
 
-import type { ModalBaseProps } from "@/components/app/overlays/modals/Modal.types";
+import type { ButtonVariant } from "@/components/ui/button/button.svelte";
 
-export interface ConfirmModalBaseProps extends ModalBaseProps {
+/** Universal outcome shared by every confirm modal. */
+export const ConfirmModalChoice = {
+  Confirm: "confirm",
+  Cancel: "cancel",
+} as const;
+export type ConfirmModalChoice = (typeof ConfirmModalChoice)[keyof typeof ConfirmModalChoice];
+
+/**
+ * Returned by an action's `run` to control the modal. Returning nothing means success and
+ * the modal closes.
+ *
+ * Mirrors the convention already used by `entry-actions.ts` ("false on failure, toast
+ * already shown"): failures are reported by the caller and signalled by a return value,
+ * never by throwing.
+ */
+export const ConfirmModalResult = {
+  KeepOpen: "keep-open",
+} as const;
+export type ConfirmModalResult = (typeof ConfirmModalResult)[keyof typeof ConfirmModalResult];
+
+/**
+ * Async work owned by an action.
+ *
+ * Runs while the modal stays open in a pending state. Return `ConfirmModalResult.KeepOpen`
+ * to keep it open (the caller has already shown its own error toast); return nothing to
+ * close. Throwing is treated as `KeepOpen` and logged — it is a safety net so an unhandled
+ * rejection cannot silently close a destructive modal, not the failure channel.
+ *
+ * `run` must not navigate: it executes while the modal is open, so a `goto()` here can
+ * trigger a navigation guard that opens a second modal. Navigate after `showConfirmModal()`
+ * resolves instead.
+ */
+export type ConfirmModalRun = () => Promise<ConfirmModalResult | void> | ConfirmModalResult | void;
+
+export interface ConfirmModalAction<Id extends string = string> {
+  /** Returned by `showConfirmModal()` when this action is chosen. */
+  id: Id;
+  label: string;
+  variant?: ButtonVariant;
+  /** Present selects async mode for this action; absent closes the modal immediately. */
+  run?: ConfirmModalRun;
+  /** Button label while `run` is in flight. Defaults to the action's own label. */
+  pendingLabel?: string;
+}
+
+export interface ConfirmModalContent {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- payload props are caller-defined
+  component: Component<any>;
+  /** Captured when `showConfirmModal()` is called; NOT live-bound to the caller's state. */
+  props?: Record<string, unknown>;
+}
+
+export interface ConfirmModalOptions<Id extends string = never> {
   title: string;
-  description: string;
-  confirm?: Snippet;
+  description?: string;
+  /** Extra body content rendered between the description and the footer. */
+  content?: ConfirmModalContent;
+
+  /** Multi-outcome dialogs. Omit for a single confirm button. Mode is decided per action. */
+  actions?: readonly ConfirmModalAction<Id>[];
+
+  /** Single-action sugar. Ignored when `actions` is provided. */
   confirmLabel?: string;
-  onCancel?: () => Promise<void> | void;
-  onConfirm?: () => Promise<void> | void;
+  /** Single-action sugar. Its presence selects async mode. Ignored when `actions` is provided. */
+  onConfirm?: ConfirmModalRun;
+  /** Single-action sugar. Ignored when `actions` is provided. */
+  pendingLabel?: string;
+  /** Styles the default confirm button. Ignored when `actions` is provided. */
+  destructive?: boolean;
+
+  cancelLabel?: string;
+}
+
+/** What `showConfirmModal()` resolves to: the chosen action's id, or `"cancel"`. */
+export type ConfirmModalChoiceOf<Id extends string> = [Id] extends [never]
+  ? ConfirmModalChoice
+  : Id | typeof ConfirmModalChoice.Cancel;
+
+/** An action with every default resolved, as held by the store and rendered by the host. */
+export interface ResolvedConfirmModalAction {
+  id: string;
+  label: string;
+  variant: ButtonVariant;
+  pendingLabel: string;
+  run?: ConfirmModalRun;
+}
+
+/** The active request, as held by the store and rendered by the host. */
+export interface ConfirmModalRequest {
+  id: number;
+  title: string;
+  description?: string;
+  content?: ConfirmModalContent;
+  actions: ResolvedConfirmModalAction[];
+  cancelLabel: string;
 }

--- a/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.types.ts
+++ b/app/frontend/src/lib/components/app/overlays/modals/confirm-modal.types.ts
@@ -17,15 +17,15 @@ export type ConfirmModalChoice = (typeof ConfirmModalChoice)[keyof typeof Confir
  * already shown"): failures are reported by the caller and signalled by a return value,
  * never by throwing.
  */
-export const ConfirmModalResult = {
+export const confirmModalResult = {
   KeepOpen: "keep-open",
 } as const;
-export type ConfirmModalResult = (typeof ConfirmModalResult)[keyof typeof ConfirmModalResult];
+export type ConfirmModalResult = (typeof confirmModalResult)[keyof typeof confirmModalResult];
 
 /**
  * Async work owned by an action.
  *
- * Runs while the modal stays open in a pending state. Return `ConfirmModalResult.KeepOpen`
+ * Runs while the modal stays open in a pending state. Return `confirmModalResult.KeepOpen`
  * to keep it open (the caller has already shown its own error toast); return nothing to
  * close. Throwing is treated as `KeepOpen` and logged — it is a safety net so an unhandled
  * rejection cannot silently close a destructive modal, not the failure channel.

--- a/app/frontend/src/lib/components/app/projects/dropdowns/project-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/projects/dropdowns/project-dropdown-menu.svelte
@@ -114,7 +114,7 @@
 
   <ConfirmModal
     title="Delete Project"
-    description={`Are you sure you want to delete the project "${projectRecord?.name}"? This action cannot be undone.`}
+    description={`Are you sure you want to delete this project "${projectRecord?.name}"? This action cannot be undone.`}
     onConfirm={deleteProject}
     bind:open={openConfirmDeleteProjectModal}
   />

--- a/app/frontend/src/lib/components/app/projects/dropdowns/project-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/projects/dropdowns/project-dropdown-menu.svelte
@@ -114,7 +114,7 @@
 
   <ConfirmModal
     title="Delete Project"
-    description="Are you sure you want to delete this project?"
+    description={`Are you sure you want to delete the project "${projectRecord?.name}"? This action cannot be undone.`}
     onConfirm={deleteProject}
     bind:open={openConfirmDeleteProjectModal}
   />

--- a/app/frontend/src/lib/components/app/projects/dropdowns/project-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/projects/dropdowns/project-dropdown-menu.svelte
@@ -5,9 +5,10 @@
   import { onMount } from "svelte";
 
   import DropdownMenus from "@/components/app/dropdown-menus/dropdown-menus.svelte";
-  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
   import ProjectFormModal from "@/components/app/projects/overlays/project-form-modal.svelte";
 
+  import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+  import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { ProjectRecord, projectsBackendDataSource } from "@/data/model/dataset/projects/project-record";
   import { authStatus } from "@/security/AuthContext";
@@ -45,9 +46,7 @@
           icon: Trash2Icon,
           destructive: true,
           hidden: !canDeleteProject,
-          action: () => {
-            openConfirmDeleteProjectModal = true;
-          },
+          action: confirmDeleteProject,
         },
       ],
     },
@@ -55,7 +54,6 @@
 
   let projectRecord: ProjectRecord | undefined = $state(undefined);
   let openEditProjectFormModal: boolean = $state(false);
-  let openConfirmDeleteProjectModal: boolean = $state(false);
 
   // Lifecycle
   onMount(async () => {
@@ -87,23 +85,32 @@
     });
   }
 
-  async function deleteProject(): Promise<void> {
-    try {
-      await projectsBackendDataSource.delete(projectId, { showErrorToast: false });
+  async function confirmDeleteProject(): Promise<void> {
+    const choice = await showConfirmModal({
+      title: "Delete Project",
+      description: `Are you sure you want to delete this project "${projectRecord?.name}"? This action cannot be undone.`,
+      onConfirm: async () => {
+        try {
+          await projectsBackendDataSource.delete(projectId, { showErrorToast: false });
 
-      openConfirmDeleteProjectModal = false;
-      $refetches.projects.list = new Date();
-      goto(resolve("/projects"));
-      showToast.success({
-        title: "Project deleted",
-        description: `The project "${projectRecord?.name}" has been deleted.`,
-      });
-    } catch (error) {
-      showToast.error({
-        title: "Unable to delete project",
-        description: error?.errors[0]?.detail || "The action could not be completed, please try again later.",
-      });
-    }
+          $refetches.projects.list = new Date();
+          showToast.success({
+            title: "Project deleted",
+            description: `The project "${projectRecord?.name}" has been deleted.`,
+          });
+        } catch (error) {
+          showToast.error({
+            title: "Unable to delete project",
+            description: error?.errors[0]?.detail || "The action could not be completed, please try again later.",
+          });
+          return ConfirmModalResult.KeepOpen;
+        }
+      },
+    });
+    if (choice === ConfirmModalChoice.Cancel) return;
+
+    // Navigating inside `onConfirm` would run while the modal is still open.
+    goto(resolve("/projects"));
   }
 </script>
 
@@ -111,11 +118,4 @@
   <DropdownMenus {menus} {align} />
 
   <ProjectFormModal title="Project" action="update" {projectRecord} bind:open={openEditProjectFormModal} />
-
-  <ConfirmModal
-    title="Delete Project"
-    description={`Are you sure you want to delete this project "${projectRecord?.name}"? This action cannot be undone.`}
-    onConfirm={deleteProject}
-    bind:open={openConfirmDeleteProjectModal}
-  />
 {/if}

--- a/app/frontend/src/lib/components/app/projects/dropdowns/project-dropdown-menu.svelte
+++ b/app/frontend/src/lib/components/app/projects/dropdowns/project-dropdown-menu.svelte
@@ -8,7 +8,7 @@
   import ProjectFormModal from "@/components/app/projects/overlays/project-form-modal.svelte";
 
   import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
-  import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+  import { ConfirmModalChoice, confirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import { ProjectRecord, projectsBackendDataSource } from "@/data/model/dataset/projects/project-record";
   import { authStatus } from "@/security/AuthContext";
@@ -103,7 +103,7 @@
             title: "Unable to delete project",
             description: error?.errors[0]?.detail || "The action could not be completed, please try again later.",
           });
-          return ConfirmModalResult.KeepOpen;
+          return confirmModalResult.KeepOpen;
         }
       },
     });

--- a/app/frontend/src/lib/components/app/projects/members/datasource-tables/member-entries-warning.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/datasource-tables/member-entries-warning.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { TriangleAlertIcon } from "@lucide/svelte";
+
+  import AccountEntries from "@/components/app/projects/entries/account-entries.svelte";
+
+  // Props
+  interface Props {
+    accountId: string | number;
+    projectId: string;
+  }
+  let { accountId, projectId }: Props = $props();
+</script>
+
+<!-- Stays collapsed until <AccountEntries> actually renders a dataset list. -->
+<div
+  class="hidden gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-400 [&:has(div>div)]:!flex"
+>
+  <TriangleAlertIcon class="mt-0.5 size-4 shrink-0" />
+  <div class="[&>div]:!text-current">
+    <AccountEntries
+      {accountId}
+      {projectId}
+      labelText="Entries on these datasets will be unassigned from this account:"
+    />
+  </div>
+</div>

--- a/app/frontend/src/lib/components/app/projects/members/datasource-tables/project-member-role-cell.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/datasource-tables/project-member-role-cell.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import Can from "@/security/can.svelte";
-  import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select";
   import ProjectMemberRoleBadge from "@/components/app/projects/members/badges/project-member-role-badge.svelte";
   import RoleChangeWarning from "@/components/app/projects/members/datasource-tables/role-change-warning.svelte";
+  import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select";
+  import Can from "@/security/can.svelte";
 
   import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
-  import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+  import { ConfirmModalChoice, confirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import {
     ProjectMemberRecord,
@@ -102,7 +102,7 @@
           });
         } catch (error) {
           showActionFailedToast(error);
-          return ConfirmModalResult.KeepOpen;
+          return confirmModalResult.KeepOpen;
         }
       },
     });

--- a/app/frontend/src/lib/components/app/projects/members/datasource-tables/project-member-role-cell.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/datasource-tables/project-member-role-cell.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
-  import { TriangleAlertIcon } from "@lucide/svelte";
-
   import Can from "@/security/can.svelte";
   import { Select, SelectContent, SelectItem, SelectTrigger } from "@/components/ui/select";
-  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
-  import Button from "@/components/ui/button/button.svelte";
-  import AccountEntries from "@/components/app/projects/entries/account-entries.svelte";
   import ProjectMemberRoleBadge from "@/components/app/projects/members/badges/project-member-role-badge.svelte";
+  import RoleChangeWarning from "@/components/app/projects/members/datasource-tables/role-change-warning.svelte";
 
+  import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+  import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { showToast } from "@/components/ui/toast/index.svelte";
   import {
     ProjectMemberRecord,
@@ -56,48 +54,61 @@
   // Variables
   let selectedRole: ProjectMemberRole = $state(projectMember.role);
   let selectResetKey: number = $state(0);
-  let pendingRole: ProjectMemberRole | null = $state(null);
-  let openConfirmModal: boolean = $state(false);
 
   let selectedRoleLabel = $derived(projectMemberRoles.find((r) => r.value === selectedRole)?.label ?? selectedRole);
-  let pendingRoleLabel = $derived(projectMemberRoles.find((r) => r.value === pendingRole)?.label ?? pendingRole);
-  let warningMessage = $derived(pendingRole ? (warningMessages[selectedRole]?.[pendingRole] ?? null) : null);
-  let needsDatasets = $derived(pendingRole ? scenariosNeedingDatasets.has(`${selectedRole}→${pendingRole}`) : false);
+
+  function roleLabel(role: ProjectMemberRole) {
+    return projectMemberRoles.find((r) => r.value === role)?.label ?? role;
+  }
 
   // Functions
   function onRoleChange(value: string): void {
     if (value === selectedRole) return;
-    pendingRole = value as ProjectMemberRole;
-    openConfirmModal = true;
+    void confirmRoleChange(value as ProjectMemberRole);
   }
 
-  async function confirmRoleChange(): Promise<void> {
-    if (!pendingRole) return;
+  async function confirmRoleChange(newRole: ProjectMemberRole): Promise<void> {
+    const fromRole = selectedRole;
 
-    const newRole = pendingRole;
-    pendingRole = null;
+    const choice = await showConfirmModal({
+      title: "Role Change",
+      confirmLabel: "Confirm",
+      destructive: false,
+      content: {
+        component: RoleChangeWarning,
+        props: {
+          email: projectMember.email,
+          fromRoleLabel: roleLabel(fromRole),
+          toRoleLabel: roleLabel(newRole),
+          warningMessage: warningMessages[fromRole]?.[newRole] ?? null,
+          needsDatasets: scenariosNeedingDatasets.has(`${fromRole}→${newRole}`),
+          accountId: projectMember.account_id,
+          projectId: projectMember.project_id,
+        },
+      },
+      onConfirm: async () => {
+        try {
+          await projectMembersBackendDataSource.update(
+            projectMember.id,
+            { attributes: { role: newRole } },
+            { showErrorToast: false },
+          );
 
-    try {
-      await projectMembersBackendDataSource.update(
-        projectMember.id,
-        { attributes: { role: newRole } },
-        { showErrorToast: false },
-      );
+          selectedRole = newRole;
+          $refetches.projectMembers.list = new Date();
+          showToast.success({
+            title: "Member role updated",
+            description: `"${projectMember.email}" is now a ${roleLabel(newRole)}.`,
+          });
+        } catch (error) {
+          showActionFailedToast(error);
+          return ConfirmModalResult.KeepOpen;
+        }
+      },
+    });
 
-      selectedRole = newRole;
-      $refetches.projectMembers.list = new Date();
-      showToast.success({
-        title: "Member role updated",
-        description: `"${projectMember.email}" is now a ${projectMemberRoles.find((r) => r.value === newRole)?.label}.`,
-      });
-    } catch (error) {
-      showActionFailedToast(error);
-    }
-  }
-
-  function cancelRoleChange(): void {
-    pendingRole = null;
-    selectResetKey++;
+    // Cancel, Escape or a route change: put the <Select> back on the current role.
+    if (choice === ConfirmModalChoice.Cancel) selectResetKey++;
   }
 </script>
 
@@ -135,43 +146,4 @@
       </SelectContent>
     </Select>
   {/key}
-
-  <ConfirmModal
-    title="Role Change"
-    description=""
-    bind:open={openConfirmModal}
-    onConfirm={confirmRoleChange}
-    onCancel={cancelRoleChange}
-  >
-    {#snippet confirm()}
-      <Button onclick={confirmRoleChange}>Confirm</Button>
-    {/snippet}
-
-    {#snippet modalDescription()}
-      <p class="text-muted-foreground text-sm">
-        Are you sure you want to change <strong>{projectMember.email}</strong>'s role from
-        <strong>{selectedRoleLabel}</strong> to <strong>{pendingRoleLabel}</strong>?
-      </p>
-
-      {#if warningMessage}
-        <div
-          class="mt-3 flex gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-400"
-        >
-          <TriangleAlertIcon class="mt-0.5 size-4 shrink-0" />
-          <div>
-            <span><strong>{projectMember.email}</strong> {warningMessage}</span>
-
-            {#if needsDatasets}
-              <div class="hidden has-[+div:not(:empty)]:block">
-                <hr class="my-2 border-amber-300 dark:border-amber-500/40" />
-              </div>
-              <div class="[&>div]:!text-current">
-                <AccountEntries accountId={projectMember.account_id} projectId={projectMember.project_id} />
-              </div>
-            {/if}
-          </div>
-        </div>
-      {/if}
-    {/snippet}
-  </ConfirmModal>
 </Can>

--- a/app/frontend/src/lib/components/app/projects/members/datasource-tables/project-member-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/datasource-tables/project-member-row-action-cell.svelte
@@ -8,7 +8,7 @@
   import Can from "@/security/can.svelte";
 
   import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
-  import { ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+  import { confirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { ProjectMemberRecord, projectMembersBackendDataSource } from "@/data/model/dataset/projects/members/record";
   import { showActionFailedToast } from "@/utils/error/error.toasts";
   import { refetches } from "@/utils/refetch";
@@ -52,7 +52,7 @@
           });
         } catch (error) {
           showActionFailedToast(error);
-          return ConfirmModalResult.KeepOpen;
+          return confirmModalResult.KeepOpen;
         }
       },
     });

--- a/app/frontend/src/lib/components/app/projects/members/datasource-tables/project-member-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/datasource-tables/project-member-row-action-cell.svelte
@@ -32,7 +32,7 @@
   // Functions
   async function confirmRemoveProjectMember(): Promise<void> {
     await showConfirmModal({
-      title: "Remove member",
+      title: "Remove Member",
       description: `Are you sure you want to remove "${projectMember.email}" from this project?`,
       content: {
         component: MemberEntriesWarning,

--- a/app/frontend/src/lib/components/app/projects/members/datasource-tables/project-member-row-action-cell.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/datasource-tables/project-member-row-action-cell.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import { page } from "$app/state";
-  import { TriangleAlertIcon, UserRoundXIcon } from "@lucide/svelte";
+  import { UserRoundXIcon } from "@lucide/svelte";
 
-  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
-  import AccountEntries from "@/components/app/projects/entries/account-entries.svelte";
+  import MemberEntriesWarning from "@/components/app/projects/members/datasource-tables/member-entries-warning.svelte";
   import Tooltips from "@/components/app/tooltips/tooltips.svelte";
   import Button from "@/components/ui/button/button.svelte";
   import Can from "@/security/can.svelte";
 
+  import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+  import { ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { ProjectMemberRecord, projectMembersBackendDataSource } from "@/data/model/dataset/projects/members/record";
   import { showActionFailedToast } from "@/utils/error/error.toasts";
   import { refetches } from "@/utils/refetch";
@@ -27,26 +28,34 @@
 
   // Variables
   let projectId = page.params.projectId as string;
-  let openConfirmRemoveMemberModal: boolean = $state(false);
 
   // Functions
-  async function removeProjectMember(): Promise<void> {
-    try {
-      await projectMembersBackendDataSource.delete(projectMember.id, { showErrorToast: false });
+  async function confirmRemoveProjectMember(): Promise<void> {
+    await showConfirmModal({
+      title: "Remove member",
+      description: `Are you sure you want to remove "${projectMember.email}" from this project?`,
+      content: {
+        component: MemberEntriesWarning,
+        props: { accountId: projectMember.account_id, projectId },
+      },
+      onConfirm: async () => {
+        try {
+          await projectMembersBackendDataSource.delete(projectMember.id, { showErrorToast: false });
 
-      openConfirmRemoveMemberModal = false;
+          // Delete entries cache
+          clearCache(resourcePath(entriesBasePath, null, undefined));
 
-      // Delete entries cache
-      clearCache(resourcePath(entriesBasePath, null, undefined));
-
-      $refetches.projectMembers.list = new Date();
-      showToast.success({
-        title: "Project member removed",
-        description: `"${projectMember.email}" has been removed from the project.`,
-      });
-    } catch (error) {
-      showActionFailedToast(error);
-    }
+          $refetches.projectMembers.list = new Date();
+          showToast.success({
+            title: "Project member removed",
+            description: `"${projectMember.email}" has been removed from the project.`,
+          });
+        } catch (error) {
+          showActionFailedToast(error);
+          return ConfirmModalResult.KeepOpen;
+        }
+      },
+    });
   }
 </script>
 
@@ -65,7 +74,7 @@
 >
   <Tooltips align="center">
     {#snippet trigger()}
-      <Button variant="ghost" size="icon-sm" onclick={() => (openConfirmRemoveMemberModal = true)}>
+      <Button variant="ghost" size="icon-sm" onclick={confirmRemoveProjectMember}>
         <UserRoundXIcon />
       </Button>
     {/snippet}
@@ -74,24 +83,4 @@
       Remove "{projectMember.email}" <br /> from project membership
     {/snippet}
   </Tooltips>
-
-  <ConfirmModal
-    title="Remove member"
-    description={`Are you sure you want to remove "${projectMember.email}" from this project?`}
-    onConfirm={removeProjectMember}
-    bind:open={openConfirmRemoveMemberModal}
-  >
-    <div
-      class="hidden gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-400 [&:has(div>div)]:!flex"
-    >
-      <TriangleAlertIcon class="mt-0.5 size-4 shrink-0" />
-      <div class="[&>div]:!text-current">
-        <AccountEntries
-          accountId={projectMember.account_id}
-          {projectId}
-          labelText="Entries on these datasets will be unassigned from this account:"
-        />
-      </div>
-    </div>
-  </ConfirmModal>
 </Can>

--- a/app/frontend/src/lib/components/app/projects/members/datasource-tables/role-change-warning.svelte
+++ b/app/frontend/src/lib/components/app/projects/members/datasource-tables/role-change-warning.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { TriangleAlertIcon } from "@lucide/svelte";
+
+  import AccountEntries from "@/components/app/projects/entries/account-entries.svelte";
+
+  // Props
+  interface Props {
+    email: string;
+    fromRoleLabel: string;
+    toRoleLabel: string;
+    /** Consequence of this specific (from → to) transition, or null when there is none. */
+    warningMessage: string | null;
+    /** Whether the transition also needs the member's assigned-entry datasets listed. */
+    needsDatasets: boolean;
+    accountId: string | number;
+    projectId: string;
+  }
+  let { email, fromRoleLabel, toRoleLabel, warningMessage, needsDatasets, accountId, projectId }: Props = $props();
+</script>
+
+<p class="text-muted-foreground text-sm">
+  Are you sure you want to change <strong>{email}</strong>'s role from
+  <strong>{fromRoleLabel}</strong> to <strong>{toRoleLabel}</strong>?
+</p>
+
+{#if warningMessage}
+  <div
+    class="mt-3 flex gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-400"
+  >
+    <TriangleAlertIcon class="mt-0.5 size-4 shrink-0" />
+    <div>
+      <span><strong>{email}</strong> {warningMessage}</span>
+
+      {#if needsDatasets}
+        <div class="hidden has-[+div:not(:empty)]:block">
+          <hr class="my-2 border-amber-300 dark:border-amber-500/40" />
+        </div>
+        <div class="[&>div]:!text-current">
+          <AccountEntries {accountId} {projectId} />
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/app/frontend/src/lib/plugin/layout/sidebar/notes/dropdown-menus/note-dropdown-menus.svelte
+++ b/app/frontend/src/lib/plugin/layout/sidebar/notes/dropdown-menus/note-dropdown-menus.svelte
@@ -3,9 +3,9 @@
   import { SvelteURL } from "svelte/reactivity";
 
   import DropdownMenus from "@/components/app/dropdown-menus/dropdown-menus.svelte";
-  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
   import Button from "@/components/ui/button/button.svelte";
 
+  import { showConfirmModal } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
   import { showToast } from "@/components/ui/toast/index.svelte";
 
   import type { IDropdownMenus } from "@/components/app/dropdown-menus/types";
@@ -33,7 +33,6 @@
   }: Props = $props();
 
   // Variables
-  let openConfirmDeleteModal = $state(false);
 
   const menus: IDropdownMenus = $derived({
     actions: {
@@ -68,21 +67,29 @@
           icon: Trash2Icon,
           destructive: true,
           disabled: !deletable,
-          action: () => {
-            openConfirmDeleteModal = true;
-          },
+          action: confirmDeleteNote,
         },
       ],
     },
   });
 
   // Functions
-  async function deleteNote() {
-    try {
-      await onDelete?.();
-    } finally {
-      openConfirmDeleteModal = false;
-    }
+  async function confirmDeleteNote(): Promise<void> {
+    await showConfirmModal({
+      title: noteCommentId ? "Delete Note Comment" : "Delete Note Feed",
+      description: "Are you sure you want to delete this note? This action cannot be undone.",
+      onConfirm: async () => {
+        try {
+          await onDelete?.();
+        } catch {
+          /**
+           * Deliberately does NOT return ConfirmModalResult.KeepOpen: the parent owns error
+           * reporting and this modal closed on failure before the migration too (it used
+           * try/finally). Keeping that behaviour is intentional.
+           */
+        }
+      },
+    });
   }
 </script>
 
@@ -93,10 +100,3 @@
     </Button>
   {/snippet}
 </DropdownMenus>
-
-<ConfirmModal
-  title={noteCommentId ? "Delete Note Comment" : "Delete Note Feed"}
-  description="Are you sure you want to delete this note? This action cannot be undone."
-  onConfirm={deleteNote}
-  bind:open={openConfirmDeleteModal}
-></ConfirmModal>

--- a/app/frontend/src/lib/plugin/layout/sidebar/notes/dropdown-menus/note-dropdown-menus.svelte
+++ b/app/frontend/src/lib/plugin/layout/sidebar/notes/dropdown-menus/note-dropdown-menus.svelte
@@ -83,7 +83,7 @@
           await onDelete?.();
         } catch {
           /**
-           * Deliberately does NOT return ConfirmModalResult.KeepOpen: the parent owns error
+           * Deliberately does NOT return confirmModalResult.KeepOpen: the parent owns error
            * reporting and this modal closed on failure before the migration too (it used
            * try/finally). Keeping that behaviour is intentional.
            */

--- a/app/frontend/src/routes/(protected)/(app)/organizations/[organizationId]/+layout.svelte
+++ b/app/frontend/src/routes/(protected)/(app)/organizations/[organizationId]/+layout.svelte
@@ -10,6 +10,7 @@
   import PageLoading from "@/components/app/page/page-loading.svelte";
   import PageProvider from "@/components/app/page/page-provider.svelte";
   import AddNewProjectButton from "@/components/app/projects/buttons/add-new-project-button.svelte";
+  import Text from "@/components/ui/text/Text.svelte";
 
   import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
   import { OrganizationRecord, organizationsBackendDataSource } from "@/data/model/iam/organizations/record";
@@ -61,9 +62,12 @@
     <PageLoading />
   {:then organization}
     <PageProvider name="organization-detail" roles={["admin", "org_owner"]} action="read" resource="iam:organizations">
-      <PageHeader title={organization.name}>
-        {#snippet actions()}
-          <OrganizationDropdownMenu {organizationId} align="end" />
+      <PageHeader>
+        {#snippet slotTitle()}
+          <div class="flex items-center gap-2">
+            <Text size="h2" weight="semibold">{organization.name}</Text>
+            <OrganizationDropdownMenu {organizationId} align="center" />
+          </div>
         {/snippet}
       </PageHeader>
 

--- a/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/datasets/[datasetId]/+layout.svelte
+++ b/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/datasets/[datasetId]/+layout.svelte
@@ -68,7 +68,22 @@
     return dataset;
   }
 
-  function handleTabChange(value: DatasetTab): void {
+  /**
+   * Tabs are a view of the URL, never their own state.
+   *
+   * bits-ui activates a trigger optimistically, before any navigation resolves. That would
+   * strand the tab on a destination the router never reached — the labels page cancels
+   * navigation when there are unsaved changes, so cancelling the prompt used to leave the
+   * tab on the page the user never went to.
+   *
+   * Preventing the event stops that activation: svelte-toolbelt's `composeHandlers` runs our
+   * handler before the primitive's and skips the rest once `defaultPrevented` is set. The
+   * tab therefore only moves when `activeTab` recomputes from a URL that actually changed.
+   */
+  function selectTab(event: Event, value: DatasetTab): void {
+    event.preventDefault();
+    if (value === activeTab) return;
+
     goto(resolve(`/projects/${projectId}/datasets/${datasetId}/${value}`));
   }
 </script>
@@ -88,10 +103,21 @@
         {/snippet}
       </PageHeader>
 
-      <Tabs bind:value={activeTab}>
+      <!-- One-way: the URL owns the selection, so a cancelled navigation leaves it untouched. -->
+      <Tabs value={activeTab} activationMode="manual">
         <TabsList>
           {#each tabs as { label, value } (value)}
-            <TabsTrigger {value} onclick={() => handleTabChange(value)}>{label}</TabsTrigger>
+            <TabsTrigger
+              {value}
+              onclick={(event) => selectTab(event, value)}
+              onkeydown={(event) => {
+                /* Enter/Space would otherwise activate optimistically and swallow the click. */
+                if (event.key !== "Enter" && event.key !== " ") return;
+                selectTab(event, value);
+              }}
+            >
+              {label}
+            </TabsTrigger>
           {/each}
         </TabsList>
       </Tabs>

--- a/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/datasets/[datasetId]/labels/+page.svelte
+++ b/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/datasets/[datasetId]/labels/+page.svelte
@@ -11,11 +11,11 @@
   import PageLoading from "@/components/app/page/page-loading.svelte";
   import Button from "@/components/ui/button/button.svelte";
   import Can from "@/security/can.svelte";
-  
+
   import { LabelConfigController } from "@/components/app/datasets/labels/label-config-controller.svelte";
   import {
-      isConfirmModalActive,
-      showConfirmModal,
+    isConfirmModalActive,
+    showConfirmModal,
   } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
   import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { projectBreadcrumb } from "@/components/app/page/breadcrumbs/constants";

--- a/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/datasets/[datasetId]/labels/+page.svelte
+++ b/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/datasets/[datasetId]/labels/+page.svelte
@@ -5,15 +5,19 @@
   import { SaveIcon } from "@lucide/svelte";
   import { getContext, onMount } from "svelte";
 
-  import LabelConfigEditor from "@/components/app/datasets/labels/label-config-editor.svelte";
-  import { LabelConfigController } from "@/components/app/datasets/labels/label-config-controller.svelte";
   import LabelConfigTemplateDropdownMenu from "@/components/app/datasets/labels/dropdown-menus/LabelConfigTemplateDropdownMenu.svelte";
-  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
+  import LabelConfigEditor from "@/components/app/datasets/labels/label-config-editor.svelte";
   import PageHeader from "@/components/app/page/page-header.svelte";
   import PageLoading from "@/components/app/page/page-loading.svelte";
   import Button from "@/components/ui/button/button.svelte";
   import Can from "@/security/can.svelte";
-
+  
+  import { LabelConfigController } from "@/components/app/datasets/labels/label-config-controller.svelte";
+  import {
+      isConfirmModalActive,
+      showConfirmModal,
+  } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
+  import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { projectBreadcrumb } from "@/components/app/page/breadcrumbs/constants";
   import { pageBreadcrumbsStore } from "@/components/app/page/breadcrumbs/stores";
   import { showToast } from "@/components/ui/toast/index.svelte";
@@ -23,7 +27,7 @@
   import { showActionFailedToast } from "@/utils/error/error.toasts";
 
   import type { ModalityShapes } from "@/data/model/setting/plugin/types";
-  import type { Resource, Scope, ProjectMemberScope } from "@/security/types";
+  import type { ProjectMemberScope, Resource, Scope } from "@/security/types";
 
   // Contexts
   const project: ProjectRecord = getContext("project");
@@ -38,10 +42,14 @@
   let modality = $state("");
   let shapes = $state<ModalityShapes>({});
   let loaded = $state(false);
-  let openUnsavedChangesModal = $state(false);
-  let pendingNavigationUrl = $state<URL | null>(null);
   // Set right before re-triggering goto() from the modal so beforeNavigate doesn't re-block it.
   let bypassNavigationGuard = false;
+
+  /** Outcomes of the unsaved-changes prompt, beyond the universal cancel. */
+  const UnsavedChangesChoice = {
+    Save: "save",
+    Discard: "discard",
+  } as const;
 
   const as_project_owner: { as_user: ProjectMemberScope } = {
     as_user: {
@@ -105,11 +113,7 @@
     }
   }
 
-  function leaveWithoutSaving() {
-    openUnsavedChangesModal = false;
-    const url = pendingNavigationUrl;
-    pendingNavigationUrl = null;
-    if (!url) return;
+  function leaveTo(url: URL): void {
     bypassNavigationGuard = true;
     // destination captured from SvelteKit's own beforeNavigate event, not a static route pattern.
     // eslint-disable-next-line svelte/no-navigation-without-resolve -- url is already a resolved
@@ -118,18 +122,38 @@
     });
   }
 
-  async function saveAndLeave() {
-    await saveLabelConfigChanges();
-    if (controller.hasUnsavedChanges) return; // save failed, stay on the page
-    leaveWithoutSaving();
+  async function confirmUnsavedChanges(url: URL): Promise<void> {
+    const choice = await showConfirmModal({
+      title: "Unsaved changes",
+      description: "You have unsaved changes. Do you want to save them before leaving the page?",
+      actions: [
+        { id: UnsavedChangesChoice.Discard, label: "Don't Save", variant: "outline" },
+        {
+          id: UnsavedChangesChoice.Save,
+          label: "Save",
+          pendingLabel: "Saving",
+          run: async () => {
+            await saveLabelConfigChanges();
+            // Save failed: keep the prompt up so the user can retry or leave without saving.
+            if (controller.hasUnsavedChanges) return ConfirmModalResult.KeepOpen;
+          },
+        },
+      ],
+    });
+    if (choice === ConfirmModalChoice.Cancel) return;
+
+    // Navigating inside `run` would run while the modal is still open.
+    leaveTo(url);
   }
 
-  // In-app navigation (e.g. clicking to another dataset): cancel and ask via ConfirmModal.
+  // In-app navigation (e.g. clicking to another dataset): cancel and ask before leaving.
   beforeNavigate((navigation) => {
     if (bypassNavigationGuard || !loaded || !controller.hasUnsavedChanges || !navigation.to) return;
+    // Already asking. The overlay blocks clicks but not the browser's Back button, so this
+    // guard is re-entrant; showConfirmModal() throws if called while a modal is open.
+    if (isConfirmModalActive()) return;
     navigation.cancel();
-    pendingNavigationUrl = navigation.to.url;
-    openUnsavedChangesModal = true;
+    void confirmUnsavedChanges(navigation.to.url);
   });
 
   // Tab close / refresh / external navigation: browsers only allow their own generic prompt.
@@ -178,17 +202,3 @@
 
   <LabelConfigEditor {modality} {shapes} {controller} {permission} {datasetId} allowDuplicateToDatasets />
 {/await}
-
-<ConfirmModal
-  title="Unsaved changes"
-  description="You have unsaved changes. Do you want to save them before leaving the page?"
-  onCancel={() => {
-    pendingNavigationUrl = null;
-  }}
-  bind:open={openUnsavedChangesModal}
->
-  {#snippet confirm()}
-    <Button variant="outline" onclick={leaveWithoutSaving}>Don't Save</Button>
-    <Button loading={saving} loadingLabel="Saving" onclick={saveAndLeave}>Save</Button>
-  {/snippet}
-</ConfirmModal>

--- a/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/datasets/[datasetId]/labels/+page.svelte
+++ b/app/frontend/src/routes/(protected)/(app)/projects/[projectId]/datasets/[datasetId]/labels/+page.svelte
@@ -17,7 +17,7 @@
     isConfirmModalActive,
     showConfirmModal,
   } from "@/components/app/overlays/modals/confirm-modal.service.svelte";
-  import { ConfirmModalChoice, ConfirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
+  import { ConfirmModalChoice, confirmModalResult } from "@/components/app/overlays/modals/confirm-modal.types";
   import { projectBreadcrumb } from "@/components/app/page/breadcrumbs/constants";
   import { pageBreadcrumbsStore } from "@/components/app/page/breadcrumbs/stores";
   import { showToast } from "@/components/ui/toast/index.svelte";
@@ -135,7 +135,7 @@
           run: async () => {
             await saveLabelConfigChanges();
             // Save failed: keep the prompt up so the user can retry or leave without saving.
-            if (controller.hasUnsavedChanges) return ConfirmModalResult.KeepOpen;
+            if (controller.hasUnsavedChanges) return confirmModalResult.KeepOpen;
           },
         },
       ],

--- a/app/frontend/src/routes/+layout.svelte
+++ b/app/frontend/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
   import { ModeWatcher } from "mode-watcher";
 
   import favicon from "@/components/app/brand/idah-logo-favicon.svg";
+  import ConfirmModal from "@/components/app/overlays/modals/confirm-modal.svelte";
 
   import { Toaster } from "@/components/ui/sonner";
 
@@ -37,6 +38,8 @@
       <TriangleAlertIcon class="size-4" />
     {/snippet}
   </Toaster>
+
+  <ConfirmModal />
 
   {@render children?.()}
 </main>


### PR DESCRIPTION
## Summary

Replaces 18 locally-rendered `<ConfirmModal>` instances across 15 files with a single renderer mounted once in `src/routes/+layout.svelte`. Callers now ask for a confirmation through `showConfirmModal()` and hold no modal state of their own.

The original scope of this branch — naming the record in delete dialogs — is included; the refactor grew out of it.

## Why

Every call site owned an `open` boolean, its own `<ConfirmModal>` markup, and its own close-timing policy. That drifted:

- **Escape never ran cancel cleanup.** `ConfirmModal` passed only `bind:open`, no `onOpenChange`, so `onCancel` never fired on Escape. Three sites used it purely for cleanup and were left with stale state.
- **Two dialogs never closed** after a successful confirm (`organization-owner-row-action-cell`, `project-member-role-cell`).
- Five of the call sites are data-table row cells, so a 50-row table held ~100 modal component instances.

## Approach

A single `<ConfirmModal />` in the root layout, driven by a module-scoped service.

Lifecycle is **hybrid, selected per action by the presence of `run`** — there is no mode flag:

```ts
// sync — closes on click
const choice = await showConfirmModal({ title, description, confirmLabel: "Yes, Overwrite" });
if (choice === ConfirmModalChoice.Cancel) return;

// async — stays open, shows pending, closes only on success
await showConfirmModal({
  title, description,
  onConfirm: async () => {
    try { await deleteThing(); showToast.success(…); }
    catch (error) { showToast.error(…); return ConfirmModalResult.KeepOpen; }
  },
});
```

Failure is signalled by a **return value, not an exception**, matching the convention already used by `entry-actions.ts` ("false on failure, toast already shown"). A thrown error is caught, logged, and treated as `KeepOpen` — a safety net so an unhandled rejection cannot silently close a destructive modal.

16 of the 18 call sites use async mode, preserving today's stay-open-on-error behaviour. `labels/+page.svelte` mixes both in one dialog: *Don't Save* is sync, *Save* keeps the prompt open when the save fails.

`run` must not navigate — it executes while the modal is open, where a `goto()` can trip a navigation guard. The four sites that navigate do so after the `await`.

## Behaviour changes

**Fixes**
- Escape now runs cancel cleanup everywhere.
- The two never-closing dialogs now close on success and stay open on failure.
- Bulk dataset delete read `"delete dataset 3 datasets?"` — fixed, now uses the existing `pluralizeUnit` helper.
- The bulk-delete success toast reported **"The 0 datasets have been deleted"**: `selectedDatasetsCount` is derived from a store that is cleared before the toast fires. The count is now captured up front.
- Dataset tabs no longer move optimistically. `<Tabs bind:value={activeTab}>` wrote back into a `$derived`, so cancelling the unsaved-changes prompt left the tab on a page the router never reached. The tab now follows the URL, and keyboard activation navigates instead of only moving the highlight.

**Intentional UX copy change — please review**
- "This action cannot be undone." added to the bulk dataset-delete dialog. This is new copy, not a migration artifact.

**Behaviour deliberately preserved**
- Stay-open-on-error on all 16 destructive actions.
- `note-dropdown-menus` closes on failure, as it did before via `try/finally` — the one place a `catch` intentionally omits `KeepOpen`, commented in place.

## Concurrency

Confirmations are strictly sequential; an overlapping `showConfirmModal()` throws. Two details worth a reviewer's attention:

- The guard checks "is someone awaiting a decision?" (`activeResolve`), **not** "is a modal on screen?" (`request`). `request` outlives the promise so the closing modal has something to render, so gating on it rejected a legitimate `await show(A); show(B)` for the length of the exit animation.
- `{#key request.id}` on the content payload is load-bearing *because* of that: a request can now replace another without passing through `null`, and without the key Svelte would reuse the previous content instance along with its in-flight fetch.

`labels/+page.svelte`'s `beforeNavigate` guard is re-entrant — the overlay blocks clicks but not the browser Back button — so it bails via `isConfirmModalActive()` rather than calling `showConfirmModal()` twice.

## Testing

31 unit/integration tests (23 service, 8 component), covering both lifecycle modes, `KeepOpen`, thrown-`run` handling, pending state, stale-result suppression, sequential confirms mid-exit-animation, and the SSR guard.

Manually verified in Chrome against the real components: dialog stacking and focus return over an open `Sheet`, Escape behaviour, and all six unsaved-changes navigation flows including browser Back.

`svelte-check` is unchanged at the repo baseline (186 errors / 44 files — all pre-existing). ESLint and Prettier are clean on all 26 files this branch touches; the 27 ESLint errors reported repo-wide are in `ui/` and `data/` files this branch does not touch. The 13 failing tests in the full suite are pre-existing and were verified against a clean worktree at `main`.

## Out of scope

Deliberately excluded, with reasoning: `FormModal` (29 files, holds form state — does not belong in a module singleton), the same optimistic-tab issue in the organizations/projects layouts (keyboard-only, no navigation guard there, so no user-visible bug), `AbortSignal` support for `run`, and `project-dataset-dropdown-menu`'s `datasetRecord?.name` which can render `"undefined"`.

## Notes for reviewers

- A `no-restricted-imports` ESLint rule enforces that only `src/routes/+layout.svelte` may import the component.
- `showConfirmModal` is a no-op under SSR — it logs in dev and resolves as cancelled.
- The bulk-delete copy addition above is the one change that is not behaviour-preserving by design.

ClickUp: CU-869ebfnc5
