### PR TITLE
Frontend: idah-video mutli selection shape shift drag actions

### DIFF
--- a/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/_SelectedAnnotationsList.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/SelectionPanel/_SelectedAnnotationsList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Badge } from "$lib/components/ui/Badge";
   import Icon from "$lib/components/ui/Icon";
   import { Separator } from "$lib/components/ui/Separator";
   import Text from "$lib/components/ui/Text/Text.svelte";
@@ -41,6 +42,8 @@
   const showPagination = $derived(sourceItems.length > PAGE_SIZE);
   const placeholderCount = $derived(showPagination ? PAGE_SIZE - pagedAnnotations.length : 0);
 
+  const countLabel = $derived(`${sourceItems.length} ${sourceItems.length === 1 ? "annotation" : "annotations"}`);
+
   $effect(() => {
     if (page > totalPages) page = totalPages;
   });
@@ -48,8 +51,8 @@
 
 <section class="flex flex-col gap-2">
   <div class="flex items-center gap-2">
-    <Text weight="semibold">Selected</Text>
-    <span class="text-muted-foreground text-xs">{sourceItems.length} annotations</span>
+    <Text weight="semibold">Multiple selection</Text>
+    <Badge variant="info">{countLabel}</Badge>
   </div>
 
   <div class="flex flex-col gap-1">

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/BBoxShape.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/BBoxShape.svelte
@@ -390,7 +390,6 @@
           ? "cursor-grab"
           : "cursor-pointer",
   );
-
 </script>
 
 {#if pathD}
@@ -420,6 +419,12 @@
 
       // In review mode, let the event bubble for panning
       if (viewport.mode === "review") return;
+
+      // Shift+Drag over a shape that isn't part of an editable selection is a
+      // rectangle selection: let it bubble to the container. When the shape IS
+      // selected and editable, shift keeps its old meaning — grab and move the
+      // selection — so multi-shape drags still start here.
+      if (e.shiftKey && !(editable && selected)) return;
 
       if (editable && selected && cursor) {
         startSelection(cursor);

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/BBoxShape.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/BBoxShape.svelte
@@ -437,7 +437,10 @@
     }}
   />
 
-  {#if editable && selected && !isEditing && displayPoints.length === 4}
+  <!-- Handles hide while the shape is edited, and while ANY shape in a multi-selection
+       is dragged: multiDragDelta is non-null for the whole group drag, so the read-only
+       dots on the shapes being carried along disappear with the dragged one's. -->
+  {#if editable && selected && !isEditing && !multiDragDelta && displayPoints.length === 4}
     <BBoxHandler
       {displayPoints}
       {centroidN}

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/BoundingBox/_BBoxHandler.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/BoundingBox/_BBoxHandler.svelte
@@ -103,272 +103,266 @@
   <!-- Read-only (multi-select): inert gray dots at each handle position, no rotation handle -->
   <g style:transform-origin="{centroidPx[0]}px {centroidPx[1]}px" style:transform="rotate({currentAngle}rad)">
     {#each boundingBoxHandle(displayPoints) as point, handleIndex (handleIndex)}
-      <circle
-        cx={point[0] * w}
-        cy={point[1] * h}
-        r={R}
-        fill="#9ca3af"
-        pointer-events="none"
-      />
+      <circle cx={point[0] * w} cy={point[1] * h} r={R / 2} fill="#9ca3af" pointer-events="none" />
     {/each}
   </g>
 {:else}
-<g style:transform-origin="{centroidPx[0]}px {centroidPx[1]}px" style:transform="rotate({currentAngle}rad)">
-  <!-- Rotation line + handle -->
-  <line
-    x1={rotationLayout.topMidN[0] * w}
-    y1={rotationLayout.topMidN[1] * h}
-    x2={rotationLayout.topMidN[0] * w}
-    y2={(rotationLayout.topMidN[1] - rotationLayout.rotOffset) * h}
-    stroke={color}
-    stroke-width={S_line}
-    pointer-events="none"
-  />
-  <!-- Rotation top dot: white outline + filled center -->
-  <!-- White halo for contrast → expands on hover -->
-  <circle
-    cx={rotationLayout.topMidN[0] * w}
-    cy={(rotationLayout.topMidN[1] - rotationLayout.rotOffset) * h}
-    r={hoveredRotate ? R_hovered : R_hit}
-    fill="white"
-    fill-opacity={hoveredRotate ? 0.8 : 0.6}
-    pointer-events="none"
-  />
-  <circle
-    cx={rotationLayout.topMidN[0] * w}
-    cy={(rotationLayout.topMidN[1] - rotationLayout.rotOffset) * h}
-    r={R_rotate_dot}
-    fill={color}
-    pointer-events="none"
-  />
-  <circle
-    role="slider"
-    tabindex="0"
-    style:outline="none"
-    aria-valuenow={currentAngle * (180 / Math.PI)}
-    onmouseenter={() => (hoveredRotate = true)}
-    onmouseleave={() => (hoveredRotate = false)}
-    onmousedown={(e) => {
-      e.stopPropagation();
-      const cp: Point = [centroidN[0] * w, centroidN[1] * h];
-      onStartRotate(cp);
-    }}
-    cx={rotationLayout.topMidN[0] * w}
-    cy={(rotationLayout.topMidN[1] - rotationLayout.rotOffset) * h}
-    r={R_rotate_hit}
-    fill="transparent"
-    style:cursor={isEditing ? "none" : `url('${rotateCursorSVG(color)}') 18 18, grab`}
-  />
-  <circle
-    cx={rotationLayout.topMidN[0] * w}
-    cy={(rotationLayout.topMidN[1] - rotationLayout.rotOffset) * h}
-    r={hoveredRotate ? R_rotate_hovered : R_rotate}
-    fill={color}
-    fill-opacity={rotateFillOpacity}
-    stroke={color}
-    stroke-width={S_line}
-    pointer-events="none"
-  />
-
-  <!-- Resize handles -->
-  {#each boundingBoxHandle(displayPoints) as point, handleIndex (handleIndex)}
-    {@const isHovered = hoveredHandleIndex === handleIndex}
-    {@const curR = isHovered ? R_hovered : R}
-    {@const curFillOpacity = isHovered ? 0.5 : 0.25}
-    <!-- White halo for contrast → expands on hover -->
-    <circle
-      cx={point[0] * w}
-      cy={point[1] * h}
-      r={isHovered ? R_hovered : R_hit}
-      fill="white"
-      fill-opacity={isHovered ? 0.8 : 0.6}
-      pointer-events="none"
-    />
-    <!-- Transparent hit zone -->
-    <circle
-      role="grid"
-      tabindex="-1"
-      style:outline="none"
-      onmouseenter={() => (hoveredHandleIndex = handleIndex)}
-      onmouseleave={() => (hoveredHandleIndex = undefined)}
-      onmousedown={(e) => {
-        e.stopPropagation();
-        onStartResize(handleIndex);
-      }}
-      cx={point[0] * w}
-      cy={point[1] * h}
-      r={R_hit}
-      fill="transparent"
-      style:cursor={isEditing
-        ? "none"
-        : `url('${rotatedCursorSVG(handleIndex, currentAngle, color)}') 18 18, ${handleCursor(handleIndex)}`}
-    />
-    <!-- Filled handle ring → grows and deepens on hover -->
-    <circle
-      cx={point[0] * w}
-      cy={point[1] * h}
-      r={curR}
-      fill={color}
-      fill-opacity={curFillOpacity}
+  <g style:transform-origin="{centroidPx[0]}px {centroidPx[1]}px" style:transform="rotate({currentAngle}rad)">
+    <!-- Rotation line + handle -->
+    <line
+      x1={rotationLayout.topMidN[0] * w}
+      y1={rotationLayout.topMidN[1] * h}
+      x2={rotationLayout.topMidN[0] * w}
+      y2={(rotationLayout.topMidN[1] - rotationLayout.rotOffset) * h}
       stroke={color}
       stroke-width={S_line}
       pointer-events="none"
     />
-    <!-- Center dot -->
-    <circle cx={point[0] * w} cy={point[1] * h} r={R_center_dot} fill={color} pointer-events="none" />
-  {/each}
-</g>
+    <!-- Rotation top dot: white outline + filled center -->
+    <!-- White halo for contrast → expands on hover -->
+    <circle
+      cx={rotationLayout.topMidN[0] * w}
+      cy={(rotationLayout.topMidN[1] - rotationLayout.rotOffset) * h}
+      r={hoveredRotate ? R_hovered : R_hit}
+      fill="white"
+      fill-opacity={hoveredRotate ? 0.8 : 0.6}
+      pointer-events="none"
+    />
+    <circle
+      cx={rotationLayout.topMidN[0] * w}
+      cy={(rotationLayout.topMidN[1] - rotationLayout.rotOffset) * h}
+      r={R_rotate_dot}
+      fill={color}
+      pointer-events="none"
+    />
+    <circle
+      role="slider"
+      tabindex="0"
+      style:outline="none"
+      aria-valuenow={currentAngle * (180 / Math.PI)}
+      onmouseenter={() => (hoveredRotate = true)}
+      onmouseleave={() => (hoveredRotate = false)}
+      onmousedown={(e) => {
+        e.stopPropagation();
+        const cp: Point = [centroidN[0] * w, centroidN[1] * h];
+        onStartRotate(cp);
+      }}
+      cx={rotationLayout.topMidN[0] * w}
+      cy={(rotationLayout.topMidN[1] - rotationLayout.rotOffset) * h}
+      r={R_rotate_hit}
+      fill="transparent"
+      style:cursor={isEditing ? "none" : `url('${rotateCursorSVG(color)}') 18 18, grab`}
+    />
+    <circle
+      cx={rotationLayout.topMidN[0] * w}
+      cy={(rotationLayout.topMidN[1] - rotationLayout.rotOffset) * h}
+      r={hoveredRotate ? R_rotate_hovered : R_rotate}
+      fill={color}
+      fill-opacity={rotateFillOpacity}
+      stroke={color}
+      stroke-width={S_line}
+      pointer-events="none"
+    />
 
-<!-- Rotation preview line -->
-{#if rotateStart && cursorPx}
-  <line
-    x1={centroidPx[0]}
-    y1={centroidPx[1]}
-    x2={cursorPx[0]}
-    y2={cursorPx[1]}
-    stroke={color}
-    stroke-width={S_line}
-    stroke-dasharray="5,5"
+    <!-- Resize handles -->
+    {#each boundingBoxHandle(displayPoints) as point, handleIndex (handleIndex)}
+      {@const isHovered = hoveredHandleIndex === handleIndex}
+      {@const curR = isHovered ? R_hovered : R}
+      {@const curFillOpacity = isHovered ? 0.5 : 0.25}
+      <!-- White halo for contrast → expands on hover -->
+      <circle
+        cx={point[0] * w}
+        cy={point[1] * h}
+        r={isHovered ? R_hovered : R_hit}
+        fill="white"
+        fill-opacity={isHovered ? 0.8 : 0.6}
+        pointer-events="none"
+      />
+      <!-- Transparent hit zone -->
+      <circle
+        role="grid"
+        tabindex="-1"
+        style:outline="none"
+        onmouseenter={() => (hoveredHandleIndex = handleIndex)}
+        onmouseleave={() => (hoveredHandleIndex = undefined)}
+        onmousedown={(e) => {
+          e.stopPropagation();
+          onStartResize(handleIndex);
+        }}
+        cx={point[0] * w}
+        cy={point[1] * h}
+        r={R_hit}
+        fill="transparent"
+        style:cursor={isEditing
+          ? "none"
+          : `url('${rotatedCursorSVG(handleIndex, currentAngle, color)}') 18 18, ${handleCursor(handleIndex)}`}
+      />
+      <!-- Filled handle ring → grows and deepens on hover -->
+      <circle
+        cx={point[0] * w}
+        cy={point[1] * h}
+        r={curR}
+        fill={color}
+        fill-opacity={curFillOpacity}
+        stroke={color}
+        stroke-width={S_line}
+        pointer-events="none"
+      />
+      <!-- Center dot -->
+      <circle cx={point[0] * w} cy={point[1] * h} r={R_center_dot} fill={color} pointer-events="none" />
+    {/each}
+  </g>
+
+  <!-- Rotation preview line -->
+  {#if rotateStart && cursorPx}
+    <line
+      x1={centroidPx[0]}
+      y1={centroidPx[1]}
+      x2={cursorPx[0]}
+      y2={cursorPx[1]}
+      stroke={color}
+      stroke-width={S_line}
+      stroke-dasharray="5,5"
+      pointer-events="none"
+    />
+  {/if}
+  <!-- Revolution controls -->
+  <!-- White halo for contrast → expands on hover -->
+  <circle
+    cx={rotationLayout.rotHPxX - S_offset}
+    cy={rotationLayout.rotHPxY}
+    r={hoveredRevMinus ? R_hovered : R_hit}
+    fill="white"
+    fill-opacity={hoveredRevMinus ? 0.8 : 0.6}
     pointer-events="none"
   />
-{/if}
-<!-- Revolution controls -->
-<!-- White halo for contrast → expands on hover -->
-<circle
-  cx={rotationLayout.rotHPxX - S_offset}
-  cy={rotationLayout.rotHPxY}
-  r={hoveredRevMinus ? R_hovered : R_hit}
-  fill="white"
-  fill-opacity={hoveredRevMinus ? 0.8 : 0.6}
-  pointer-events="none"
-/>
 
-<circle
-  cx={rotationLayout.rotHPxX + S_offset}
-  cy={rotationLayout.rotHPxY}
-  r={hoveredRevPlus ? R_hovered : R_hit}
-  fill="white"
-  fill-opacity={hoveredRevPlus ? 0.8 : 0.6}
-  pointer-events="none"
-/>
-<circle
-  role="button"
-  tabindex="-1"
-  style:outline="none"
-  onmouseenter={() => (hoveredRevMinus = true)}
-  onmouseleave={() => (hoveredRevMinus = false)}
-  cx={rotationLayout.rotHPxX - S_offset}
-  cy={rotationLayout.rotHPxY}
-  r={hoveredRevMinus ? R_rev_hovered : R_rev}
-  fill={color}
-  fill-opacity={revMinusFillOpacity}
-  stroke={color}
-  stroke-width={S_line}
-  style:cursor="pointer"
-  onmousedown={(e) => {
-    e.stopPropagation();
-    onDecrementRevolution();
-  }}
-/>
-{#if hoveredRevMinus}
+  <circle
+    cx={rotationLayout.rotHPxX + S_offset}
+    cy={rotationLayout.rotHPxY}
+    r={hoveredRevPlus ? R_hovered : R_hit}
+    fill="white"
+    fill-opacity={hoveredRevPlus ? 0.8 : 0.6}
+    pointer-events="none"
+  />
+  <circle
+    role="button"
+    tabindex="-1"
+    style:outline="none"
+    onmouseenter={() => (hoveredRevMinus = true)}
+    onmouseleave={() => (hoveredRevMinus = false)}
+    cx={rotationLayout.rotHPxX - S_offset}
+    cy={rotationLayout.rotHPxY}
+    r={hoveredRevMinus ? R_rev_hovered : R_rev}
+    fill={color}
+    fill-opacity={revMinusFillOpacity}
+    stroke={color}
+    stroke-width={S_line}
+    style:cursor="pointer"
+    onmousedown={(e) => {
+      e.stopPropagation();
+      onDecrementRevolution();
+    }}
+  />
+  {#if hoveredRevMinus}
+    <line
+      x1={rotationLayout.rotHPxX - S_offset - L_rev}
+      y1={rotationLayout.rotHPxY}
+      x2={rotationLayout.rotHPxX - S_offset + L_rev}
+      y2={rotationLayout.rotHPxY}
+      stroke="white"
+      stroke-width={S_line_hovered}
+      pointer-events="none"
+      stroke-linecap="round"
+    />
+  {/if}
   <line
     x1={rotationLayout.rotHPxX - S_offset - L_rev}
     y1={rotationLayout.rotHPxY}
     x2={rotationLayout.rotHPxX - S_offset + L_rev}
     y2={rotationLayout.rotHPxY}
-    stroke="white"
-    stroke-width={S_line_hovered}
+    stroke={color}
+    stroke-width={S_line}
     pointer-events="none"
-    stroke-linecap="round"
   />
-{/if}
-<line
-  x1={rotationLayout.rotHPxX - S_offset - L_rev}
-  y1={rotationLayout.rotHPxY}
-  x2={rotationLayout.rotHPxX - S_offset + L_rev}
-  y2={rotationLayout.rotHPxY}
-  stroke={color}
-  stroke-width={S_line}
-  pointer-events="none"
-/>
 
-<text
-  x={rotationLayout.rotHPxX}
-  y={rotationLayout.rotHPxY - S_offset}
-  text-anchor="middle"
-  dominant-baseline="central"
-  style:font-size="{S_font}px"
-  style:font-weight="bold"
-  style:fill={color}
-  style:paint-order="stroke"
-  style:stroke="white"
-  style:stroke-width="{S_font / 6}px"
-  style:stroke-linecap="round"
-  style:stroke-linejoin="round"
-  style:pointer-events="none"
-  style:user-select="none"
->
-  {(currentAngle * (180 / Math.PI)).toFixed(1)}° {revolutionDisplay}
-</text>
+  <text
+    x={rotationLayout.rotHPxX}
+    y={rotationLayout.rotHPxY - S_offset}
+    text-anchor="middle"
+    dominant-baseline="central"
+    style:font-size="{S_font}px"
+    style:font-weight="bold"
+    style:fill={color}
+    style:paint-order="stroke"
+    style:stroke="white"
+    style:stroke-width="{S_font / 6}px"
+    style:stroke-linecap="round"
+    style:stroke-linejoin="round"
+    style:pointer-events="none"
+    style:user-select="none"
+  >
+    {(currentAngle * (180 / Math.PI)).toFixed(1)}° {revolutionDisplay}
+  </text>
 
-<circle
-  role="button"
-  tabindex="-1"
-  style:outline="none"
-  onmouseenter={() => (hoveredRevPlus = true)}
-  onmouseleave={() => (hoveredRevPlus = false)}
-  cx={rotationLayout.rotHPxX + S_offset}
-  cy={rotationLayout.rotHPxY}
-  r={hoveredRevPlus ? R_rev_hovered : R_rev}
-  fill={color}
-  fill-opacity={revPlusFillOpacity}
-  stroke={color}
-  stroke-width={S_line}
-  style:cursor="pointer"
-  onmousedown={(e) => {
-    e.stopPropagation();
-    onIncrementRevolution();
-  }}
-/>
+  <circle
+    role="button"
+    tabindex="-1"
+    style:outline="none"
+    onmouseenter={() => (hoveredRevPlus = true)}
+    onmouseleave={() => (hoveredRevPlus = false)}
+    cx={rotationLayout.rotHPxX + S_offset}
+    cy={rotationLayout.rotHPxY}
+    r={hoveredRevPlus ? R_rev_hovered : R_rev}
+    fill={color}
+    fill-opacity={revPlusFillOpacity}
+    stroke={color}
+    stroke-width={S_line}
+    style:cursor="pointer"
+    onmousedown={(e) => {
+      e.stopPropagation();
+      onIncrementRevolution();
+    }}
+  />
 
-{#if hoveredRevPlus}
+  {#if hoveredRevPlus}
+    <line
+      x1={rotationLayout.rotHPxX + S_offset - L_rev}
+      y1={rotationLayout.rotHPxY}
+      x2={rotationLayout.rotHPxX + S_offset + L_rev}
+      y2={rotationLayout.rotHPxY}
+      stroke="white"
+      stroke-width={S_line_hovered}
+      pointer-events="none"
+      stroke-linecap="round"
+    />
+    <line
+      x1={rotationLayout.rotHPxX + S_offset}
+      y1={rotationLayout.rotHPxY - L_rev}
+      x2={rotationLayout.rotHPxX + S_offset}
+      y2={rotationLayout.rotHPxY + L_rev}
+      stroke="white"
+      stroke-width={S_line_hovered}
+      pointer-events="none"
+      stroke-linecap="round"
+    />
+  {/if}
   <line
     x1={rotationLayout.rotHPxX + S_offset - L_rev}
     y1={rotationLayout.rotHPxY}
     x2={rotationLayout.rotHPxX + S_offset + L_rev}
     y2={rotationLayout.rotHPxY}
-    stroke="white"
-    stroke-width={S_line_hovered}
+    stroke={color}
+    stroke-width={S_line}
     pointer-events="none"
-    stroke-linecap="round"
   />
   <line
     x1={rotationLayout.rotHPxX + S_offset}
     y1={rotationLayout.rotHPxY - L_rev}
     x2={rotationLayout.rotHPxX + S_offset}
     y2={rotationLayout.rotHPxY + L_rev}
-    stroke="white"
-    stroke-width={S_line_hovered}
+    stroke={color}
+    stroke-width={S_line}
     pointer-events="none"
-    stroke-linecap="round"
   />
-{/if}
-<line
-  x1={rotationLayout.rotHPxX + S_offset - L_rev}
-  y1={rotationLayout.rotHPxY}
-  x2={rotationLayout.rotHPxX + S_offset + L_rev}
-  y2={rotationLayout.rotHPxY}
-  stroke={color}
-  stroke-width={S_line}
-  pointer-events="none"
-/>
-<line
-  x1={rotationLayout.rotHPxX + S_offset}
-  y1={rotationLayout.rotHPxY - L_rev}
-  x2={rotationLayout.rotHPxX + S_offset}
-  y2={rotationLayout.rotHPxY + L_rev}
-  stroke={color}
-  stroke-width={S_line}
-  pointer-events="none"
-/>
 {/if}

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/Polygon/_PolygonHandler.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/Polygon/_PolygonHandler.svelte
@@ -74,150 +74,144 @@
   <!-- Read-only (multi-select): inert gray dots at vertices only → no edge
        diamonds, no scale handle, no interactivity -->
   {#each vertexHandles as point, i (i)}
-    <circle
-      cx={point[0] * w}
-      cy={point[1] * h}
-      r={R}
-      fill="#9ca3af"
-      pointer-events="none"
-    />
+    <circle cx={point[0] * w} cy={point[1] * h} r={R / 2} fill="#9ca3af" pointer-events="none" />
   {/each}
 {:else}
-<!-- Edge midpoint handles (diamond shape) -->
-{#each edgeMidpoints as point, i (i)}
-  {@const isHovered = hoveredEdgeIndex === i}
-  {@const cx = point[0] * w}
-  {@const cy = point[1] * h}
-  {@const r = isHovered ? R_edge_hovered : R_edge}
-  <polygon
-    points={`${cx},${cy - r} ${cx + r},${cy} ${cx},${cy + r} ${cx - r},${cy}`}
-    fill="grey"
-    stroke="white"
-    stroke-width={S_line}
-    stroke-linejoin="round"
-    pointer-events="none"
-  />
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <polygon
-    points={`${cx},${cy - R_edge_hit} ${cx + R_edge_hit},${cy} ${cx},${cy + R_edge_hit} ${cx - R_edge_hit},${cy}`}
-    fill="transparent"
-    style:outline="none"
-    style:cursor={isEditing ? "default" : addCursorCss}
-    onmouseenter={() => (hoveredEdgeIndex = i)}
-    onmouseleave={() => (hoveredEdgeIndex = undefined)}
-    onmousedown={(e) => {
-      e.stopPropagation();
-      onAddVertex(i);
-    }}
-  />
-{/each}
+  <!-- Edge midpoint handles (diamond shape) -->
+  {#each edgeMidpoints as point, i (i)}
+    {@const isHovered = hoveredEdgeIndex === i}
+    {@const cx = point[0] * w}
+    {@const cy = point[1] * h}
+    {@const r = isHovered ? R_edge_hovered : R_edge}
+    <polygon
+      points={`${cx},${cy - r} ${cx + r},${cy} ${cx},${cy + r} ${cx - r},${cy}`}
+      fill="grey"
+      stroke="white"
+      stroke-width={S_line}
+      stroke-linejoin="round"
+      pointer-events="none"
+    />
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <polygon
+      points={`${cx},${cy - R_edge_hit} ${cx + R_edge_hit},${cy} ${cx},${cy + R_edge_hit} ${cx - R_edge_hit},${cy}`}
+      fill="transparent"
+      style:outline="none"
+      style:cursor={isEditing ? "default" : addCursorCss}
+      onmouseenter={() => (hoveredEdgeIndex = i)}
+      onmouseleave={() => (hoveredEdgeIndex = undefined)}
+      onmousedown={(e) => {
+        e.stopPropagation();
+        onAddVertex(i);
+      }}
+    />
+  {/each}
 
-<!-- Vertex handles -->
-{#each vertexHandles as point, i (i)}
-  {@const isHovered = hoveredVertexIndex === i}
-  {@const isSelected = selectedIndices.has(i)}
-  {@const curR = isHovered || isSelected ? R_hovered : R}
-  <!-- White halo for contrast -->
-  <circle
-    cx={point[0] * w}
-    cy={point[1] * h}
-    r={isHovered || isSelected ? R_hovered : R}
-    fill="white"
-    fill-opacity={isHovered ? 0.8 : 0.6}
-    pointer-events="none"
-  />
-  <circle
-    cx={point[0] * w}
-    cy={point[1] * h}
-    r={curR}
-    fill={color}
-    fill-opacity={isSelected ? 0.7 : isHovered ? 0.5 : 0.25}
-    stroke={color}
-    stroke-width={isSelected ? S_line * 2 : S_line}
-    pointer-events="none"
-  />
-  <circle cx={point[0] * w} cy={point[1] * h} r={R_dot} fill={color} pointer-events="none" />
-  {#if isSelected}
+  <!-- Vertex handles -->
+  {#each vertexHandles as point, i (i)}
+    {@const isHovered = hoveredVertexIndex === i}
+    {@const isSelected = selectedIndices.has(i)}
+    {@const curR = isHovered || isSelected ? R_hovered : R}
+    <!-- White halo for contrast -->
     <circle
       cx={point[0] * w}
       cy={point[1] * h}
-      r={R_hovered + 3 * invScale}
-      fill="none"
-      stroke={color}
-      stroke-width={1.5}
-      stroke-dasharray="3,2"
-      vector-effect="non-scaling-stroke"
+      r={isHovered || isSelected ? R_hovered : R}
+      fill="white"
+      fill-opacity={isHovered ? 0.8 : 0.6}
       pointer-events="none"
     />
-  {/if}
-  <!-- Minus icon when Alt+hover (delete mode) -->
-  {#if isHovered && altHeld}
-    <line
-      x1={point[0] * w - R_dot}
-      y1={point[1] * h}
-      x2={point[0] * w + R_dot}
-      y2={point[1] * h}
+    <circle
+      cx={point[0] * w}
+      cy={point[1] * h}
+      r={curR}
+      fill={color}
+      fill-opacity={isSelected ? 0.7 : isHovered ? 0.5 : 0.25}
       stroke={color}
-      stroke-width={S_line * 2}
-      stroke-linecap="round"
+      stroke-width={isSelected ? S_line * 2 : S_line}
       pointer-events="none"
     />
-  {/if}
-  <!-- Hit zone -->
+    <circle cx={point[0] * w} cy={point[1] * h} r={R_dot} fill={color} pointer-events="none" />
+    {#if isSelected}
+      <circle
+        cx={point[0] * w}
+        cy={point[1] * h}
+        r={R_hovered + 3 * invScale}
+        fill="none"
+        stroke={color}
+        stroke-width={1.5}
+        stroke-dasharray="3,2"
+        vector-effect="non-scaling-stroke"
+        pointer-events="none"
+      />
+    {/if}
+    <!-- Minus icon when Alt+hover (delete mode) -->
+    {#if isHovered && altHeld}
+      <line
+        x1={point[0] * w - R_dot}
+        y1={point[1] * h}
+        x2={point[0] * w + R_dot}
+        y2={point[1] * h}
+        stroke={color}
+        stroke-width={S_line * 2}
+        stroke-linecap="round"
+        pointer-events="none"
+      />
+    {/if}
+    <!-- Hit zone -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <circle
+      cx={point[0] * w}
+      cy={point[1] * h}
+      r={R_hit}
+      fill="transparent"
+      style:outline="none"
+      style:cursor={altHeld ? removeCursorCss : isEditing ? "none" : "move"}
+      onmouseenter={() => (hoveredVertexIndex = i)}
+      onmouseleave={() => (hoveredVertexIndex = undefined)}
+      onmousedown={(e) => {
+        e.stopPropagation();
+        if (e.altKey) onDeleteVertex(i);
+        else onStartVertexDrag(i);
+      }}
+    />
+  {/each}
+
+  <!-- Scale handle at centroid -->
+  <!-- White halo for contrast -->
+  <circle
+    cx={centroid[0] * w}
+    cy={centroid[1] * h}
+    r={hoveredScale ? R_scale_hovered : R_scale}
+    fill="white"
+    fill-opacity={hoveredScale ? 0.8 : 0.6}
+    pointer-events="none"
+  />
+  <circle
+    cx={centroid[0] * w}
+    cy={centroid[1] * h}
+    r={hoveredScale ? R_scale_hovered : R_scale}
+    fill={color}
+    fill-opacity={hoveredScale ? 0.4 : 0.2}
+    stroke={color}
+    stroke-width={S_line}
+    pointer-events="none"
+  />
+  <circle cx={centroid[0] * w} cy={centroid[1] * h} r={R_scale_dot} fill={color} pointer-events="none" />
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <circle
-    cx={point[0] * w}
-    cy={point[1] * h}
-    r={R_hit}
+    cx={centroid[0] * w}
+    cy={centroid[1] * h}
+    r={R_scale_hit}
     fill="transparent"
     style:outline="none"
-    style:cursor={altHeld ? removeCursorCss : isEditing ? "none" : "move"}
-    onmouseenter={() => (hoveredVertexIndex = i)}
-    onmouseleave={() => (hoveredVertexIndex = undefined)}
+    style:cursor={isEditing ? "none" : `url('${scaleCursorSVG("black")}') 12 12, nesw-resize`}
+    onmouseenter={() => (hoveredScale = true)}
+    onmouseleave={() => (hoveredScale = false)}
     onmousedown={(e) => {
       e.stopPropagation();
-      if (e.altKey) onDeleteVertex(i);
-      else onStartVertexDrag(i);
+      onStartScale();
     }}
   />
-{/each}
-
-<!-- Scale handle at centroid -->
-<!-- White halo for contrast -->
-<circle
-  cx={centroid[0] * w}
-  cy={centroid[1] * h}
-  r={hoveredScale ? R_scale_hovered : R_scale}
-  fill="white"
-  fill-opacity={hoveredScale ? 0.8 : 0.6}
-  pointer-events="none"
-/>
-<circle
-  cx={centroid[0] * w}
-  cy={centroid[1] * h}
-  r={hoveredScale ? R_scale_hovered : R_scale}
-  fill={color}
-  fill-opacity={hoveredScale ? 0.4 : 0.2}
-  stroke={color}
-  stroke-width={S_line}
-  pointer-events="none"
-/>
-<circle cx={centroid[0] * w} cy={centroid[1] * h} r={R_scale_dot} fill={color} pointer-events="none" />
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<circle
-  cx={centroid[0] * w}
-  cy={centroid[1] * h}
-  r={R_scale_hit}
-  fill="transparent"
-  style:outline="none"
-  style:cursor={isEditing ? "none" : `url('${scaleCursorSVG("black")}') 12 12, nesw-resize`}
-  onmouseenter={() => (hoveredScale = true)}
-  onmouseleave={() => (hoveredScale = false)}
-  onmousedown={(e) => {
-    e.stopPropagation();
-    onStartScale();
-  }}
-/>
 {/if}
 
 <!-- Box selection overlay -->

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/PolygonShape.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/PolygonShape.svelte
@@ -261,7 +261,6 @@
           ? "cursor-grab"
           : "cursor-pointer",
   );
-
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -299,6 +298,12 @@
 
       // In review mode, let the event bubble for panning
       if (viewport.mode === "review") return;
+
+      // Shift+Drag over a shape that isn't part of an editable selection is a
+      // rectangle selection: let it bubble to the container. When the shape IS
+      // selected and editable, shift keeps its old meaning — grab and move the
+      // selection — so multi-shape drags still start here.
+      if (e.shiftKey && !(editable && selected)) return;
 
       if (editable && selected) {
         // Convert client coords to SVG viewBox coords, then to normalized (0-1) media coords.

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/PolygonShape.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/PolygonShape.svelte
@@ -332,7 +332,9 @@
     }}
   />
 
-  {#if editable && selected && !isEditing && displayVertices.length >= 3}
+  <!-- See BBoxShape: !multiDragDelta hides the read-only dots on every shape in the
+       group while any one of them is being dragged. -->
+  {#if editable && selected && !isEditing && !multiDragDelta && displayVertices.length >= 3}
     <PolygonHandler
       vertices={displayVertices}
       {color}

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
@@ -49,6 +49,7 @@
   import noteIconSvg from "$lib/assets/icons/message-circle.svg?raw";
   import { draft as polygonDraft } from "$lib/commands/annotation/polygon.add_point.svelte";
   import { nearFirstPolygonPoint } from "./Polygon/utils";
+  import { rotatePointN } from "./BoundingBox/utils";
   import type { IAnnotationRecord } from "$idah/v2/types";
   import {
     NON_DRAWABLE_SHAPE_TYPES,
@@ -491,8 +492,21 @@
     const interp = getInterpolatedFrame(shape, viewport.video.displayedFrame.value);
     if (!interp?.points?.length) return null;
 
-    const xs = interp.points.map((p) => p[0]);
-    const ys = interp.points.map((p) => p[1]);
+    // `points` holds the unrotated corners — `angle` is applied as a render
+    // transform around the centroid (see BBoxShape's transform-origin), so the
+    // box must be rotated the same way here. Otherwise a rotated annotation is
+    // hit-tested against the bounds it would occupy at 0°, which is not where
+    // the user sees it. rotatePointN does the math in pixel space, matching the
+    // render; polygons carry no angle and skip this untouched.
+    const angle = interp.angle ?? 0;
+    let pts = interp.points;
+    if (angle !== 0 && media.width > 0 && media.height > 0) {
+      const center = centroidUtil(pts);
+      pts = pts.map((p) => rotatePointN(p, center, angle, media.width, media.height));
+    }
+
+    const xs = pts.map((p) => p[0]);
+    const ys = pts.map((p) => p[1]);
     return [Math.min(...xs), Math.min(...ys), Math.max(...xs), Math.max(...ys)];
   }
 

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
@@ -1002,7 +1002,7 @@
         height={(selectionRect[3] - selectionRect[1]) * media.height}
         fill="rgba(59, 130, 246, 0.2)"
         stroke="#3b82f6"
-        stroke-width={1.5 / viewport.workspace.transform.scale}
+        stroke-width={1.5}
         vector-effect="non-scaling-stroke"
         pointer-events="none"
       />

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
@@ -50,7 +50,12 @@
   import { draft as polygonDraft } from "$lib/commands/annotation/polygon.add_point.svelte";
   import { nearFirstPolygonPoint } from "./Polygon/utils";
   import type { IAnnotationRecord } from "$idah/v2/types";
-  import { NON_DRAWABLE_SHAPE_TYPES, type IVideoAnnotationRecord, type IVideoAnnotationShape, type IVideoFrameSelection } from "$lib/types";
+  import {
+    NON_DRAWABLE_SHAPE_TYPES,
+    type IVideoAnnotationRecord,
+    type IVideoAnnotationShape,
+    type IVideoFrameSelection,
+  } from "$lib/types";
   import type { Point } from "$lib/utils/math/point";
   import { centroid as centroidUtil } from "$lib/utils/math/point";
   import { getInterpolatedFrame } from "$lib/utils/interpolation";
@@ -244,9 +249,62 @@
   let rectStart: Point | null = $state(null);
   let rectEnd: Point | null = $state(null);
 
+  /** Screen-pixel movement below which a press-and-release still counts as a click, not a drag. */
+  const DRAG_SLOP_PX = 4;
+
+  /**
+   * Client position of the most recent mousedown, recorded in the capture phase
+   * so it is captured even for presses a shape stops on the bubble phase. Comparing
+   * against it tells a real click apart from the click that trails every drag —
+   * no flag to set, so nothing can go stale between gestures.
+   */
+  let _mouseDownClient: Point | null = null;
+
+  /** Whether the pointer moved past the slop between the last mousedown and this event. */
+  function movedSinceMouseDown(e: MouseEvent): boolean {
+    if (!_mouseDownClient) return false;
+    return (
+      Math.abs(e.clientX - _mouseDownClient[0]) > DRAG_SLOP_PX ||
+      Math.abs(e.clientY - _mouseDownClient[1]) > DRAG_SLOP_PX
+    );
+  }
+
+  /** Whether the current Shift+Drag moved far enough to be a rectangle selection rather than a click. */
+  function rectSelectionIsDrag(): boolean {
+    if (!rectStart || !rectEnd) return false;
+    const scale = viewport.workspace.transform.scale || 1;
+    const dx = Math.abs(rectEnd[0] - rectStart[0]) * media.width * scale;
+    const dy = Math.abs(rectEnd[1] - rectStart[1]) * media.height * scale;
+    return dx > DRAG_SLOP_PX || dy > DRAG_SLOP_PX;
+  }
+
+  /** Clear rectangle-selection state without touching the current selection. */
+  function cancelRectSelection() {
+    isRectSelecting = false;
+    rectStart = null;
+    rectEnd = null;
+    document.removeEventListener("mouseup", onDocRectMouseUp);
+  }
+
+  /**
+   * Finalize a rectangle selection. Also bound to document mouseup while one is
+   * active: releasing outside the SVG must never leave `isRectSelecting` stuck,
+   * because onMouseMove returns early while it is set — which would silently
+   * block panning and every subsequent shape drag.
+   */
+  function finishRectSelection() {
+    if (!isRectSelecting) return;
+    if (rectSelectionIsDrag()) completeRectSelection();
+    else cancelRectSelection();
+  }
+
+  function onDocRectMouseUp() {
+    finishRectSelection();
+  }
+
   /** Normalized selection rectangle: [minX, minY, maxX, maxY]. */
   let selectionRect = $derived.by((): [number, number, number, number] | null => {
-    if (!isRectSelecting || !rectStart || !rectEnd) return null;
+    if (!isRectSelecting || !rectStart || !rectEnd || !rectSelectionIsDrag()) return null;
     return [
       Math.min(rectStart[0], rectEnd[0]),
       Math.min(rectStart[1], rectEnd[1]),
@@ -354,6 +412,7 @@
     return () => {
       ro.disconnect();
       document.head.removeChild(style);
+      document.removeEventListener("mouseup", onDocRectMouseUp);
     };
   });
 
@@ -439,9 +498,7 @@
       .map((ann) => ann.id);
 
     selection.selectAnnotations(intersectingIds);
-    isRectSelecting = false;
-    rectStart = null;
-    rectEnd = null;
+    cancelRectSelection();
   }
 
   // ── Event handlers ───────────────────────────────────────────────────
@@ -514,6 +571,8 @@
   // phase, so this runs in the capture phase to get in first. Once started, the
   // Viewport's own document-level listeners carry the drag to completion.
   function onMouseDownCapture(e: MouseEvent) {
+    _mouseDownClient = [e.clientX, e.clientY];
+
     if (e.button !== 1) return;
     e.preventDefault(); // suppress the browser's middle-click autoscroll
     e.stopPropagation(); // keep shape/selection handlers from reacting
@@ -558,6 +617,7 @@
       isRectSelecting = true;
       rectStart = sceneNormalizedCursor;
       rectEnd = sceneNormalizedCursor;
+      document.addEventListener("mouseup", onDocRectMouseUp);
       e.stopPropagation();
       return;
     }
@@ -588,12 +648,8 @@
     for (let i = 0; i < _compRefs.length; i++) {
       _compRefs[i]?.getToolSelection()?.endSelection(sceneNormalizedCursor);
     }
-    // Cancel active rectangle selection
-    if (isRectSelecting) {
-      isRectSelecting = false;
-      rectStart = null;
-      rectEnd = null;
-    }
+    // An active rectangle selection is intentionally left running: dragging past
+    // the SVG edge and back should keep the same rectangle.
     // Stop viewport panning
     zoomableElement!.mouseUp(new MouseEvent("mouseup"));
   }
@@ -602,7 +658,9 @@
     // ── Rectangle selection: complete selection ────────────────────
     if (isRectSelecting) {
       rectEnd = sceneNormalizedCursor;
-      completeRectSelection();
+      // A drag commits the rectangle; a plain Shift+Click falls through to
+      // handleClick's toggle with the selection untouched.
+      finishRectSelection();
       return;
     }
 
@@ -747,6 +805,11 @@
    * - Plain Click: select only that annotation.
    */
   function handleClick(ann: IAnnotationRecord, event?: MouseEvent) {
+    // Swallow the click that trails a drag (rectangle selection, or a shape move
+    // released over another shape) — mouseup already did the meaningful work, and
+    // running Shift+Click toggling here would undo it.
+    if (event && movedSinceMouseDown(event)) return;
+
     // Note mode: create an annotation-anchored note
     if (isNoteMode) {
       _noteHandledByClick = true;

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
@@ -419,6 +419,10 @@
       .cursor-grabbing, .cursor-grabbing * { cursor: grabbing !important; }
       .cursor-pointer { cursor: pointer; }
       .cursor-target { cursor: alias; }
+      /* Applied to <body> while a viewport gesture is live: a drag that leaves the
+         SVG would otherwise start a native text selection across the sidebars and
+         timeline it passes over. */
+      .idah-video-dragging, .idah-video-dragging * { user-select: none !important; -webkit-user-select: none !important; }
     `;
     document.head.appendChild(style);
 
@@ -524,14 +528,24 @@
   function beginGestureTracking() {
     document.addEventListener("mousemove", onDocMouseMove);
     document.addEventListener("mouseup", onDocMouseUp);
+    document.body.classList.add("idah-video-dragging");
   }
 
   function endGestureTracking() {
     document.removeEventListener("mousemove", onDocMouseMove);
     document.removeEventListener("mouseup", onDocMouseUp);
+    document.body.classList.remove("idah-video-dragging");
   }
 
   function onDocMouseMove(e: MouseEvent) {
+    // Recovery: no buttons held means the release happened somewhere we never
+    // saw it (released over another window, say). Finalize rather than leave the
+    // gesture — and the body's user-select lock — hanging.
+    if (e.buttons === 0) {
+      onDocMouseUp(e);
+      return;
+    }
+
     // Moves over the SVG are already served by its own handler — this only
     // extends a gesture that has wandered outside it.
     if (!svgEl || (e.target instanceof Node && svgEl.contains(e.target))) return;

--- a/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
+++ b/plugins/idah-video/frontend/src/lib/components/App/Viewport/Shapes/ShapesContainer.svelte
@@ -283,33 +283,46 @@
     isRectSelecting = false;
     rectStart = null;
     rectEnd = null;
-    document.removeEventListener("mouseup", onDocRectMouseUp);
   }
 
-  /**
-   * Finalize a rectangle selection. Also bound to document mouseup while one is
-   * active: releasing outside the SVG must never leave `isRectSelecting` stuck,
-   * because onMouseMove returns early while it is set — which would silently
-   * block panning and every subsequent shape drag.
-   */
+  /** Finalize a rectangle selection: a real drag commits it, a click-sized one is discarded. */
   function finishRectSelection() {
     if (!isRectSelecting) return;
     if (rectSelectionIsDrag()) completeRectSelection();
     else cancelRectSelection();
   }
 
-  function onDocRectMouseUp() {
-    finishRectSelection();
-  }
+  /**
+   * The region currently on screen, in normalized media coords: [minX, minY, maxX, maxY].
+   * Mirrors the SVG viewBox — scene origin is -translate/scale, extent is dimensions/scale.
+   */
+  let visibleBoundsN = $derived.by((): [number, number, number, number] => {
+    const [tx, ty] = viewport.workspace.transform.translate;
+    const [w, h] = viewport.workspace.dimensions;
+    const s = viewport.workspace.transform.scale || 1;
+    const mw = media.width || 1;
+    const mh = media.height || 1;
+    return [-tx / s / mw, -ty / s / mh, (-tx + w) / s / mw, (-ty + h) / s / mh];
+  });
 
-  /** Normalized selection rectangle: [minX, minY, maxX, maxY]. */
+  /**
+   * Normalized selection rectangle: [minX, minY, maxX, maxY].
+   *
+   * Clamped to the visible region: the drag keeps tracking outside the SVG (so
+   * crossing the edge doesn't strand the gesture), but the rectangle itself must
+   * not reach content the user cannot see and did not knowingly sweep over.
+   * Clamping here covers both the drawn overlay and completeRectSelection, so the
+   * box the user sees is exactly the box that selects.
+   */
   let selectionRect = $derived.by((): [number, number, number, number] | null => {
     if (!isRectSelecting || !rectStart || !rectEnd || !rectSelectionIsDrag()) return null;
+    const [vx0, vy0, vx1, vy1] = visibleBoundsN;
+    const clamp = (v: number, lo: number, hi: number) => Math.min(Math.max(v, lo), hi);
     return [
-      Math.min(rectStart[0], rectEnd[0]),
-      Math.min(rectStart[1], rectEnd[1]),
-      Math.max(rectStart[0], rectEnd[0]),
-      Math.max(rectStart[1], rectEnd[1]),
+      clamp(Math.min(rectStart[0], rectEnd[0]), vx0, vx1),
+      clamp(Math.min(rectStart[1], rectEnd[1]), vy0, vy1),
+      clamp(Math.max(rectStart[0], rectEnd[0]), vx0, vx1),
+      clamp(Math.max(rectStart[1], rectEnd[1]), vy0, vy1),
     ];
   });
 
@@ -412,7 +425,7 @@
     return () => {
       ro.disconnect();
       document.head.removeChild(style);
-      document.removeEventListener("mouseup", onDocRectMouseUp);
+      endGestureTracking();
     };
   });
 
@@ -501,9 +514,43 @@
     cancelRectSelection();
   }
 
+  // ── Document-level gesture tracking ──────────────────────────────────
+  // A press that starts on the SVG must keep tracking after the cursor leaves it,
+  // and must finalize wherever it is released. Without this, crossing the viewport
+  // edge mid-drag stranded the gesture: the batch commit for a multi-selection
+  // lives in onMouseUp, which never fires for a release outside the SVG, so only
+  // the shape that was under the cursor kept its new position.
+  // Viewport does the same for panning (see panStart there).
+  function beginGestureTracking() {
+    document.addEventListener("mousemove", onDocMouseMove);
+    document.addEventListener("mouseup", onDocMouseUp);
+  }
+
+  function endGestureTracking() {
+    document.removeEventListener("mousemove", onDocMouseMove);
+    document.removeEventListener("mouseup", onDocMouseUp);
+  }
+
+  function onDocMouseMove(e: MouseEvent) {
+    // Moves over the SVG are already served by its own handler — this only
+    // extends a gesture that has wandered outside it.
+    if (!svgEl || (e.target instanceof Node && svgEl.contains(e.target))) return;
+    const rect = svgEl.getBoundingClientRect();
+    handlePointerMove(e, [e.clientX - rect.left, e.clientY - rect.top], true);
+  }
+
+  function onDocMouseUp(e: MouseEvent) {
+    endGestureTracking();
+    onMouseUp(e);
+  }
+
   // ── Event handlers ───────────────────────────────────────────────────
   function onMouseMove(e: MouseEvent) {
-    mousePosition = [e.offsetX, e.offsetY];
+    handlePointerMove(e, [e.offsetX, e.offsetY], false);
+  }
+
+  function handlePointerMove(e: MouseEvent, position: Point, fromDocument: boolean) {
+    mousePosition = position;
 
     // Track the last known cursor position in normalized coords so commands
     // (e.g. selection.paste) can target where the user's cursor currently is.
@@ -555,8 +602,10 @@
       ];
     }
 
-    // Only pan in editor mode
-    if (viewport.mode === EDITOR_MODE || viewport.mode === REVIEW_MODE) {
+    // Only pan in editor mode. Never forward a document-sourced event: its
+    // offsetX/offsetY are relative to whatever element happens to be under the
+    // cursor, and Viewport installs its own document listeners once a pan starts.
+    if (!fromDocument && (viewport.mode === EDITOR_MODE || viewport.mode === REVIEW_MODE)) {
       zoomableElement!.mouseMove(e);
     }
   }
@@ -572,6 +621,9 @@
   // Viewport's own document-level listeners carry the drag to completion.
   function onMouseDownCapture(e: MouseEvent) {
     _mouseDownClient = [e.clientX, e.clientY];
+    // Capture phase: runs even for presses a shape stops on bubble, so every
+    // gesture that starts here is tracked to its release, wherever that lands.
+    beginGestureTracking();
 
     if (e.button !== 1) return;
     e.preventDefault(); // suppress the browser's middle-click autoscroll
@@ -617,7 +669,6 @@
       isRectSelecting = true;
       rectStart = sceneNormalizedCursor;
       rectEnd = sceneNormalizedCursor;
-      document.addEventListener("mouseup", onDocRectMouseUp);
       e.stopPropagation();
       return;
     }
@@ -637,21 +688,6 @@
     // Nothing hit — deselect and start panning
     selection.deselect();
     zoomableElement!.mouseDown(e);
-  }
-
-  function onMouseLeave(_e: MouseEvent) {
-    // Cancel any active tool edit (bounding box drag, resize, rotate) on EVERY
-    // component — same reason as onMouseUp: the primary annotation's toolSelection
-    // is not necessarily the one that started a drag.
-    // Note: _compRefs holds AnnotationGeometry instances; they expose endSelection
-    // through getToolSelection(), not directly.
-    for (let i = 0; i < _compRefs.length; i++) {
-      _compRefs[i]?.getToolSelection()?.endSelection(sceneNormalizedCursor);
-    }
-    // An active rectangle selection is intentionally left running: dragging past
-    // the SVG edge and back should keep the same rectangle.
-    // Stop viewport panning
-    zoomableElement!.mouseUp(new MouseEvent("mouseup"));
   }
 
   function onMouseUp(e: MouseEvent) {
@@ -887,10 +923,8 @@
     bind:this={svgEl}
     onmousedowncapture={onMouseDownCapture}
     onmousedown={onMouseDown}
-    onmouseup={onMouseUp}
     onclick={onSvgClick}
     onmousemove={onMouseMove}
-    onmouseleave={onMouseLeave}
     onwheel={onWheel}
   >
     <!-- Crosshair (for build modes) -->


### PR DESCRIPTION
## Assigned
- Shift+drag now works when you start on top of a shape.
- Dragging a group past the edge now moves the whole group, not just one shape.
- No more text highlighting in the sidebar/timeline while dragging.


## Additinal
- Shift+click still toggles one shape, the click at the end of a drag no longer undoes your box.
- Releasing outside the video no longer jams panning and later drags.
- The box only selects what's visible on screen.
- The selection box border stays the same thickness at every zoom level.
- The panel now says "Multiple selection" with a count badge, so it's clear more than one annotation is selected.