### PR TITLE
IDAH Update Outdated Tooltip For Properties Visibility Field In Label Editor

### DIFF
--- a/app/frontend/src/lib/components/app/datasets/labels/properties/property-options.svelte
+++ b/app/frontend/src/lib/components/app/datasets/labels/properties/property-options.svelte
@@ -301,8 +301,8 @@
 
                 <p>
                   To target a specific category, enter a condition:<br />
-                  <code class="bg-secondary/20 rounded">value.category = "[category_id]"</code><br />
-                  Example: <code class="bg-secondary/20 rounded">value.category = "vehicles/car"</code>
+                  <code class="bg-secondary/20 rounded">annotation.category = "[category_id]"</code><br />
+                  Example: <code class="bg-secondary/20 rounded">annotation.category = "vehicles/car"</code>
                 </p>
                 <br />
 
@@ -310,7 +310,7 @@
                   To target multiple categories, combine conditions using "or":<br />
                   Example:
                   <code class="bg-secondary/20 rounded"
-                    >(value.category = "vehicles/car") or (value.category = "traffic-light")</code
+                    >(annotation.category = "vehicles/car") or (annotation.category = "traffic-light")</code
                   >
                 </p>
                 <br />


### PR DESCRIPTION
## Summary
Updates the Visibility field tooltip in the Label Editor to use the current expression syntax: `value.category` → `annotation.category`.

## Why
The tooltip still documented `value.category`, which no longer matches what the visibility parser accepts, so users copying the example got an invalid condition.

## Changes
- `property-options.svelte`: replaced `value.category` with `annotation.category` in the single-category example, the `[category_id]` template, and the multi-category `or` example.

## Testing
Docs-only string change inside the tooltip — no logic touched. Verify by hovering the Visibility info icon in the Label Editor and confirming the shown expression parses without a validation error.
